### PR TITLE
Add built-in workspace code viewer

### DIFF
--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -828,6 +828,60 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return { relativePath: target.relativePath };
       }
 
+      case WS_METHODS.projectsReadFile: {
+        const body = stripRequestTag(request.body);
+        const target = yield* resolveWorkspaceWritePath({
+          workspaceRoot: body.cwd,
+          relativePath: body.relativePath,
+          path,
+        });
+        const MAX_READ_SIZE = 1_048_576; // 1MB
+        const fileStat = yield* fileSystem.stat(target.absolutePath).pipe(
+          Effect.mapError(
+            (cause) =>
+              new RouteRequestError({
+                message: `Failed to read file: ${String(cause)}`,
+              }),
+          ),
+        );
+        if (fileStat.type !== "File") {
+          return yield* new RouteRequestError({
+            message: `Path is not a file: ${target.relativePath}`,
+          });
+        }
+        const sizeBytes = Number(fileStat.size);
+        if (sizeBytes > MAX_READ_SIZE) {
+          return yield* new RouteRequestError({
+            message: `File is too large to display (${(sizeBytes / 1024 / 1024).toFixed(1)}MB). Maximum supported size is 1MB.`,
+          });
+        }
+        // Read raw bytes to detect binary files
+        const rawBytes = yield* fileSystem.readFile(target.absolutePath).pipe(
+          Effect.mapError(
+            (cause) =>
+              new RouteRequestError({
+                message: `Failed to read file: ${String(cause)}`,
+              }),
+          ),
+        );
+        // Check for null bytes in the first 8KB to detect binary files
+        const checkLength = Math.min(rawBytes.length, 8192);
+        for (let i = 0; i < checkLength; i++) {
+          if (rawBytes[i] === 0) {
+            return yield* new RouteRequestError({
+              message: `File appears to be binary and cannot be displayed: ${target.relativePath}`,
+            });
+          }
+        }
+        const contents = new TextDecoder().decode(rawBytes);
+        return {
+          relativePath: target.relativePath,
+          contents,
+          sizeBytes,
+          truncated: false,
+        };
+      }
+
       case WS_METHODS.shellOpenInEditor: {
         const body = stripRequestTag(request.body);
         return yield* openInEditor(body);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,11 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.40.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/apps/web/src/codeViewerRouteSearch.ts
+++ b/apps/web/src/codeViewerRouteSearch.ts
@@ -1,0 +1,22 @@
+export interface CodeViewerRouteSearch {
+  codeViewer?: "1" | undefined;
+}
+
+function isCodeViewerOpenValue(value: unknown): boolean {
+  return value === "1" || value === 1 || value === true;
+}
+
+export function stripCodeViewerSearchParams<T extends Record<string, unknown>>(
+  params: T,
+): Omit<T, "codeViewer"> {
+  const { codeViewer: _codeViewer, ...rest } = params;
+  return rest as Omit<T, "codeViewer">;
+}
+
+export function parseCodeViewerRouteSearch(search: Record<string, unknown>): CodeViewerRouteSearch {
+  const codeViewer = isCodeViewerOpenValue(search.codeViewer) ? "1" : undefined;
+  if (codeViewer) {
+    return { codeViewer };
+  }
+  return {};
+}

--- a/apps/web/src/codeViewerStore.ts
+++ b/apps/web/src/codeViewerStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+
+export interface CodeViewerTab {
+  cwd: string;
+  relativePath: string;
+  label: string;
+}
+
+interface CodeViewerState {
+  tabs: CodeViewerTab[];
+  activeTabPath: string | null;
+  openFile: (cwd: string, relativePath: string) => void;
+  closeTab: (relativePath: string) => void;
+  setActiveTab: (relativePath: string) => void;
+  closeAllTabs: () => void;
+}
+
+function basenameOf(filePath: string): string {
+  const segments = filePath.split("/");
+  return segments[segments.length - 1] ?? filePath;
+}
+
+export const useCodeViewerStore = create<CodeViewerState>((set) => ({
+  tabs: [],
+  activeTabPath: null,
+
+  openFile: (cwd, relativePath) =>
+    set((state) => {
+      const existing = state.tabs.find((tab) => tab.relativePath === relativePath);
+      if (existing) {
+        return { activeTabPath: relativePath };
+      }
+      const newTab: CodeViewerTab = {
+        cwd,
+        relativePath,
+        label: basenameOf(relativePath),
+      };
+      return {
+        tabs: [...state.tabs, newTab],
+        activeTabPath: relativePath,
+      };
+    }),
+
+  closeTab: (relativePath) =>
+    set((state) => {
+      const index = state.tabs.findIndex((tab) => tab.relativePath === relativePath);
+      if (index === -1) return state;
+      const nextTabs = state.tabs.filter((tab) => tab.relativePath !== relativePath);
+      let nextActive = state.activeTabPath;
+      if (state.activeTabPath === relativePath) {
+        // Activate the nearest tab
+        const nearestIndex = Math.min(index, nextTabs.length - 1);
+        nextActive = nextTabs[nearestIndex]?.relativePath ?? null;
+      }
+      return { tabs: nextTabs, activeTabPath: nextActive };
+    }),
+
+  setActiveTab: (relativePath) => set({ activeTabPath: relativePath }),
+
+  closeAllTabs: () => set({ tabs: [], activeTabPath: null }),
+}));

--- a/apps/web/src/components/CodeMirrorViewer.tsx
+++ b/apps/web/src/components/CodeMirrorViewer.tsx
@@ -1,0 +1,149 @@
+import { EditorState, type Extension, Compartment } from "@codemirror/state";
+import {
+  EditorView,
+  lineNumbers,
+  highlightActiveLine,
+  highlightSpecialChars,
+} from "@codemirror/view";
+import {
+  syntaxHighlighting,
+  defaultHighlightStyle,
+  LanguageDescription,
+} from "@codemirror/language";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { memo, useEffect, useRef } from "react";
+
+const themeCompartment = new Compartment();
+const languageCompartment = new Compartment();
+
+const baseExtensions: Extension[] = [
+  lineNumbers(),
+  highlightActiveLine(),
+  highlightSpecialChars(),
+  syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+  EditorView.editable.of(false),
+  EditorState.readOnly.of(true),
+  EditorView.theme({
+    "&": {
+      height: "100%",
+      fontSize: "12px",
+    },
+    ".cm-scroller": {
+      fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+      overflow: "auto",
+    },
+    ".cm-gutters": {
+      borderRight: "1px solid var(--border, #e5e7eb)",
+      backgroundColor: "transparent",
+    },
+    ".cm-lineNumbers .cm-gutterElement": {
+      padding: "0 8px 0 12px",
+      minWidth: "3ch",
+      color: "var(--muted-foreground, #6b7280)",
+      opacity: "0.5",
+      fontSize: "11px",
+    },
+  }),
+];
+
+function getThemeExtension(resolvedTheme: "light" | "dark"): Extension {
+  return resolvedTheme === "dark" ? oneDark : [];
+}
+
+async function loadLanguageExtension(filePath: string): Promise<Extension> {
+  const languages = (await import("@codemirror/language-data")).languages;
+  const match = LanguageDescription.matchFilename(languages, filePath);
+  if (!match) return [];
+  const support = await match.load();
+  return support;
+}
+
+export const CodeMirrorViewer = memo(function CodeMirrorViewer(props: {
+  contents: string;
+  filePath: string;
+  resolvedTheme: "light" | "dark";
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const filePathRef = useRef<string | null>(null);
+
+  // Create editor on mount
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const state = EditorState.create({
+      doc: props.contents,
+      extensions: [
+        ...baseExtensions,
+        themeCompartment.of(getThemeExtension(props.resolvedTheme)),
+        languageCompartment.of([]),
+      ],
+    });
+
+    const view = new EditorView({
+      state,
+      parent: containerRef.current,
+    });
+
+    viewRef.current = view;
+
+    // Load language support asynchronously
+    void loadLanguageExtension(props.filePath).then((langExt) => {
+      if (viewRef.current === view) {
+        view.dispatch({
+          effects: languageCompartment.reconfigure(langExt),
+        });
+      }
+    });
+    filePathRef.current = props.filePath;
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Only re-create on mount/unmount — updates handled below
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Update contents when they change
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const currentDoc = view.state.doc.toString();
+    if (currentDoc !== props.contents) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: props.contents },
+      });
+    }
+  }, [props.contents]);
+
+  // Update theme when it changes
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    view.dispatch({
+      effects: themeCompartment.reconfigure(getThemeExtension(props.resolvedTheme)),
+    });
+  }, [props.resolvedTheme]);
+
+  // Update language when file path changes
+  useEffect(() => {
+    if (filePathRef.current === props.filePath) return;
+    filePathRef.current = props.filePath;
+
+    const view = viewRef.current;
+    if (!view) return;
+
+    void loadLanguageExtension(props.filePath).then((langExt) => {
+      if (viewRef.current === view) {
+        view.dispatch({
+          effects: languageCompartment.reconfigure(langExt),
+        });
+      }
+    });
+  }, [props.filePath]);
+
+  return <div ref={containerRef} className="h-full min-h-0 overflow-hidden" />;
+});

--- a/apps/web/src/components/CodeViewerPanel.tsx
+++ b/apps/web/src/components/CodeViewerPanel.tsx
@@ -1,0 +1,155 @@
+import { useQuery } from "@tanstack/react-query";
+import { FileCodeIcon, XIcon } from "lucide-react";
+import { memo, useCallback } from "react";
+
+import { useCodeViewerStore, type CodeViewerTab } from "~/codeViewerStore";
+import { useTheme } from "~/hooks/useTheme";
+import { projectReadFileQueryOptions } from "~/lib/projectReactQuery";
+import { cn } from "~/lib/utils";
+import { CodeMirrorViewer } from "./CodeMirrorViewer";
+import { type DiffPanelMode, DiffPanelShell, DiffPanelLoadingState } from "./DiffPanelShell";
+
+export type CodeViewerPanelMode = DiffPanelMode;
+
+function CodeViewerTabStrip(props: {
+  tabs: CodeViewerTab[];
+  activeTabPath: string | null;
+  onSelectTab: (relativePath: string) => void;
+  onCloseTab: (relativePath: string) => void;
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [-webkit-app-region:no-drag]">
+      {props.tabs.map((tab) => {
+        const isActive = tab.relativePath === props.activeTabPath;
+        return (
+          <div
+            key={tab.relativePath}
+            className={cn(
+              "group flex max-w-[180px] shrink-0 items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] transition-colors",
+              isActive
+                ? "border-border bg-accent text-accent-foreground"
+                : "border-transparent text-muted-foreground/70 hover:border-border/60 hover:text-foreground/80",
+            )}
+          >
+            <button
+              type="button"
+              className="min-w-0 flex-1 truncate text-left font-mono"
+              onClick={() => props.onSelectTab(tab.relativePath)}
+              title={tab.relativePath}
+            >
+              {tab.label}
+            </button>
+            <button
+              type="button"
+              className="shrink-0 rounded-sm p-0.5 opacity-0 transition-opacity hover:bg-accent/80 group-hover:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation();
+                props.onCloseTab(tab.relativePath);
+              }}
+              aria-label={`Close ${tab.label}`}
+            >
+              <XIcon className="size-3" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const CodeViewerFileContent = memo(function CodeViewerFileContent(props: {
+  cwd: string;
+  relativePath: string;
+  resolvedTheme: "light" | "dark";
+}) {
+  const query = useQuery(
+    projectReadFileQueryOptions({
+      cwd: props.cwd,
+      relativePath: props.relativePath,
+    }),
+  );
+
+  if (query.isLoading) {
+    return <DiffPanelLoadingState label="Loading file..." />;
+  }
+
+  if (query.isError) {
+    const message = query.error instanceof Error ? query.error.message : "Failed to load file.";
+    return (
+      <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-destructive/80">
+        {message}
+      </div>
+    );
+  }
+
+  if (!query.data?.contents && query.data?.contents !== "") {
+    return (
+      <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
+        No content available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      {query.data.truncated && (
+        <div className="border-b border-amber-500/30 bg-amber-500/10 px-3 py-1 text-[11px] text-amber-700 dark:text-amber-300/90">
+          File is larger than 1MB. Showing truncated content.
+        </div>
+      )}
+      <CodeMirrorViewer
+        contents={query.data.contents}
+        filePath={props.relativePath}
+        resolvedTheme={props.resolvedTheme}
+      />
+    </div>
+  );
+});
+
+interface CodeViewerPanelProps {
+  mode?: CodeViewerPanelMode;
+}
+
+export default function CodeViewerPanel({ mode = "inline" }: CodeViewerPanelProps) {
+  const { resolvedTheme } = useTheme();
+  const tabs = useCodeViewerStore((state) => state.tabs);
+  const activeTabPath = useCodeViewerStore((state) => state.activeTabPath);
+  const setActiveTab = useCodeViewerStore((state) => state.setActiveTab);
+  const closeTab = useCodeViewerStore((state) => state.closeTab);
+
+  const activeTab = tabs.find((tab) => tab.relativePath === activeTabPath);
+
+  const onSelectTab = useCallback(
+    (relativePath: string) => setActiveTab(relativePath),
+    [setActiveTab],
+  );
+
+  const onCloseTab = useCallback((relativePath: string) => closeTab(relativePath), [closeTab]);
+
+  const headerRow = (
+    <CodeViewerTabStrip
+      tabs={tabs}
+      activeTabPath={activeTabPath}
+      onSelectTab={onSelectTab}
+      onCloseTab={onCloseTab}
+    />
+  );
+
+  return (
+    <DiffPanelShell mode={mode} header={headerRow}>
+      {!activeTab ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-5 text-center text-muted-foreground/60">
+          <FileCodeIcon className="size-8 opacity-40" />
+          <p className="text-xs">Click a file in the sidebar to view it here.</p>
+        </div>
+      ) : (
+        <CodeViewerFileContent
+          key={activeTab.relativePath}
+          cwd={activeTab.cwd}
+          relativePath={activeTab.relativePath}
+          resolvedTheme={resolvedTheme}
+        />
+      )}
+    </DiffPanelShell>
+  );
+}

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -690,9 +690,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
       success: (count) => ({
         title: count === 1 ? "Opened conflicted file" : "Opened conflicted files",
         description:
-          count === 1
-            ? (conflictedFiles[0] ?? undefined)
-            : `${count} files opened in your editor.`,
+          count === 1 ? (conflictedFiles[0] ?? undefined) : `${count} files opened in your editor.`,
         data: threadToastData,
       }),
       error: (error) => ({

--- a/apps/web/src/components/WorkspaceFileTree.tsx
+++ b/apps/web/src/components/WorkspaceFileTree.tsx
@@ -2,6 +2,7 @@ import { type ProjectDirectoryEntry } from "@okcode/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronRightIcon, FolderClosedIcon, FolderIcon, TriangleAlertIcon } from "lucide-react";
 import { memo, useCallback, useState } from "react";
+import { useCodeViewerStore } from "~/codeViewerStore";
 import { openInPreferredEditor } from "~/editorPreferences";
 import { projectListDirectoryQueryOptions } from "~/lib/projectReactQuery";
 import { cn } from "~/lib/utils";
@@ -27,27 +28,36 @@ export const WorkspaceFileTree = memo(function WorkspaceFileTree(props: {
     }));
   }, []);
 
+  const openFileInViewer = useCodeViewerStore((state) => state.openFile);
+
   const openFile = useCallback(
-    (filePath: string) => {
-      const api = readNativeApi();
-      if (!api) {
-        toastManager.add({
-          type: "error",
-          title: "File opening is unavailable.",
+    (filePath: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => {
+      // Cmd/Ctrl+click opens in external editor
+      if (event?.metaKey || event?.ctrlKey) {
+        const api = readNativeApi();
+        if (!api) {
+          toastManager.add({
+            type: "error",
+            title: "File opening is unavailable.",
+          });
+          return;
+        }
+
+        const targetPath = resolvePathLinkTarget(filePath, props.cwd);
+        void openInPreferredEditor(api, targetPath).catch((error) => {
+          toastManager.add({
+            type: "error",
+            title: "Unable to open file",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          });
         });
         return;
       }
 
-      const targetPath = resolvePathLinkTarget(filePath, props.cwd);
-      void openInPreferredEditor(api, targetPath).catch((error) => {
-        toastManager.add({
-          type: "error",
-          title: "Unable to open file",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        });
-      });
+      // Default click opens in built-in code viewer
+      openFileInViewer(props.cwd, filePath);
     },
-    [props.cwd],
+    [props.cwd, openFileInViewer],
   );
 
   return (
@@ -71,7 +81,7 @@ const WorkspaceFileTreeDirectory = memo(function WorkspaceFileTreeDirectory(prop
   expandedDirectories: Readonly<Record<string, boolean>>;
   resolvedTheme: "light" | "dark";
   onToggleDirectory: (pathValue: string) => void;
-  onOpenFile: (pathValue: string) => void;
+  onOpenFile: (pathValue: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => void;
 }) {
   const query = useQuery(
     projectListDirectoryQueryOptions({
@@ -196,7 +206,7 @@ const WorkspaceFileRow = memo(function WorkspaceFileRow(props: {
   depth: number;
   entry: ProjectDirectoryEntry;
   resolvedTheme: "light" | "dark";
-  onOpenFile: (pathValue: string) => void;
+  onOpenFile: (pathValue: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => void;
 }) {
   const leftPadding = TREE_ROW_LEFT_PADDING + props.depth * TREE_ROW_DEPTH_OFFSET;
 
@@ -205,7 +215,9 @@ const WorkspaceFileRow = memo(function WorkspaceFileRow(props: {
       type="button"
       className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-accent/60"
       style={{ paddingLeft: `${leftPadding}px` }}
-      onClick={() => props.onOpenFile(props.entry.path)}
+      onClick={(event) =>
+        props.onOpenFile(props.entry.path, { metaKey: event.metaKey, ctrlKey: event.ctrlKey })
+      }
       title={props.entry.path}
     >
       <span aria-hidden="true" className="size-3.5 shrink-0" />

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -1,4 +1,8 @@
-import type { ProjectListDirectoryResult, ProjectSearchEntriesResult } from "@okcode/contracts";
+import type {
+  ProjectListDirectoryResult,
+  ProjectReadFileResult,
+  ProjectSearchEntriesResult,
+} from "@okcode/contracts";
 import { queryOptions } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
 
@@ -8,6 +12,8 @@ export const projectQueryKeys = {
     ["projects", "search-entries", cwd, query, limit] as const,
   listDirectory: (cwd: string | null, directoryPath: string | null) =>
     ["projects", "list-directory", cwd, directoryPath] as const,
+  readFile: (cwd: string | null, relativePath: string | null) =>
+    ["projects", "read-file", cwd, relativePath] as const,
 };
 
 const DEFAULT_SEARCH_ENTRIES_LIMIT = 80;
@@ -45,6 +51,36 @@ export function projectSearchEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
     staleTime: input.staleTime ?? DEFAULT_PROJECT_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
+  });
+}
+
+const EMPTY_READ_FILE_RESULT: ProjectReadFileResult = {
+  relativePath: "" as ProjectReadFileResult["relativePath"],
+  contents: "",
+  sizeBytes: 0,
+  truncated: false,
+};
+
+export function projectReadFileQueryOptions(input: {
+  cwd: string | null;
+  relativePath: string | null;
+  enabled?: boolean;
+}) {
+  return queryOptions({
+    queryKey: projectQueryKeys.readFile(input.cwd, input.relativePath),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!input.cwd || !input.relativePath) {
+        throw new Error("File reading is unavailable.");
+      }
+      return api.projects.readFile({
+        cwd: input.cwd,
+        relativePath: input.relativePath,
+      });
+    },
+    enabled: (input.enabled ?? true) && input.cwd !== null && input.relativePath !== null,
+    staleTime: 5_000,
+    placeholderData: (previous) => previous ?? EMPTY_READ_FILE_RESULT,
   });
 }
 

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -24,16 +24,22 @@ import {
   parseDiffRouteSearch,
   stripDiffSearchParams,
 } from "../diffRouteSearch";
+import { useCodeViewerStore } from "../codeViewerStore";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useStore } from "../store";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
+const CodeViewerPanel = lazy(() => import("../components/CodeViewerPanel"));
+
 const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
+const CODE_VIEWER_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_code_viewer_sidebar_width";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
+const CODE_VIEWER_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
+const CODE_VIEWER_INLINE_SIDEBAR_MIN_WIDTH = 22 * 16;
 const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 
 const DiffPanelSheet = (props: {
@@ -62,10 +68,40 @@ const DiffPanelSheet = (props: {
   );
 };
 
+const CodeViewerSheet = (props: { children: ReactNode; open: boolean; onClose: () => void }) => {
+  return (
+    <Sheet
+      open={props.open}
+      onOpenChange={(open) => {
+        if (!open) {
+          props.onClose();
+        }
+      }}
+    >
+      <SheetPopup
+        side="right"
+        showCloseButton={false}
+        keepMounted
+        className="w-[min(88vw,820px)] max-w-[820px] p-0"
+      >
+        {props.children}
+      </SheetPopup>
+    </Sheet>
+  );
+};
+
 const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   return (
     <DiffPanelShell mode={props.mode} header={<DiffPanelHeaderSkeleton />}>
       <DiffPanelLoadingState label="Loading diff viewer..." />
+    </DiffPanelShell>
+  );
+};
+
+const CodeViewerLoadingFallback = (props: { mode: DiffPanelMode }) => {
+  return (
+    <DiffPanelShell mode={props.mode} header={null}>
+      <DiffPanelLoadingState label="Loading code viewer..." />
     </DiffPanelShell>
   );
 };
@@ -79,6 +115,59 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
     </DiffWorkerPoolProvider>
   );
 };
+
+const LazyCodeViewerPanel = (props: { mode: DiffPanelMode }) => {
+  return (
+    <Suspense fallback={<CodeViewerLoadingFallback mode={props.mode} />}>
+      <CodeViewerPanel mode={props.mode} />
+    </Suspense>
+  );
+};
+
+function useShouldAcceptInlineSidebarWidth() {
+  return useCallback(({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
+    const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
+    if (!composerForm) return true;
+    const composerViewport = composerForm.parentElement;
+    if (!composerViewport) return true;
+    const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
+    wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+
+    const viewportStyle = window.getComputedStyle(composerViewport);
+    const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
+    const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
+    const viewportContentWidth = Math.max(
+      0,
+      composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
+    );
+    const formRect = composerForm.getBoundingClientRect();
+    const composerFooter = composerForm.querySelector<HTMLElement>(
+      "[data-chat-composer-footer='true']",
+    );
+    const composerRightActions = composerForm.querySelector<HTMLElement>(
+      "[data-chat-composer-actions='right']",
+    );
+    const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
+    const composerFooterGap = composerFooter
+      ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
+        Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
+        0
+      : 0;
+    const minimumComposerWidth =
+      COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
+    const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
+    const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
+    const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
+
+    if (previousSidebarWidth.length > 0) {
+      wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
+    } else {
+      wrapper.style.removeProperty("--sidebar-width");
+    }
+
+    return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
+  }, []);
+}
 
 const DiffPanelInlineSidebar = (props: {
   diffOpen: boolean;
@@ -97,51 +186,7 @@ const DiffPanelInlineSidebar = (props: {
     },
     [onCloseDiff, onOpenDiff],
   );
-  const shouldAcceptInlineSidebarWidth = useCallback(
-    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
-      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-      if (!composerForm) return true;
-      const composerViewport = composerForm.parentElement;
-      if (!composerViewport) return true;
-      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-      const viewportStyle = window.getComputedStyle(composerViewport);
-      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-      const viewportContentWidth = Math.max(
-        0,
-        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-      );
-      const formRect = composerForm.getBoundingClientRect();
-      const composerFooter = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-footer='true']",
-      );
-      const composerRightActions = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-actions='right']",
-      );
-      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-      const composerFooterGap = composerFooter
-        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-          0
-        : 0;
-      const minimumComposerWidth =
-        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-      if (previousSidebarWidth.length > 0) {
-        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-      } else {
-        wrapper.style.removeProperty("--sidebar-width");
-      }
-
-      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-    },
-    [],
-  );
+  const shouldAcceptInlineSidebarWidth = useShouldAcceptInlineSidebarWidth();
 
   return (
     <SidebarProvider
@@ -168,6 +213,50 @@ const DiffPanelInlineSidebar = (props: {
   );
 };
 
+const CodeViewerInlineSidebar = (props: {
+  codeViewerOpen: boolean;
+  onCloseCodeViewer: () => void;
+  onOpenCodeViewer: () => void;
+  renderContent: boolean;
+}) => {
+  const { codeViewerOpen, onCloseCodeViewer, onOpenCodeViewer, renderContent } = props;
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        onOpenCodeViewer();
+        return;
+      }
+      onCloseCodeViewer();
+    },
+    [onCloseCodeViewer, onOpenCodeViewer],
+  );
+  const shouldAcceptInlineSidebarWidth = useShouldAcceptInlineSidebarWidth();
+
+  return (
+    <SidebarProvider
+      defaultOpen={false}
+      open={codeViewerOpen}
+      onOpenChange={onOpenChange}
+      className="w-auto min-h-0 flex-none bg-transparent"
+      style={{ "--sidebar-width": CODE_VIEWER_INLINE_DEFAULT_WIDTH } as CSSProperties}
+    >
+      <Sidebar
+        side="right"
+        collapsible="offcanvas"
+        className="border-l border-border bg-card text-foreground"
+        resizable={{
+          minWidth: CODE_VIEWER_INLINE_SIDEBAR_MIN_WIDTH,
+          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
+          storageKey: CODE_VIEWER_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+        }}
+      >
+        {renderContent ? <LazyCodeViewerPanel mode="sidebar" /> : null}
+        <SidebarRail />
+      </Sidebar>
+    </SidebarProvider>
+  );
+};
+
 function ChatThreadRouteView() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const navigate = useNavigate();
@@ -182,9 +271,17 @@ function ChatThreadRouteView() {
   const routeThreadExists = threadExists || draftThreadExists;
   const diffOpen = search.diff === "1";
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
+
+  // Code viewer state from Zustand store
+  const codeViewerTabs = useCodeViewerStore((state) => state.tabs);
+  const codeViewerOpen = codeViewerTabs.length > 0;
+  const closeAllCodeViewerTabs = useCodeViewerStore((state) => state.closeAllTabs);
+
   // TanStack Router keeps active route components mounted across param-only navigations
   // unless remountDeps are configured, so this stays warm across thread switches.
   const [hasOpenedDiff, setHasOpenedDiff] = useState(diffOpen);
+  const [hasOpenedCodeViewer, setHasOpenedCodeViewer] = useState(codeViewerOpen);
+
   const closeDiff = useCallback(() => {
     void navigate({
       to: "/$threadId",
@@ -203,11 +300,25 @@ function ChatThreadRouteView() {
     });
   }, [navigate, threadId]);
 
+  const closeCodeViewer = useCallback(() => {
+    closeAllCodeViewerTabs();
+  }, [closeAllCodeViewerTabs]);
+
+  const openCodeViewer = useCallback(() => {
+    // No-op — code viewer opens when files are added via the store
+  }, []);
+
   useEffect(() => {
     if (diffOpen) {
       setHasOpenedDiff(true);
     }
   }, [diffOpen]);
+
+  useEffect(() => {
+    if (codeViewerOpen) {
+      setHasOpenedCodeViewer(true);
+    }
+  }, [codeViewerOpen]);
 
   useEffect(() => {
     if (!threadsHydrated) {
@@ -225,6 +336,7 @@ function ChatThreadRouteView() {
   }
 
   const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+  const shouldRenderCodeViewerContent = codeViewerOpen || hasOpenedCodeViewer;
 
   if (!shouldUseDiffSheet) {
     return (
@@ -232,6 +344,12 @@ function ChatThreadRouteView() {
         <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
           <ChatView key={threadId} threadId={threadId} />
         </SidebarInset>
+        <CodeViewerInlineSidebar
+          codeViewerOpen={codeViewerOpen}
+          onCloseCodeViewer={closeCodeViewer}
+          onOpenCodeViewer={openCodeViewer}
+          renderContent={shouldRenderCodeViewerContent}
+        />
         <DiffPanelInlineSidebar
           diffOpen={diffOpen}
           onCloseDiff={closeDiff}
@@ -247,6 +365,9 @@ function ChatThreadRouteView() {
       <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
         <ChatView key={threadId} threadId={threadId} />
       </SidebarInset>
+      <CodeViewerSheet open={codeViewerOpen} onClose={closeCodeViewer}>
+        {shouldRenderCodeViewerContent ? <LazyCodeViewerPanel mode="sheet" /> : null}
+      </CodeViewerSheet>
       <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
         {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
       </DiffPanelSheet>

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -134,6 +134,7 @@ export function createWsNativeApi(): NativeApi {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       listDirectory: (input) => transport.request(WS_METHODS.projectsListDirectory, input),
       writeFile: (input) => transport.request(WS_METHODS.projectsWriteFile, input),
+      readFile: (input) => transport.request(WS_METHODS.projectsReadFile, input),
     },
     shell: {
       openInEditor: (cwd, editor) =>

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,11 @@
       "version": "0.0.1",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.40.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -254,6 +259,64 @@
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
+
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/lang-angular": ["@codemirror/lang-angular@0.1.4", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.3" } }, "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g=="],
+
+    "@codemirror/lang-cpp": ["@codemirror/lang-cpp@6.0.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/cpp": "^1.0.0" } }, "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-go": ["@codemirror/lang-go@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/go": "^1.0.0" } }, "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-java": ["@codemirror/lang-java@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/java": "^1.0.0" } }, "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-jinja": ["@codemirror/lang-jinja@6.0.0", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.4.0" } }, "sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw=="],
+
+    "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
+
+    "@codemirror/lang-less": ["@codemirror/lang-less@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ=="],
+
+    "@codemirror/lang-liquid": ["@codemirror/lang-liquid@6.3.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/lang-php": ["@codemirror/lang-php@6.0.2", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/php": "^1.0.0" } }, "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA=="],
+
+    "@codemirror/lang-python": ["@codemirror/lang-python@6.2.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.3.2", "@codemirror/language": "^6.8.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/python": "^1.1.4" } }, "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw=="],
+
+    "@codemirror/lang-rust": ["@codemirror/lang-rust@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/rust": "^1.0.0" } }, "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA=="],
+
+    "@codemirror/lang-sass": ["@codemirror/lang-sass@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/sass": "^1.0.0" } }, "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
+
+    "@codemirror/lang-vue": ["@codemirror/lang-vue@0.1.3", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug=="],
+
+    "@codemirror/lang-wast": ["@codemirror/lang-wast@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q=="],
+
+    "@codemirror/lang-xml": ["@codemirror/lang-xml@6.1.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/xml": "^1.0.0" } }, "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg=="],
+
+    "@codemirror/lang-yaml": ["@codemirror/lang-yaml@6.1.3", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.0.0", "@lezer/yaml": "^1.0.0" } }, "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/language-data": ["@codemirror/language-data@6.5.2", "", { "dependencies": { "@codemirror/lang-angular": "^0.1.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-jinja": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-less": "^6.0.0", "@codemirror/lang-liquid": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sass": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-vue": "^0.1.1", "@codemirror/lang-wast": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.4.0" } }, "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg=="],
+
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
+
+    "@codemirror/view": ["@codemirror/view@6.40.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
@@ -488,6 +551,42 @@
     "@lexical/utils": ["@lexical/utils@0.41.0", "", { "dependencies": { "@lexical/selection": "0.41.0", "lexical": "0.41.0" } }, "sha512-Wlsokr5NQCq83D+7kxZ9qs5yQ3dU3Qaf2M+uXxLRoPoDaXqW8xTWZq1+ZFoEzsHzx06QoPa4Vu/40BZR91uQPg=="],
 
     "@lexical/yjs": ["@lexical/yjs@0.41.0", "", { "dependencies": { "@lexical/offset": "0.41.0", "@lexical/selection": "0.41.0", "lexical": "0.41.0" }, "peerDependencies": { "yjs": ">=13.5.22" } }, "sha512-PaKTxSbVC4fpqUjQ7vUL9RkNF1PjL8TFl5jRe03PqoPYpE33buf3VXX6+cOUEfv9+uknSqLCPHoBS/4jN3a97w=="],
+
+    "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
+
+    "@lezer/cpp": ["@lezer/cpp@1.1.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw=="],
+
+    "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
+
+    "@lezer/go": ["@lezer/go@1.0.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/java": ["@lezer/java@1.1.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.8", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
+
+    "@lezer/php": ["@lezer/php@1.0.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.1.0" } }, "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA=="],
+
+    "@lezer/python": ["@lezer/python@1.1.18", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg=="],
+
+    "@lezer/rust": ["@lezer/rust@1.0.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg=="],
+
+    "@lezer/sass": ["@lezer/sass@1.1.0", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ=="],
+
+    "@lezer/xml": ["@lezer/xml@1.0.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww=="],
+
+    "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -950,6 +1049,8 @@
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
@@ -1653,6 +1754,8 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1836,6 +1939,8 @@
     "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "wait-on": ["wait-on@8.0.5", "", { "dependencies": { "axios": "^1.12.1", "joi": "^18.0.1", "lodash": "^4.17.21", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag=="],
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -22,6 +22,8 @@ import type {
 import type {
   ProjectListDirectoryInput,
   ProjectListDirectoryResult,
+  ProjectReadFileInput,
+  ProjectReadFileResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
@@ -180,6 +182,7 @@ export interface NativeApi {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     listDirectory: (input: ProjectListDirectoryInput) => Promise<ProjectListDirectoryResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
+    readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -60,3 +60,17 @@ export const ProjectWriteFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
 });
 export type ProjectWriteFileResult = typeof ProjectWriteFileResult.Type;
+
+export const ProjectReadFileInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_WRITE_FILE_PATH_MAX_LENGTH)),
+});
+export type ProjectReadFileInput = typeof ProjectReadFileInput.Type;
+
+export const ProjectReadFileResult = Schema.Struct({
+  relativePath: TrimmedNonEmptyString,
+  contents: Schema.String,
+  sizeBytes: Schema.Number,
+  truncated: Schema.Boolean,
+});
+export type ProjectReadFileResult = typeof ProjectReadFileResult.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -37,6 +37,7 @@ import {
 import { KeybindingRule } from "./keybindings";
 import {
   ProjectListDirectoryInput,
+  ProjectReadFileInput,
   ProjectSearchEntriesInput,
   ProjectWriteFileInput,
 } from "./project";
@@ -53,6 +54,7 @@ export const WS_METHODS = {
   projectsSearchEntries: "projects.searchEntries",
   projectsListDirectory: "projects.listDirectory",
   projectsWriteFile: "projects.writeFile",
+  projectsReadFile: "projects.readFile",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -120,6 +122,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsListDirectory, ProjectListDirectoryInput),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
+  tagRequestBody(WS_METHODS.projectsReadFile, ProjectReadFileInput),
 
   // Shell methods
   tagRequestBody(WS_METHODS.shellOpenInEditor, OpenInEditorInput),


### PR DESCRIPTION
## Summary
- Added a built-in code viewer for workspace files with CodeMirror-based syntax highlighting, read-only rendering, and theme-aware styling.
- Wired the file tree so normal clicks open files in the in-app viewer, while Cmd/Ctrl-click still opens the file in the external editor.
- Added file-read support to the server and shared WS/native contracts, including size and binary-file guards for safer display.
- Introduced route/store state for viewer tabs and integrated the viewer into both inline sidebar and sheet layouts.

## Testing
- Not run.
- Expected checks before merge: `bun fmt`.
- Expected checks before merge: `bun lint`.
- Expected checks before merge: `bun typecheck`.