### PR TITLE
Open single-thread projects directly in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1435,9 +1435,22 @@ export default function Sidebar() {
       if (selectedThreadIds.size > 0) {
         clearSelection();
       }
+      // When expanding a project with exactly one thread, navigate directly to it.
+      const project = projects.find((p) => p.id === projectId);
+      if (project && !project.expanded) {
+        const projectThreads = threads.filter((t) => t.projectId === projectId);
+        if (projectThreads.length === 1) {
+          toggleProject(projectId);
+          void navigate({
+            to: "/$threadId",
+            params: { threadId: projectThreads[0]!.id },
+          });
+          return;
+        }
+      }
       toggleProject(projectId);
     },
-    [clearSelection, selectedThreadIds.size, toggleProject],
+    [clearSelection, navigate, projects, selectedThreadIds.size, threads, toggleProject],
   );
 
   const handleProjectTitleKeyDown = useCallback(
@@ -1447,9 +1460,22 @@ export default function Sidebar() {
       if (dragInProgressRef.current) {
         return;
       }
+      // When expanding a project with exactly one thread, navigate directly to it.
+      const project = projects.find((p) => p.id === projectId);
+      if (project && !project.expanded) {
+        const projectThreads = threads.filter((t) => t.projectId === projectId);
+        if (projectThreads.length === 1) {
+          toggleProject(projectId);
+          void navigate({
+            to: "/$threadId",
+            params: { threadId: projectThreads[0]!.id },
+          });
+          return;
+        }
+      }
       toggleProject(projectId);
     },
-    [toggleProject],
+    [navigate, projects, threads, toggleProject],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- When expanding a collapsed project that contains exactly one thread, the sidebar now navigates straight to that thread.
- Applied the same behavior for both mouse clicks and keyboard interactions on project titles.
- Preserves existing selection clearing and drag-in-progress guards.

## Testing
- Not run (not requested).
- Suggested checks: expand a collapsed project with one thread and confirm it opens the thread directly.
- Suggested checks: expand a project with multiple threads and confirm it only toggles expansion.