### PR TITLE
Default new diff files to collapsed

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -679,7 +679,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                   const themedFileKey = `${fileKey}:${resolvedTheme}`;
                   const fileReviewState = activeReviewState[filePath] ?? {
                     accepted: false,
-                    collapsed: false,
+                    collapsed: true,
                   };
                   return (
                     <DiffFileSection

--- a/apps/web/src/lib/diffFileReviewState.test.ts
+++ b/apps/web/src/lib/diffFileReviewState.test.ts
@@ -18,9 +18,9 @@ describe("reconcileDiffFileReviewState", () => {
     });
   });
 
-  it("initializes new files as unaccepted and expanded", () => {
+  it("initializes new files as unaccepted and collapsed", () => {
     expect(reconcileDiffFileReviewState(["src/a.ts"], undefined)).toEqual({
-      "src/a.ts": { accepted: false, collapsed: false },
+      "src/a.ts": { accepted: false, collapsed: true },
     });
   });
 });
@@ -79,6 +79,7 @@ describe("expandDiffFile", () => {
     const state = {
       "src/a.ts": { accepted: false, collapsed: false },
     };
+    // File is already expanded, so the same object reference is returned.
     expect(expandDiffFile(state, "src/a.ts")).toBe(state);
   });
 });

--- a/apps/web/src/lib/diffFileReviewState.ts
+++ b/apps/web/src/lib/diffFileReviewState.ts
@@ -6,7 +6,7 @@ export interface DiffFileReviewState {
 export type DiffFileReviewStateByPath = Record<string, DiffFileReviewState>;
 
 const DEFAULT_DIFF_FILE_REVIEW_STATE: DiffFileReviewState = {
-  collapsed: false,
+  collapsed: true,
   accepted: false,
 };
 


### PR DESCRIPTION
## Summary
- Default newly discovered diff files to start collapsed instead of expanded.
- Update the diff review state default to match the new UX behavior.
- Adjust tests to reflect the collapsed initial state and verify the no-op expand path still preserves object identity.

## Testing
- Not run (PR content only).
- Existing unit coverage updated in `apps/web/src/lib/diffFileReviewState.test.ts`.