### PR TITLE
Add provider onboarding and doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,59 @@ A minimal web GUI for coding agents. Currently supports Codex and Claude, with m
 
 ## Quick Start
 
-> [!WARNING]
-> You need [Codex CLI](https://github.com/openai/codex) installed and authorized for OK Code to work.
-
 ```bash
 npx okcode
 ```
 
+This starts the OK Code server and opens your browser. The app automatically detects which providers you have installed.
+
 Or install the [desktop app from the Releases page](https://github.com/OpenKnots/okcode/releases).
+
+### Provider Setup
+
+OK Code supports multiple AI providers. You need **at least one** configured to start coding.
+
+<details>
+<summary><strong>Option A: OpenAI (Codex CLI)</strong></summary>
+
+1. Install: `npm install -g @openai/codex`
+2. Authenticate: `codex login`
+3. Verify: `codex login status`
+
+If using a custom model provider (Azure OpenAI, Portkey, etc.), configure `model_provider` in `~/.codex/config.toml` instead — no `codex login` needed.
+
+</details>
+
+<details>
+<summary><strong>Option B: Anthropic (Claude Code)</strong></summary>
+
+1. Install: `npm install -g @anthropic-ai/claude-code`
+2. Authenticate: `claude auth login`
+3. Verify: `claude auth status`
+
+</details>
+
+> [!TIP]
+> You can install both providers and switch between them per session.
+
+### Troubleshooting
+
+Run the built-in diagnostic to check your setup:
+
+```bash
+npx okcode doctor
+```
+
+If OK Code shows a provider error banner after launch:
+
+| Banner message                 | Fix                                               |
+| ------------------------------ | ------------------------------------------------- |
+| "not installed or not on PATH" | Install the CLI (see above), then restart OK Code |
+| "not authenticated"            | Run the login command for that provider           |
+| "version check failed"         | Update the CLI to the latest version              |
+
+> [!NOTE]
+> OK Code launches even without providers configured — you can explore the UI and configure provider binary paths from **Settings** before starting a session.
 
 ## Development Setup
 

--- a/apps/server/src/doctor.ts
+++ b/apps/server/src/doctor.ts
@@ -1,0 +1,85 @@
+/**
+ * doctor - CLI diagnostic command.
+ *
+ * Runs provider health checks and prints a summary to the terminal
+ * without starting the full server.
+ *
+ * @module doctor
+ */
+import { Effect } from "effect";
+import { Command } from "effect/unstable/cli";
+
+import {
+  checkCodexProviderStatus,
+  checkClaudeProviderStatus,
+} from "./provider/Layers/ProviderHealth";
+import type { ServerProviderStatus } from "@okcode/contracts";
+import { fixPath } from "./os-jank";
+
+const STATUS_ICONS: Record<string, string> = {
+  ready: "\u2705",
+  warning: "\u26A0\uFE0F",
+  error: "\u274C",
+};
+
+const AUTH_LABELS: Record<string, string> = {
+  authenticated: "authenticated",
+  unauthenticated: "not authenticated",
+  unknown: "unknown",
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  codex: "Codex (OpenAI)",
+  claudeAgent: "Claude (Anthropic)",
+};
+
+function printStatus(status: ServerProviderStatus): void {
+  const icon = STATUS_ICONS[status.status] ?? "?";
+  const label = PROVIDER_LABELS[status.provider] ?? status.provider;
+  const auth = AUTH_LABELS[status.authStatus] ?? status.authStatus;
+
+  console.log("");
+  console.log(`  ${icon} ${label}`);
+  console.log(`     Status: ${status.status}`);
+  console.log(`     Auth:   ${auth}`);
+  if (status.message) {
+    console.log(`     Detail: ${status.message}`);
+  }
+}
+
+const doctorProgram = Effect.gen(function* () {
+  // Fix PATH so CLIs installed via nvm/volta/etc. are reachable.
+  fixPath();
+
+  console.log("OK Code Doctor");
+  console.log("==============");
+  console.log("");
+  console.log("Checking provider health...");
+
+  const statuses = yield* Effect.all([checkCodexProviderStatus, checkClaudeProviderStatus], {
+    concurrency: "unbounded",
+  });
+
+  for (const status of statuses) {
+    printStatus(status);
+  }
+
+  const readyCount = statuses.filter((s) => s.status === "ready").length;
+  console.log("");
+  if (readyCount === 0) {
+    console.log("No providers are ready. Set up at least one provider to start coding:");
+    console.log("");
+    console.log("  Codex:  npm install -g @openai/codex && codex login");
+    console.log("  Claude: npm install -g @anthropic-ai/claude-code && claude auth login");
+  } else if (readyCount === statuses.length) {
+    console.log("All providers are ready.");
+  } else {
+    console.log(`${readyCount} of ${statuses.length} providers ready.`);
+  }
+  console.log("");
+});
+
+export const doctorCmd = Command.make("doctor").pipe(
+  Command.withDescription("Check provider health and system requirements."),
+  Command.withHandler(() => doctorProgram),
+);

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -27,6 +27,7 @@ import { Server } from "./wsServer";
 import { ServerLoggerLive } from "./serverLogger";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
+import { doctorCmd } from "./doctor";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -329,7 +330,7 @@ const logWebSocketEventsFlag = Flag.boolean("log-websocket-events").pipe(
   Flag.optional,
 );
 
-export const okcodeCli = Command.make("okcode", {
+const serveCmd = Command.make("okcode", {
   mode: modeFlag,
   port: portFlag,
   host: hostFlag,
@@ -342,4 +343,7 @@ export const okcodeCli = Command.make("okcode", {
 }).pipe(
   Command.withDescription("Run the OK Code server."),
   Command.withHandler((input) => Effect.scoped(makeServerProgram(input))),
+  Command.withSubcommands([doctorCmd]),
 );
+
+export { serveCmd as okcodeCli };

--- a/apps/web/src/components/chat/ProviderSetupCard.tsx
+++ b/apps/web/src/components/chat/ProviderSetupCard.tsx
@@ -1,0 +1,153 @@
+import { type ServerProviderStatus } from "@okcode/contracts";
+import { memo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  CheckCircle2Icon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  CircleAlertIcon,
+  SettingsIcon,
+  TerminalIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { Button } from "../ui/button";
+
+const PROVIDER_CONFIG = {
+  codex: {
+    label: "OpenAI (Codex CLI)",
+    installCmd: "npm install -g @openai/codex",
+    authCmd: "codex login",
+    verifyCmd: "codex login status",
+  },
+  claudeAgent: {
+    label: "Anthropic (Claude Code)",
+    installCmd: "npm install -g @anthropic-ai/claude-code",
+    authCmd: "claude auth login",
+    verifyCmd: "claude auth status",
+  },
+} as const;
+
+function StatusIcon({ status }: { status: ServerProviderStatus["status"] }) {
+  switch (status) {
+    case "ready":
+      return <CheckCircle2Icon className="size-4 text-emerald-500" />;
+    case "warning":
+      return <CircleAlertIcon className="size-4 text-amber-500" />;
+    case "error":
+      return <XCircleIcon className="size-4 text-red-400" />;
+  }
+}
+
+function ProviderRow({ status }: { status: ServerProviderStatus }) {
+  const [expanded, setExpanded] = useState(status.status !== "ready");
+  const config = PROVIDER_CONFIG[status.provider as keyof typeof PROVIDER_CONFIG];
+  if (!config) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-card/50 p-3">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2.5 text-left text-sm"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <StatusIcon status={status.status} />
+        <span className="flex-1 font-medium text-foreground">{config.label}</span>
+        {expanded ? (
+          <ChevronDownIcon className="size-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRightIcon className="size-3.5 text-muted-foreground" />
+        )}
+      </button>
+
+      {status.status !== "ready" && status.message && (
+        <p className="mt-1.5 ml-6.5 text-xs text-muted-foreground">{status.message}</p>
+      )}
+
+      {expanded && status.status !== "ready" && (
+        <div className="mt-3 ml-6.5 space-y-2">
+          <div className="space-y-1.5">
+            <Step n={1} label="Install">
+              <Code>{config.installCmd}</Code>
+            </Step>
+            <Step n={2} label="Authenticate">
+              <Code>{config.authCmd}</Code>
+            </Step>
+            <Step n={3} label="Verify">
+              <Code>{config.verifyCmd}</Code>
+            </Step>
+          </div>
+        </div>
+      )}
+
+      {status.status === "ready" && (
+        <p className="mt-1 ml-6.5 text-xs text-emerald-600 dark:text-emerald-400">Ready</p>
+      )}
+    </div>
+  );
+}
+
+function Step({ n, label, children }: { n: number; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-2 text-xs">
+      <span className="shrink-0 text-muted-foreground">
+        {n}. {label}:
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+      {children}
+    </code>
+  );
+}
+
+export const ProviderSetupCard = memo(function ProviderSetupCard({
+  providers,
+}: {
+  providers: ReadonlyArray<ServerProviderStatus>;
+}) {
+  const navigate = useNavigate();
+  const readyCount = providers.filter((p) => p.status === "ready").length;
+
+  // Don't show if all providers are ready
+  if (readyCount === providers.length && providers.length > 0) {
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-md space-y-4">
+      <div className="space-y-1.5 text-center">
+        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-xl border border-border bg-card shadow-sm">
+          <TerminalIcon className="size-5 text-foreground" />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground">Set up a provider</h2>
+        <p className="text-sm text-muted-foreground">
+          {readyCount === 0
+            ? "Connect at least one AI provider to start coding."
+            : `${readyCount} of ${providers.length} providers ready. Set up another provider or start coding.`}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {providers.map((status) => (
+          <ProviderRow key={status.provider} status={status} />
+        ))}
+      </div>
+
+      <div className="flex items-center justify-center gap-2 pt-1">
+        <Button variant="outline" size="sm" onClick={() => void navigate({ to: "/settings" })}>
+          <SettingsIcon />
+          Settings
+        </Button>
+      </div>
+
+      <p className="text-center text-xs text-muted-foreground/60">
+        Run <Code>npx okcode doctor</Code> to diagnose setup issues from the terminal.
+      </p>
+    </div>
+  );
+});

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -1,9 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
+import { ProviderSetupCard } from "../components/chat/ProviderSetupCard";
 import { SidebarTrigger } from "../components/ui/sidebar";
+import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 
 function ChatIndexRouteView() {
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const providers = serverConfigQuery.data?.providers ?? [];
+  const hasReadyProvider = providers.some((p) => p.status === "ready");
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
       {!isElectron && (
@@ -21,10 +28,14 @@ function ChatIndexRouteView() {
         </div>
       )}
 
-      <div className="flex flex-1 items-center justify-center">
-        <div className="text-center">
-          <p className="text-sm">Select a thread or create a new one to get started.</p>
-        </div>
+      <div className="flex flex-1 items-center justify-center p-6">
+        {!hasReadyProvider && providers.length > 0 ? (
+          <ProviderSetupCard providers={providers} />
+        ) : (
+          <div className="text-center">
+            <p className="text-sm">Select a thread or create a new one to get started.</p>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added a `doctor` CLI command that checks Codex and Claude provider health from the terminal.
- Added an onboarding card in the chat landing view that explains how to install, authenticate, and verify providers when none are ready.
- Updated the README quick start with provider setup and troubleshooting guidance.
- Simplified the release runbook structure and refreshed the release process notes.

## Testing
- Not run (`bun fmt`)
- Not run (`bun lint`)
- Not run (`bun typecheck`)
- Not run (`bun run test`)