### PR TITLE
Promote code viewer to a full-page overlay

### DIFF
--- a/apps/web/src/codeViewerStore.ts
+++ b/apps/web/src/codeViewerStore.ts
@@ -6,13 +6,26 @@ export interface CodeViewerTab {
   label: string;
 }
 
+export interface CodeViewerPendingContext {
+  filePath: string;
+  fromLine: number;
+  toLine: number;
+}
+
 interface CodeViewerState {
+  isOpen: boolean;
   tabs: CodeViewerTab[];
   activeTabPath: string | null;
+  pendingContext: CodeViewerPendingContext | null;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
   openFile: (cwd: string, relativePath: string) => void;
   closeTab: (relativePath: string) => void;
   setActiveTab: (relativePath: string) => void;
   closeAllTabs: () => void;
+  setPendingContext: (ctx: CodeViewerPendingContext) => void;
+  clearPendingContext: () => void;
 }
 
 function basenameOf(filePath: string): string {
@@ -21,14 +34,26 @@ function basenameOf(filePath: string): string {
 }
 
 export const useCodeViewerStore = create<CodeViewerState>((set) => ({
+  isOpen: false,
   tabs: [],
   activeTabPath: null,
+  pendingContext: null,
+
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false, tabs: [], activeTabPath: null }),
+  toggle: () =>
+    set((state) => {
+      if (state.isOpen) {
+        return { isOpen: false, tabs: [], activeTabPath: null };
+      }
+      return { isOpen: true };
+    }),
 
   openFile: (cwd, relativePath) =>
     set((state) => {
       const existing = state.tabs.find((tab) => tab.relativePath === relativePath);
       if (existing) {
-        return { activeTabPath: relativePath };
+        return { isOpen: true, activeTabPath: relativePath };
       }
       const newTab: CodeViewerTab = {
         cwd,
@@ -36,6 +61,7 @@ export const useCodeViewerStore = create<CodeViewerState>((set) => ({
         label: basenameOf(relativePath),
       };
       return {
+        isOpen: true,
         tabs: [...state.tabs, newTab],
         activeTabPath: relativePath,
       };
@@ -52,10 +78,17 @@ export const useCodeViewerStore = create<CodeViewerState>((set) => ({
         const nearestIndex = Math.min(index, nextTabs.length - 1);
         nextActive = nextTabs[nearestIndex]?.relativePath ?? null;
       }
+      // If no tabs left, close the viewer
+      if (nextTabs.length === 0) {
+        return { isOpen: false, tabs: [], activeTabPath: null };
+      }
       return { tabs: nextTabs, activeTabPath: nextActive };
     }),
 
   setActiveTab: (relativePath) => set({ activeTabPath: relativePath }),
 
-  closeAllTabs: () => set({ tabs: [], activeTabPath: null }),
+  closeAllTabs: () => set({ isOpen: false, tabs: [], activeTabPath: null }),
+
+  setPendingContext: (ctx) => set({ pendingContext: ctx }),
+  clearPendingContext: () => set({ pendingContext: null }),
 }));

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -15,7 +15,6 @@ import {
   type ServerProviderStatus,
   type ThreadId,
   type TurnId,
-  type EditorId,
   type KeybindingCommand,
   OrchestrationThreadActivity,
   ProviderInteractionMode,
@@ -153,6 +152,7 @@ import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./Compose
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
+import { useCodeViewerStore } from "~/codeViewerStore";
 import { PreviewPanel } from "./PreviewPanel";
 import { ContextWindowMeter } from "./chat/ContextWindowMeter";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -196,7 +196,6 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
-const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 
@@ -1149,7 +1148,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [nonPersistedComposerImageIds],
   );
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
-  const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
   const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
   const activeProviderStatus = useMemo(
     () => providerStatuses.find((status) => status.provider === selectedProvider) ?? null,
@@ -1199,6 +1197,22 @@ export default function ChatView({ threadId }: ChatViewProps) {
       },
     });
   }, [diffOpen, navigate, threadId]);
+
+  const toggleCodeViewer = useCodeViewerStore((state) => state.toggle);
+  const pendingContext = useCodeViewerStore((state) => state.pendingContext);
+  const clearPendingContext = useCodeViewerStore((state) => state.clearPendingContext);
+
+  // When Cmd+L is pressed in the code viewer, insert the @file:lines mention into the composer
+  useEffect(() => {
+    if (!pendingContext) return;
+    const { filePath, fromLine, toLine } = pendingContext;
+    const mention =
+      fromLine === toLine ? `@${filePath}:L${fromLine}` : `@${filePath}:L${fromLine}-L${toLine}`;
+    const currentPrompt = prompt;
+    const separator = currentPrompt.length > 0 && !currentPrompt.endsWith(" ") ? " " : "";
+    setPrompt(`${currentPrompt}${separator}${mention} `);
+    clearPendingContext();
+  }, [pendingContext, clearPendingContext, prompt, setPrompt]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3842,7 +3856,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
             activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
           }
           keybindings={keybindings}
-          availableEditors={availableEditors}
           terminalAvailable={activeProject !== undefined}
           terminalOpen={terminalState.terminalOpen}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
@@ -3862,6 +3875,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           onToggleDiff={onToggleDiff}
           onTogglePreview={() => togglePreviewOpen(activeThread.id)}
           onTogglePreviewLayout={() => togglePreviewLayout(activeThread.id)}
+          onToggleCodeViewer={toggleCodeViewer}
         />
       </header>
 

--- a/apps/web/src/components/CodeMirrorViewer.tsx
+++ b/apps/web/src/components/CodeMirrorViewer.tsx
@@ -4,6 +4,7 @@ import {
   lineNumbers,
   highlightActiveLine,
   highlightSpecialChars,
+  keymap,
 } from "@codemirror/view";
 import {
   syntaxHighlighting,
@@ -12,9 +13,17 @@ import {
 } from "@codemirror/language";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { memo, useEffect, useRef } from "react";
+import { isMacPlatform } from "~/lib/utils";
+
+export interface CodeContextSelection {
+  filePath: string;
+  fromLine: number;
+  toLine: number;
+}
 
 const themeCompartment = new Compartment();
 const languageCompartment = new Compartment();
+const keymapCompartment = new Compartment();
 
 const baseExtensions: Extension[] = [
   lineNumbers(),
@@ -50,6 +59,9 @@ const baseExtensions: Extension[] = [
     ".cm-activeLineGutter": {
       backgroundColor: "transparent",
     },
+    ".cm-selectionBackground": {
+      backgroundColor: "color-mix(in srgb, var(--primary) 25%, transparent) !important",
+    },
   }),
 ];
 
@@ -77,18 +89,44 @@ async function loadLanguageExtension(filePath: string): Promise<Extension> {
   return support;
 }
 
+function buildAddContextKeymap(
+  filePath: string,
+  onAddContext: (ctx: CodeContextSelection) => void,
+): Extension {
+  return keymap.of([
+    {
+      key: isMacPlatform(navigator.platform) ? "Mod-l" : "Ctrl-l",
+      run: (view) => {
+        const { from, to } = view.state.selection.main;
+        if (from === to) return false; // No selection
+        const fromLine = view.state.doc.lineAt(from).number;
+        const toLine = view.state.doc.lineAt(to).number;
+        onAddContext({ filePath, fromLine, toLine });
+        return true;
+      },
+    },
+  ]);
+}
+
 export const CodeMirrorViewer = memo(function CodeMirrorViewer(props: {
   contents: string;
   filePath: string;
   resolvedTheme: "light" | "dark";
+  onAddContext?: (ctx: CodeContextSelection) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const filePathRef = useRef<string | null>(null);
+  const onAddContextRef = useRef(props.onAddContext);
+  onAddContextRef.current = props.onAddContext;
 
   // Create editor on mount
   useEffect(() => {
     if (!containerRef.current) return;
+
+    const addContextKeymap = buildAddContextKeymap(props.filePath, (ctx) => {
+      onAddContextRef.current?.(ctx);
+    });
 
     const state = EditorState.create({
       doc: props.contents,
@@ -96,6 +134,7 @@ export const CodeMirrorViewer = memo(function CodeMirrorViewer(props: {
         ...baseExtensions,
         themeCompartment.of(getThemeExtension(props.resolvedTheme)),
         languageCompartment.of([]),
+        keymapCompartment.of(addContextKeymap),
       ],
     });
 
@@ -147,7 +186,7 @@ export const CodeMirrorViewer = memo(function CodeMirrorViewer(props: {
     });
   }, [props.resolvedTheme]);
 
-  // Update language when file path changes
+  // Update language and keymap when file path changes
   useEffect(() => {
     if (filePathRef.current === props.filePath) return;
     filePathRef.current = props.filePath;
@@ -161,6 +200,13 @@ export const CodeMirrorViewer = memo(function CodeMirrorViewer(props: {
           effects: languageCompartment.reconfigure(langExt),
         });
       }
+    });
+
+    const addContextKeymap = buildAddContextKeymap(props.filePath, (ctx) => {
+      onAddContextRef.current?.(ctx);
+    });
+    view.dispatch({
+      effects: keymapCompartment.reconfigure(addContextKeymap),
     });
   }, [props.filePath]);
 

--- a/apps/web/src/components/CodeViewerPanel.tsx
+++ b/apps/web/src/components/CodeViewerPanel.tsx
@@ -6,16 +6,18 @@ import { useCodeViewerStore, type CodeViewerTab } from "~/codeViewerStore";
 import { useTheme } from "~/hooks/useTheme";
 import { projectReadFileQueryOptions } from "~/lib/projectReactQuery";
 import { cn } from "~/lib/utils";
-import { CodeMirrorViewer } from "./CodeMirrorViewer";
-import { type DiffPanelMode, DiffPanelShell, DiffPanelLoadingState } from "./DiffPanelShell";
-
-export type CodeViewerPanelMode = DiffPanelMode;
+import { CodeMirrorViewer, type CodeContextSelection } from "./CodeMirrorViewer";
+import { DiffPanelLoadingState } from "./DiffPanelShell";
+import { isElectron } from "~/env";
+import { Button } from "./ui/button";
+import { isMacPlatform } from "~/lib/utils";
 
 function CodeViewerTabStrip(props: {
   tabs: CodeViewerTab[];
   activeTabPath: string | null;
   onSelectTab: (relativePath: string) => void;
   onCloseTab: (relativePath: string) => void;
+  onCloseAll: () => void;
 }) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [-webkit-app-region:no-drag]">
@@ -61,6 +63,7 @@ const CodeViewerFileContent = memo(function CodeViewerFileContent(props: {
   cwd: string;
   relativePath: string;
   resolvedTheme: "light" | "dark";
+  onAddContext: (ctx: CodeContextSelection) => void;
 }) {
   const query = useQuery(
     projectReadFileQueryOptions({
@@ -101,21 +104,20 @@ const CodeViewerFileContent = memo(function CodeViewerFileContent(props: {
         contents={query.data.contents}
         filePath={props.relativePath}
         resolvedTheme={props.resolvedTheme}
+        onAddContext={props.onAddContext}
       />
     </div>
   );
 });
 
-interface CodeViewerPanelProps {
-  mode?: CodeViewerPanelMode;
-}
-
-export default function CodeViewerPanel({ mode = "inline" }: CodeViewerPanelProps) {
+export default function CodeViewerPanel() {
   const { resolvedTheme } = useTheme();
   const tabs = useCodeViewerStore((state) => state.tabs);
   const activeTabPath = useCodeViewerStore((state) => state.activeTabPath);
   const setActiveTab = useCodeViewerStore((state) => state.setActiveTab);
   const closeTab = useCodeViewerStore((state) => state.closeTab);
+  const closeViewer = useCodeViewerStore((state) => state.close);
+  const setPendingContext = useCodeViewerStore((state) => state.setPendingContext);
 
   const activeTab = tabs.find((tab) => tab.relativePath === activeTabPath);
 
@@ -126,30 +128,68 @@ export default function CodeViewerPanel({ mode = "inline" }: CodeViewerPanelProp
 
   const onCloseTab = useCallback((relativePath: string) => closeTab(relativePath), [closeTab]);
 
-  const headerRow = (
-    <CodeViewerTabStrip
-      tabs={tabs}
-      activeTabPath={activeTabPath}
-      onSelectTab={onSelectTab}
-      onCloseTab={onCloseTab}
-    />
+  const onAddContext = useCallback(
+    (ctx: CodeContextSelection) => {
+      setPendingContext({
+        filePath: ctx.filePath,
+        fromLine: ctx.fromLine,
+        toLine: ctx.toLine,
+      });
+    },
+    [setPendingContext],
   );
 
+  const modKey = isMacPlatform(navigator.platform) ? "\u2318" : "Ctrl+";
+
   return (
-    <DiffPanelShell mode={mode} header={headerRow}>
-      {!activeTab ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-5 text-center text-muted-foreground/60">
-          <FileCodeIcon className="size-8 opacity-40" />
-          <p className="text-xs">Click a file in the sidebar to view it here.</p>
-        </div>
-      ) : (
-        <CodeViewerFileContent
-          key={activeTab.relativePath}
-          cwd={activeTab.cwd}
-          relativePath={activeTab.relativePath}
-          resolvedTheme={resolvedTheme}
+    <div className="flex h-full w-full flex-col bg-background">
+      {/* Header */}
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 border-b border-border px-4",
+          isElectron ? "drag-region h-[52px]" : "h-12",
+        )}
+      >
+        <CodeViewerTabStrip
+          tabs={tabs}
+          activeTabPath={activeTabPath}
+          onSelectTab={onSelectTab}
+          onCloseTab={onCloseTab}
+          onCloseAll={closeViewer}
         />
-      )}
-    </DiffPanelShell>
+        <div className="flex shrink-0 items-center gap-2 [-webkit-app-region:no-drag]">
+          <span className="hidden text-[10px] text-muted-foreground/50 sm:inline">
+            Select code + {modKey}L to add context
+          </span>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            onClick={closeViewer}
+            aria-label="Close code viewer"
+          >
+            <XIcon className="size-4" />
+          </Button>
+        </div>
+      </div>
+      {/* Content */}
+      <div className="flex min-h-0 flex-1 justify-center overflow-hidden">
+        <div className="h-full w-full max-w-5xl">
+          {!activeTab ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 px-5 text-center text-muted-foreground/60">
+              <FileCodeIcon className="size-8 opacity-40" />
+              <p className="text-xs">Click a file in the sidebar to view it here.</p>
+            </div>
+          ) : (
+            <CodeViewerFileContent
+              key={activeTab.relativePath}
+              cwd={activeTab.cwd}
+              relativePath={activeTab.relativePath}
+              resolvedTheme={resolvedTheme}
+              onAddContext={onAddContext}
+            />
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -1,5 +1,4 @@
 import {
-  type EditorId,
   type ProjectScript,
   type ThreadId,
   type ResolvedKeybindingsConfig,
@@ -31,7 +30,6 @@ interface ChatHeaderProps {
   activeProjectScripts: ProjectScript[] | undefined;
   preferredScriptId: string | null;
   keybindings: ResolvedKeybindingsConfig;
-  availableEditors: ReadonlyArray<EditorId>;
   terminalAvailable: boolean;
   terminalOpen: boolean;
   terminalToggleShortcutLabel: string | null;
@@ -49,6 +47,7 @@ interface ChatHeaderProps {
   onToggleDiff: () => void;
   onTogglePreview: () => void;
   onTogglePreviewLayout: () => void;
+  onToggleCodeViewer: () => void;
 }
 
 export const ChatHeader = memo(function ChatHeader({
@@ -60,7 +59,6 @@ export const ChatHeader = memo(function ChatHeader({
   activeProjectScripts,
   preferredScriptId,
   keybindings,
-  availableEditors,
   terminalAvailable,
   terminalOpen,
   terminalToggleShortcutLabel,
@@ -78,6 +76,7 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleDiff,
   onTogglePreview,
   onTogglePreviewLayout,
+  onToggleCodeViewer,
 }: ChatHeaderProps) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -112,13 +111,7 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
-        {activeProjectName && (
-          <OpenInPicker
-            keybindings={keybindings}
-            availableEditors={availableEditors}
-            openInCwd={openInCwd}
-          />
-        )}
+        {activeProjectName && <OpenInPicker onToggleCodeViewer={onToggleCodeViewer} />}
         {activeProjectName && <GitActionsControl gitCwd={gitCwd} activeThreadId={activeThreadId} />}
         <Tooltip>
           <TooltipTrigger

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,128 +1,21 @@
-import { EditorId, type ResolvedKeybindingsConfig } from "@okcode/contracts";
-import { memo, useCallback, useEffect, useMemo } from "react";
-import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
-import { usePreferredEditor } from "../../editorPreferences";
-import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
+import { memo } from "react";
+import { FileCodeIcon } from "lucide-react";
 import { Button } from "../ui/button";
-import { Group, GroupSeparator } from "../ui/group";
-import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
-import { AntigravityIcon, CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
-import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
-import { readNativeApi } from "~/nativeApi";
-
-const resolveOptions = (platform: string, availableEditors: ReadonlyArray<EditorId>) => {
-  const baseOptions: ReadonlyArray<{ label: string; Icon: Icon; value: EditorId }> = [
-    {
-      label: "Cursor",
-      Icon: CursorIcon,
-      value: "cursor",
-    },
-    {
-      label: "VS Code",
-      Icon: VisualStudioCode,
-      value: "vscode",
-    },
-    {
-      label: "Zed",
-      Icon: Zed,
-      value: "zed",
-    },
-    {
-      label: "Antigravity",
-      Icon: AntigravityIcon,
-      value: "antigravity",
-    },
-    {
-      label: isMacPlatform(platform)
-        ? "Finder"
-        : isWindowsPlatform(platform)
-          ? "Explorer"
-          : "Files",
-      Icon: FolderClosedIcon,
-      value: "file-manager",
-    },
-  ];
-  return baseOptions.filter((option) => availableEditors.includes(option.value));
-};
 
 export const OpenInPicker = memo(function OpenInPicker({
-  keybindings,
-  availableEditors,
-  openInCwd,
+  onToggleCodeViewer,
 }: {
-  keybindings: ResolvedKeybindingsConfig;
-  availableEditors: ReadonlyArray<EditorId>;
-  openInCwd: string | null;
+  onToggleCodeViewer: () => void;
 }) {
-  const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
-  const options = useMemo(
-    () => resolveOptions(navigator.platform, availableEditors),
-    [availableEditors],
-  );
-  const primaryOption = options.find(({ value }) => value === preferredEditor) ?? null;
-
-  const openInEditor = useCallback(
-    (editorId: EditorId | null) => {
-      const api = readNativeApi();
-      if (!api || !openInCwd) return;
-      const editor = editorId ?? preferredEditor;
-      if (!editor) return;
-      void api.shell.openInEditor(openInCwd, editor);
-      setPreferredEditor(editor);
-    },
-    [preferredEditor, openInCwd, setPreferredEditor],
-  );
-
-  const openFavoriteEditorShortcutLabel = useMemo(
-    () => shortcutLabelForCommand(keybindings, "editor.openFavorite"),
-    [keybindings],
-  );
-
-  useEffect(() => {
-    const handler = (e: globalThis.KeyboardEvent) => {
-      const api = readNativeApi();
-      if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
-      if (!api || !openInCwd) return;
-      if (!preferredEditor) return;
-
-      e.preventDefault();
-      void api.shell.openInEditor(openInCwd, preferredEditor);
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [preferredEditor, keybindings, openInCwd]);
-
   return (
-    <Group aria-label="Subscription actions">
-      <Button
-        size="xs"
-        variant="outline"
-        disabled={!preferredEditor || !openInCwd}
-        onClick={() => openInEditor(preferredEditor)}
-      >
-        {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
-        <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
-          Open
-        </span>
-      </Button>
-      <GroupSeparator className="hidden @sm/header-actions:block" />
-      <Menu>
-        <MenuTrigger render={<Button aria-label="Copy options" size="icon-xs" variant="outline" />}>
-          <ChevronDownIcon aria-hidden="true" className="size-4" />
-        </MenuTrigger>
-        <MenuPopup align="end">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
-          {options.map(({ label, Icon, value }) => (
-            <MenuItem key={value} onClick={() => openInEditor(value)}>
-              <Icon aria-hidden="true" className="text-muted-foreground" />
-              {label}
-              {value === preferredEditor && openFavoriteEditorShortcutLabel && (
-                <MenuShortcut>{openFavoriteEditorShortcutLabel}</MenuShortcut>
-              )}
-            </MenuItem>
-          ))}
-        </MenuPopup>
-      </Menu>
-    </Group>
+    <Button
+      size="xs"
+      variant="outline"
+      onClick={onToggleCodeViewer}
+      aria-label="Toggle code viewer"
+    >
+      <FileCodeIcon aria-hidden="true" className="size-3.5" />
+      <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">Open</span>
+    </Button>
   );
 });

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -36,11 +36,8 @@ const CodeViewerPanel = lazy(() => import("../components/CodeViewerPanel"));
 
 const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
-const CODE_VIEWER_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_code_viewer_sidebar_width";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
-const CODE_VIEWER_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
-const CODE_VIEWER_INLINE_SIDEBAR_MIN_WIDTH = 22 * 16;
 const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 
 const DiffPanelSheet = (props: {
@@ -69,28 +66,6 @@ const DiffPanelSheet = (props: {
   );
 };
 
-const CodeViewerSheet = (props: { children: ReactNode; open: boolean; onClose: () => void }) => {
-  return (
-    <Sheet
-      open={props.open}
-      onOpenChange={(open) => {
-        if (!open) {
-          props.onClose();
-        }
-      }}
-    >
-      <SheetPopup
-        side="right"
-        showCloseButton={false}
-        keepMounted
-        className="w-[min(88vw,820px)] max-w-[820px] p-0"
-      >
-        {props.children}
-      </SheetPopup>
-    </Sheet>
-  );
-};
-
 const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   return (
     <DiffPanelShell mode={props.mode} header={<DiffPanelHeaderSkeleton />}>
@@ -99,11 +74,11 @@ const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   );
 };
 
-const CodeViewerLoadingFallback = (props: { mode: DiffPanelMode }) => {
+const CodeViewerLoadingFallback = () => {
   return (
-    <DiffPanelShell mode={props.mode} header={null}>
+    <div className="flex h-full w-full items-center justify-center bg-background">
       <DiffPanelLoadingState label="Loading code viewer..." />
-    </DiffPanelShell>
+    </div>
   );
 };
 
@@ -117,10 +92,10 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
   );
 };
 
-const LazyCodeViewerPanel = (props: { mode: DiffPanelMode }) => {
+const LazyCodeViewerPanel = () => {
   return (
-    <Suspense fallback={<CodeViewerLoadingFallback mode={props.mode} />}>
-      <CodeViewerPanel mode={props.mode} />
+    <Suspense fallback={<CodeViewerLoadingFallback />}>
+      <CodeViewerPanel />
     </Suspense>
   );
 };
@@ -214,47 +189,17 @@ const DiffPanelInlineSidebar = (props: {
   );
 };
 
-const CodeViewerInlineSidebar = (props: {
-  codeViewerOpen: boolean;
-  onCloseCodeViewer: () => void;
-  onOpenCodeViewer: () => void;
-  renderContent: boolean;
-}) => {
-  const { codeViewerOpen, onCloseCodeViewer, onOpenCodeViewer, renderContent } = props;
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        onOpenCodeViewer();
-        return;
-      }
-      onCloseCodeViewer();
-    },
-    [onCloseCodeViewer, onOpenCodeViewer],
-  );
-  const shouldAcceptInlineSidebarWidth = useShouldAcceptInlineSidebarWidth();
+/** Full-page overlay for the code viewer — covers the chat area entirely. */
+const CodeViewerFullPage = (props: { codeViewerOpen: boolean; renderContent: boolean }) => {
+  if (!props.codeViewerOpen && !props.renderContent) return null;
 
   return (
-    <SidebarProvider
-      defaultOpen={false}
-      open={codeViewerOpen}
-      onOpenChange={onOpenChange}
-      className="w-auto min-h-0 flex-none bg-transparent"
-      style={{ "--sidebar-width": CODE_VIEWER_INLINE_DEFAULT_WIDTH } as CSSProperties}
+    <div
+      className="absolute inset-0 z-30 bg-background"
+      style={{ display: props.codeViewerOpen ? undefined : "none" }}
     >
-      <Sidebar
-        side="right"
-        collapsible="offcanvas"
-        className="border-l border-border bg-card text-foreground"
-        resizable={{
-          minWidth: CODE_VIEWER_INLINE_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
-          storageKey: CODE_VIEWER_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
-        }}
-      >
-        {renderContent ? <LazyCodeViewerPanel mode="sidebar" /> : null}
-        <SidebarRail />
-      </Sidebar>
-    </SidebarProvider>
+      {props.renderContent ? <LazyCodeViewerPanel /> : null}
+    </div>
   );
 };
 
@@ -274,9 +219,8 @@ function ChatThreadRouteView() {
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
 
   // Code viewer state from Zustand store
-  const codeViewerTabs = useCodeViewerStore((state) => state.tabs);
-  const codeViewerOpen = codeViewerTabs.length > 0;
-  const closeAllCodeViewerTabs = useCodeViewerStore((state) => state.closeAllTabs);
+  const codeViewerOpen = useCodeViewerStore((state) => state.isOpen);
+  const closeCodeViewerStore = useCodeViewerStore((state) => state.close);
 
   // TanStack Router keeps active route components mounted across param-only navigations
   // unless remountDeps are configured, so this stays warm across thread switches.
@@ -302,12 +246,8 @@ function ChatThreadRouteView() {
   }, [navigate, threadId]);
 
   const closeCodeViewer = useCallback(() => {
-    closeAllCodeViewerTabs();
-  }, [closeAllCodeViewerTabs]);
-
-  const openCodeViewer = useCallback(() => {
-    // No-op — code viewer opens when files are added via the store
-  }, []);
+    closeCodeViewerStore();
+  }, [closeCodeViewerStore]);
 
   // Enforce mutual exclusivity: only one right-side panel open at a time.
   useMutuallyExclusivePanels(diffOpen, codeViewerOpen, closeDiff, closeCodeViewer);
@@ -345,15 +285,13 @@ function ChatThreadRouteView() {
   if (!shouldUseDiffSheet) {
     return (
       <>
-        <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+        <SidebarInset className="relative h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
           <ChatView key={threadId} threadId={threadId} />
+          <CodeViewerFullPage
+            codeViewerOpen={codeViewerOpen}
+            renderContent={shouldRenderCodeViewerContent}
+          />
         </SidebarInset>
-        <CodeViewerInlineSidebar
-          codeViewerOpen={codeViewerOpen}
-          onCloseCodeViewer={closeCodeViewer}
-          onOpenCodeViewer={openCodeViewer}
-          renderContent={shouldRenderCodeViewerContent}
-        />
         <DiffPanelInlineSidebar
           diffOpen={diffOpen}
           onCloseDiff={closeDiff}
@@ -366,12 +304,13 @@ function ChatThreadRouteView() {
 
   return (
     <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+      <SidebarInset className="relative h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
         <ChatView key={threadId} threadId={threadId} />
+        <CodeViewerFullPage
+          codeViewerOpen={codeViewerOpen}
+          renderContent={shouldRenderCodeViewerContent}
+        />
       </SidebarInset>
-      <CodeViewerSheet open={codeViewerOpen} onClose={closeCodeViewer}>
-        {shouldRenderCodeViewerContent ? <LazyCodeViewerPanel mode="sheet" /> : null}
-      </CodeViewerSheet>
       <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
         {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
       </DiffPanelSheet>


### PR DESCRIPTION
## Summary
- Reworked the code viewer into a full-page overlay instead of a right sidebar, with a dedicated header, close control, and centered content area.
- Added code-selection context capture in the viewer so `Cmd/Ctrl+L` inserts `@file:Lx-Ly` mentions into the composer.
- Simplified the chat header action by replacing the editor picker with a code viewer toggle.
- Updated viewer state to track open/close state and pending context, and removed the old inline sheet/sidebar flow.
- Trimmed and reorganized the release runbook content.

## Testing
- Not run.
- `bun fmt`
- `bun lint`
- `bun typecheck`