### PR TITLE
Remove project-specific preview link handling

### DIFF
--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -391,7 +391,7 @@ describe("wsNativeApi", () => {
     });
   });
 
-  it("forwards context menu metadata to desktop bridge", async () => {
+  it("forwards context menu items to desktop bridge without position", async () => {
     const showContextMenu = vi.fn().mockResolvedValue("delete");
     Object.defineProperty(getWindowForTest(), "desktopBridge", {
       configurable: true,
@@ -411,13 +411,13 @@ describe("wsNativeApi", () => {
       { x: 200, y: 300 },
     );
 
-    expect(showContextMenu).toHaveBeenCalledWith(
-      [
-        { id: "rename", label: "Rename thread" },
-        { id: "delete", label: "Delete", destructive: true },
-      ],
-      { x: 200, y: 300 },
-    );
+    // Position is intentionally not forwarded to the desktop bridge;
+    // Electron's Menu.popup() uses the current mouse cursor position
+    // which avoids coordinate-space mismatches.
+    expect(showContextMenu).toHaveBeenCalledWith([
+      { id: "rename", label: "Rename thread" },
+      { id: "delete", label: "Delete", destructive: true },
+    ]);
   });
 
   it("uses fallback context menu when desktop bridge is unavailable", async () => {

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -180,7 +180,13 @@ export function createWsNativeApi(): NativeApi {
         position?: { x: number; y: number },
       ): Promise<T | null> => {
         if (window.desktopBridge) {
-          return window.desktopBridge.showContextMenu(items, position) as Promise<T | null>;
+          // Don't pass explicit coordinates to the native Electron menu.
+          // Let Menu.popup() use the current mouse cursor position, which
+          // Electron resolves correctly regardless of title-bar style or
+          // display scaling. Passing CSS clientX/clientY can mis-position
+          // the menu when the sidebar content is scrolled or when the
+          // window uses titleBarStyle "hiddenInset".
+          return window.desktopBridge.showContextMenu(items) as Promise<T | null>;
         }
         return showContextMenuFallback(items, position);
       },


### PR DESCRIPTION
## Summary
- Stop forwarding terminal link coordinates to the desktop bridge and let Electron position the native menu itself.
- Remove the embedded preview link-routing path and simplify preview handling to localhost-only URLs.
- Delete the `openLinksExternally` setting and its settings UI since link opening now always uses the native browser fallback.
- Tighten preview validation and update copy/tests to reflect the localhost-only preview flow.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`