### PR TITLE
Add Ctrl+` as terminal toggle shortcut

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -20,6 +20,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
 ```json
 [
   { "key": "mod+j", "command": "terminal.toggle" },
+  { "key": "ctrl+`", "command": "terminal.toggle" },
   { "key": "mod+d", "command": "terminal.split", "when": "terminalFocus" },
   { "key": "mod+n", "command": "terminal.new", "when": "terminalFocus" },
   { "key": "mod+w", "command": "terminal.close", "when": "terminalFocus" },

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -277,7 +277,14 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       });
 
       const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
-      assert.isFalse(persisted.some((entry) => entry.command === "terminal.toggle"));
+      // The conflicting mod+j binding for terminal.toggle should NOT be added
+      assert.isFalse(
+        persisted.some((entry) => entry.command === "terminal.toggle" && entry.key === "mod+j"),
+      );
+      // But the non-conflicting ctrl+` binding for terminal.toggle should still be added
+      assert.isTrue(
+        persisted.some((entry) => entry.command === "terminal.toggle" && entry.key === "ctrl+`"),
+      );
       assert.isTrue(persisted.some((entry) => entry.command === "script.custom-action.run"));
 
       assert.isTrue(

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -66,6 +66,7 @@ type WhenToken =
 
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+j", command: "terminal.toggle" },
+  { key: "ctrl+`", command: "terminal.toggle" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
   { key: "mod+w", command: "terminal.close", when: "terminalFocus" },

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -78,6 +78,17 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
 const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("j"), command: "terminal.toggle" },
   {
+    shortcut: {
+      key: "`",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+      modKey: false,
+    },
+    command: "terminal.toggle",
+  },
+  {
     shortcut: modShortcut("d"),
     command: "terminal.split",
     whenAst: whenIdentifier("terminalFocus"),
@@ -114,6 +125,24 @@ describe("isTerminalToggleShortcut", () => {
   it("matches Ctrl+J on non-macOS", () => {
     assert.isTrue(
       isTerminalToggleShortcut(event({ ctrlKey: true }), DEFAULT_BINDINGS, { platform: "Win32" }),
+    );
+  });
+
+  it("matches Ctrl+` on all platforms", () => {
+    assert.isTrue(
+      isTerminalToggleShortcut(event({ key: "`", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+    );
+    assert.isTrue(
+      isTerminalToggleShortcut(event({ key: "`", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+      }),
+    );
+    assert.isTrue(
+      isTerminalToggleShortcut(event({ key: "`", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+      }),
     );
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/desktop": {
       "name": "@okcode/desktop",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -45,7 +45,7 @@
     },
     "apps/server": {
       "name": "okcodes",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "bin": {
         "okcode": "./dist/index.mjs",
       },
@@ -75,7 +75,7 @@
     },
     "apps/web": {
       "name": "@okcode/web",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@codemirror/language": "^6.12.3",
@@ -131,7 +131,7 @@
     },
     "packages/contracts": {
       "name": "@okcode/contracts",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "effect": "catalog:",
       },


### PR DESCRIPTION
## Summary
- Add `Ctrl+`` as an additional `terminal.toggle` shortcut alongside the existing `mod+j` binding.
- Update server-side default keybindings and web shortcut matching to recognize the new toggle shortcut on all platforms.
- Extend tests to verify the new binding is persisted and matched correctly.

## Testing
- Not run (PR content generation only)