### PR TITLE
Open diff files in the app viewer

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -5,12 +5,10 @@ import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { ThreadId, type TurnId } from "@okcode/contracts";
 import { CheckIcon, ChevronDownIcon, Columns2Icon, Rows3Icon, TextWrapIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { openInPreferredEditor } from "../editorPreferences";
 import { gitBranchesQueryOptions } from "~/lib/gitReactQuery";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
-import { readNativeApi } from "../nativeApi";
-import { resolvePathLinkTarget } from "../terminal-links";
+import { useCodeViewerStore } from "../codeViewerStore";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
 import { buildPatchCacheKey } from "../lib/diffRendering";
@@ -220,7 +218,7 @@ function DiffFileSection(props: {
           type="button"
           className="min-w-0 flex-1 truncate text-left font-mono text-[11px] text-foreground/90 underline-offset-2 hover:underline"
           onClick={() => onOpenInEditor(filePath)}
-          title={`Open ${filePath} in editor`}
+          title={`Open ${filePath}`}
         >
           {filePath}
         </button>
@@ -476,16 +474,13 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     target?.scrollIntoView({ block: "nearest" });
   }, [selectedFilePath, renderableFiles]);
 
-  const openDiffFileInEditor = useCallback(
+  const openFileInCodeViewer = useCodeViewerStore((state) => state.openFile);
+  const openDiffFileInCodeViewer = useCallback(
     (filePath: string) => {
-      const api = readNativeApi();
-      if (!api) return;
-      const targetPath = activeCwd ? resolvePathLinkTarget(filePath, activeCwd) : filePath;
-      void openInPreferredEditor(api, targetPath).catch((error) => {
-        console.warn("Failed to open diff file in editor.", error);
-      });
+      if (!activeCwd) return;
+      openFileInCodeViewer(activeCwd, filePath);
     },
-    [activeCwd],
+    [activeCwd, openFileInCodeViewer],
   );
   const updateActiveReviewState = useCallback(
     (updater: (current: DiffFileReviewStateByPath) => DiffFileReviewStateByPath) => {
@@ -687,7 +682,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                       fileDiff={fileDiff}
                       fileKey={themedFileKey}
                       filePath={filePath}
-                      onOpenInEditor={openDiffFileInEditor}
+                      onOpenInEditor={openDiffFileInCodeViewer}
                       onToggleAccepted={onToggleFileAccepted}
                       onToggleCollapsed={onToggleFileCollapsed}
                       resolvedTheme={resolvedTheme}

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/desktop": {
       "name": "@okcode/desktop",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -45,7 +45,7 @@
     },
     "apps/server": {
       "name": "okcodes",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "bin": {
         "okcode": "./dist/index.mjs",
       },
@@ -75,7 +75,7 @@
     },
     "apps/web": {
       "name": "@okcode/web",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@codemirror/language": "^6.12.3",
@@ -131,7 +131,7 @@
     },
     "packages/contracts": {
       "name": "@okcode/contracts",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "effect": "catalog:",
       },


### PR DESCRIPTION
## Summary
- Open diff files directly in the in-app code viewer instead of routing them through the old desktop-specific path.
- Remove now-unused desktop, web, contract, and settings code related to window/sidebar opacity and Spotify player settings.
- Clean up keybinding and sidebar/diff panel behavior to match the simplified diff viewing flow.

## Testing
- Not run (not requested).
- Reviewed the affected diff, including `apps/web/src/components/DiffPanel.tsx`, `apps/web/src/components/Sidebar.tsx`, and the related server/web contract removals.