### PR TITLE
Fix marketing app typecheck setup

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "typecheck": "astro check"
+    "typecheck": "astro sync && astro check"
   },
   "dependencies": {
     "astro": "^6.0.4"

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -410,7 +410,7 @@ const themeIdeas = [
     return null;
   }
 
-  function pickAsset(assets, platform) {
+  function pickAsset(assets: {name: string; browser_download_url: string}[], platform: {os: string; label: string; arch?: string}) {
     if (platform.os === "win") {
       return assets.find((a) => a.name.endsWith("-x64.exe"))?.browser_download_url ?? null;
     }
@@ -426,7 +426,7 @@ const themeIdeas = [
   }
 
   function initDownloadButton() {
-    const btn = document.getElementById("download-btn");
+    const btn = document.getElementById("download-btn") as HTMLAnchorElement | null;
     const label = document.getElementById("download-label");
     if (!btn || !label) return;
 
@@ -437,7 +437,7 @@ const themeIdeas = [
     label.textContent = platform.label;
 
     fetchLatestRelease()
-      .then((release) => {
+      .then((release: any) => {
         const url = pickAsset(release.assets ?? [], platform);
         if (url) {
           btn.href = url;
@@ -458,17 +458,17 @@ const themeIdeas = [
       const panels = Array.from(group.querySelectorAll("[data-tab-panel]"));
       const heroOverlay = group.querySelector("[data-hero-overlay]");
 
-      const activate = (id) => {
+      const activate = (id: string) => {
         buttons.forEach((button) => {
           const isActive = button.getAttribute("data-tab-target") === id;
           button.setAttribute("aria-selected", isActive ? "true" : "false");
-          button.dataset.active = isActive ? "true" : "false";
+          (button as HTMLElement).dataset.active = isActive ? "true" : "false";
         });
 
         panels.forEach((panel) => {
           const isActive = panel.getAttribute("data-tab-panel") === id;
-          panel.hidden = !isActive;
-          panel.dataset.active = isActive ? "true" : "false";
+          (panel as HTMLElement).hidden = !isActive;
+          (panel as HTMLElement).dataset.active = isActive ? "true" : "false";
         });
 
         group.setAttribute("data-active-tab", id);

--- a/apps/marketing/tsconfig.json
+++ b/apps/marketing/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "types": ["astro/client"]
+  },
+  "include": ["src", "**/*.ts", "**/*.tsx", "**/*.astro", ".astro/types.d.ts"]
 }


### PR DESCRIPTION
## Summary
- Run `astro sync` before `astro check` so the marketing app’s generated types stay in sync during typecheck.
- Add the Astro client types and explicit source includes to `apps/marketing/tsconfig.json` so `.astro` files typecheck reliably.
- Tighten the marketing homepage TypeScript annotations to satisfy Astro’s checker without changing runtime behavior.

## Testing
- Not run locally.
- Expected verification: `bun fmt`
- Expected verification: `bun lint`
- Expected verification: `bun typecheck`