### PR TITLE
Add package script import defaults and action prompts

### DIFF
--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -40,6 +40,39 @@ describe("decider project scripts", () => {
     expect((event.payload as { scripts: unknown[] }).scripts).toEqual([]);
   });
 
+  it("propagates scripts on project.create", async () => {
+    const now = new Date().toISOString();
+    const readModel = createEmptyReadModel(now);
+    const scripts = [
+      {
+        id: "lint",
+        name: "Lint",
+        command: "bun run lint",
+        icon: "lint",
+        runOnWorktreeCreate: false,
+      },
+    ] as const;
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("cmd-project-create-scripts-populated"),
+          projectId: asProjectId("project-scripts-populated"),
+          title: "Scripts",
+          workspaceRoot: "/tmp/scripts-populated",
+          scripts: Array.from(scripts),
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event.type).toBe("project.created");
+    expect((event.payload as { scripts: unknown[] }).scripts).toEqual(scripts);
+  });
+
   it("propagates scripts in project.meta.update payload", async () => {
     const now = new Date().toISOString();
     const initial = createEmptyReadModel(now);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -78,7 +78,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           title: command.title,
           workspaceRoot: command.workspaceRoot,
           defaultModel: command.defaultModel ?? null,
-          scripts: [],
+          scripts: command.scripts ?? [],
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -105,6 +105,17 @@ import {
   XIcon,
 } from "lucide-react";
 import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
 import { Separator } from "./ui/separator";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { cn, randomUUID } from "~/lib/utils";
@@ -114,12 +125,16 @@ import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybinding
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   commandForProjectScript,
+  interpolateProjectScriptCommand,
   nextProjectScriptId,
   projectScriptCwd,
+  projectScriptTemplateInputLabel,
+  projectScriptTemplateInputs,
   projectScriptRuntimeEnv,
   projectScriptIdFromCommand,
   setupProjectScript,
 } from "~/projectScripts";
+import { type ProjectScriptDraft, materializeProjectScripts } from "~/projectScriptDefaults";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
@@ -249,6 +264,14 @@ const INTERACTION_MODE_CYCLE: readonly ProviderInteractionMode[] = ["chat", "cod
 
 interface ChatViewProps {
   threadId: ThreadId;
+}
+
+interface RunProjectScriptOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  worktreePath?: string | null;
+  preferNewTerminal?: boolean;
+  rememberAsLastInvoked?: boolean;
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
@@ -384,6 +407,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const [composerHighlightedItemId, setComposerHighlightedItemId] = useState<string | null>(null);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
+  const [pendingProjectScriptRun, setPendingProjectScriptRun] = useState<{
+    script: ProjectScript;
+    inputIds: string[];
+    values: Record<string, string>;
+    error: string | null;
+    options?: RunProjectScriptOptions;
+  } | null>(null);
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
     Record<string, string[]>
   >({});
@@ -1381,17 +1411,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [activeThreadId, storeCloseTerminal, terminalState.terminalIds.length],
   );
-  const runProjectScript = useCallback(
-    async (
-      script: ProjectScript,
-      options?: {
-        cwd?: string;
-        env?: Record<string, string>;
-        worktreePath?: string | null;
-        preferNewTerminal?: boolean;
-        rememberAsLastInvoked?: boolean;
-      },
-    ) => {
+  const executeProjectScript = useCallback(
+    async (script: ProjectScript, options?: RunProjectScriptOptions) => {
       const api = readNativeApi();
       if (!api || !activeThreadId || !activeProject || !activeThread) return;
       if (options?.rememberAsLastInvoked !== false) {
@@ -1472,6 +1493,50 @@ export default function ChatView({ threadId }: ChatViewProps) {
       terminalState.terminalIds,
     ],
   );
+  const runProjectScript = useCallback(
+    async (script: ProjectScript, options?: RunProjectScriptOptions) => {
+      const inputIds = projectScriptTemplateInputs(script.command);
+      if (inputIds.length === 0) {
+        await executeProjectScript(script, options);
+        return;
+      }
+
+      setPendingProjectScriptRun({
+        script,
+        inputIds,
+        values: Object.fromEntries(inputIds.map((inputId) => [inputId, ""])),
+        error: null,
+        ...(options ? { options } : {}),
+      });
+    },
+    [executeProjectScript],
+  );
+  const submitPendingProjectScriptRun = useCallback(async () => {
+    if (!pendingProjectScriptRun) return;
+    try {
+      const resolvedCommand = interpolateProjectScriptCommand(
+        pendingProjectScriptRun.script.command,
+        pendingProjectScriptRun.values,
+      );
+      await executeProjectScript(
+        {
+          ...pendingProjectScriptRun.script,
+          command: resolvedCommand,
+        },
+        pendingProjectScriptRun.options,
+      );
+      setPendingProjectScriptRun(null);
+    } catch (error) {
+      setPendingProjectScriptRun((current) =>
+        current
+          ? {
+              ...current,
+              error: error instanceof Error ? error.message : "Failed to resolve action inputs.",
+            }
+          : current,
+      );
+    }
+  }, [executeProjectScript, pendingProjectScriptRun]);
   const persistProjectScripts = useCallback(
     async (input: {
       projectId: ProjectId;
@@ -1479,7 +1544,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       previousScripts: ProjectScript[];
       nextScripts: ProjectScript[];
       keybinding?: string | null;
-      keybindingCommand: KeybindingCommand;
+      keybindingCommand?: KeybindingCommand;
     }) => {
       const api = readNativeApi();
       if (!api) return;
@@ -1491,10 +1556,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
         scripts: input.nextScripts,
       });
 
-      const keybindingRule = decodeProjectScriptKeybindingRule({
-        keybinding: input.keybinding,
-        command: input.keybindingCommand,
-      });
+      const keybindingRule = input.keybindingCommand
+        ? decodeProjectScriptKeybindingRule({
+            keybinding: input.keybinding,
+            command: input.keybindingCommand,
+          })
+        : null;
 
       if (isElectron && keybindingRule) {
         await api.server.upsertKeybinding(keybindingRule);
@@ -1502,6 +1569,58 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
     },
     [queryClient],
+  );
+  const importProjectScripts = useCallback(
+    async (drafts: ProjectScriptDraft[]) => {
+      if (!activeProject) return;
+
+      const nextScripts = materializeProjectScripts(drafts, activeProject.scripts);
+      const unchanged = JSON.stringify(nextScripts) === JSON.stringify(activeProject.scripts);
+      if (unchanged) {
+        toastManager.add({
+          type: "info",
+          title: "Project actions are already up to date",
+        });
+        return;
+      }
+
+      const previousByName = new Map(
+        activeProject.scripts.map((script) => [script.name.trim().toLowerCase(), script]),
+      );
+      let addedCount = 0;
+      let updatedCount = 0;
+      for (const draft of drafts) {
+        const existingScript = previousByName.get(draft.name.trim().toLowerCase());
+        if (!existingScript) {
+          addedCount += 1;
+          continue;
+        }
+        if (
+          existingScript.command !== draft.command ||
+          existingScript.icon !== draft.icon ||
+          existingScript.runOnWorktreeCreate !== draft.runOnWorktreeCreate
+        ) {
+          updatedCount += 1;
+        }
+      }
+
+      await persistProjectScripts({
+        projectId: activeProject.id,
+        projectCwd: activeProject.cwd,
+        previousScripts: activeProject.scripts,
+        nextScripts,
+      });
+      toastManager.add({
+        type: "success",
+        title:
+          addedCount > 0 && updatedCount > 0
+            ? `Imported ${addedCount} action${addedCount === 1 ? "" : "s"} and refreshed ${updatedCount}`
+            : addedCount > 0
+              ? `Imported ${addedCount} action${addedCount === 1 ? "" : "s"}`
+              : `Refreshed ${updatedCount} imported action${updatedCount === 1 ? "" : "s"}`,
+      });
+    },
+    [activeProject, persistProjectScripts],
   );
   const saveProjectScript = useCallback(
     async (input: NewProjectScriptInput) => {
@@ -3865,6 +3984,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           activeThreadId={activeThread.id}
           activeThreadTitle={activeThread.title}
           activeProjectName={activeProject?.name}
+          activeProjectCwd={activeProject?.cwd}
           isGitRepo={isGitRepo}
           openInCwd={gitCwd}
           activeProjectScripts={activeProject?.scripts}
@@ -3887,6 +4007,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           onAddProjectScript={saveProjectScript}
           onUpdateProjectScript={updateProjectScript}
           onDeleteProjectScript={deleteProjectScript}
+          onImportProjectScripts={importProjectScripts}
           onToggleTerminal={toggleTerminalVisibility}
           onToggleDiff={onToggleDiff}
           onTogglePreview={() => togglePreviewOpen(activeThread.id)}
@@ -4688,6 +4809,82 @@ export default function ChatView({ threadId }: ChatViewProps) {
       })()}
 
       <SpotifyPlayerDrawer />
+
+      <Dialog
+        open={pendingProjectScriptRun !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingProjectScriptRun(null);
+          }
+        }}
+      >
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>
+              {pendingProjectScriptRun
+                ? `Run ${pendingProjectScriptRun.script.name}`
+                : "Run action"}
+            </DialogTitle>
+            <DialogDescription>
+              Fill in the template values for this action. Values are inserted directly into the
+              command before it runs.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel>
+            {pendingProjectScriptRun ? (
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void submitPendingProjectScriptRun();
+                }}
+              >
+                {pendingProjectScriptRun.inputIds.map((inputId) => (
+                  <div key={inputId} className="space-y-1.5">
+                    <Label htmlFor={`project-script-input-${inputId}`}>
+                      {projectScriptTemplateInputLabel(inputId)}
+                    </Label>
+                    <Input
+                      id={`project-script-input-${inputId}`}
+                      value={pendingProjectScriptRun.values[inputId] ?? ""}
+                      onChange={(event) => {
+                        const nextValue = event.target.value;
+                        setPendingProjectScriptRun((current) =>
+                          current
+                            ? {
+                                ...current,
+                                error: null,
+                                values: {
+                                  ...current.values,
+                                  [inputId]: nextValue,
+                                },
+                              }
+                            : current,
+                        );
+                      }}
+                    />
+                  </div>
+                ))}
+                {pendingProjectScriptRun.error ? (
+                  <p className="text-sm text-destructive">{pendingProjectScriptRun.error}</p>
+                ) : null}
+              </form>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setPendingProjectScriptRun(null)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void submitPendingProjectScriptRun()}>
+              Run action
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
 
       {expandedImage && expandedImageItem && (
         <div

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import React, { type FormEvent, type KeyboardEvent, useCallback, useMemo, useState } from "react";
 
+import { ensureNativeApi } from "~/nativeApi";
 import {
   keybindingValueForCommand,
   decodeProjectScriptKeybindingRule,
@@ -25,6 +26,14 @@ import {
   nextProjectScriptId,
   primaryProjectScript,
 } from "~/projectScripts";
+import {
+  type PackageScriptInventory,
+  type ProjectPackageManager,
+  type ProjectScriptDraft,
+  buildProjectScriptDraftsFromPackageScripts,
+  readPackageScriptInventory,
+  resolvePackageManagerResolution,
+} from "~/projectScriptDefaults";
 import { shortcutLabelForCommand } from "~/keybindings";
 import { isMacPlatform } from "~/lib/utils";
 import {
@@ -49,8 +58,9 @@ import {
 import { Group, GroupSeparator } from "./ui/group";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "./ui/menu";
+import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuShortcut, MenuTrigger } from "./ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
 import { Switch } from "./ui/switch";
 import { Textarea } from "./ui/textarea";
 
@@ -87,6 +97,7 @@ export interface NewProjectScriptInput {
 }
 
 interface ProjectScriptsControlProps {
+  projectCwd: string;
   scripts: ProjectScript[];
   keybindings: ResolvedKeybindingsConfig;
   preferredScriptId?: string | null;
@@ -94,6 +105,7 @@ interface ProjectScriptsControlProps {
   onAddScript: (input: NewProjectScriptInput) => Promise<void> | void;
   onUpdateScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void> | void;
   onDeleteScript: (scriptId: string) => Promise<void> | void;
+  onImportScripts: (scripts: ProjectScriptDraft[]) => Promise<void> | void;
 }
 
 function normalizeShortcutKeyToken(key: string): string | null {
@@ -148,6 +160,7 @@ function keybindingFromEvent(event: KeyboardEvent<HTMLInputElement>): string | n
 }
 
 export default function ProjectScriptsControl({
+  projectCwd,
   scripts,
   keybindings,
   preferredScriptId = null,
@@ -155,6 +168,7 @@ export default function ProjectScriptsControl({
   onAddScript,
   onUpdateScript,
   onDeleteScript,
+  onImportScripts,
 }: ProjectScriptsControlProps) {
   const addScriptFormId = React.useId();
   const [editingScriptId, setEditingScriptId] = useState<string | null>(null);
@@ -167,6 +181,12 @@ export default function ProjectScriptsControl({
   const [keybinding, setKeybinding] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importInventory, setImportInventory] = useState<PackageScriptInventory | null>(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [selectedPackageManager, setSelectedPackageManager] =
+    useState<ProjectPackageManager | null>(null);
 
   const primaryScript = useMemo(() => {
     if (preferredScriptId) {
@@ -178,6 +198,17 @@ export default function ProjectScriptsControl({
   const isEditing = editingScriptId !== null;
   const dropdownItemClassName =
     "data-highlighted:bg-transparent data-highlighted:text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground data-highlighted:hover:bg-accent data-highlighted:hover:text-accent-foreground data-highlighted:focus-visible:bg-accent data-highlighted:focus-visible:text-accent-foreground";
+  const packageManagerResolution = useMemo(
+    () => (importInventory ? resolvePackageManagerResolution(importInventory) : null),
+    [importInventory],
+  );
+  const availableImportDrafts = useMemo(() => {
+    if (!importInventory || !selectedPackageManager) return [];
+    return buildProjectScriptDraftsFromPackageScripts({
+      scriptNames: importInventory.scriptNames,
+      packageManager: selectedPackageManager,
+    });
+  }, [importInventory, selectedPackageManager]);
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Tab") return;
@@ -266,6 +297,44 @@ export default function ProjectScriptsControl({
     void onDeleteScript(editingScriptId);
   }, [editingScriptId, onDeleteScript]);
 
+  const openImportDialog = useCallback(() => {
+    setImportDialogOpen(true);
+    setImportLoading(true);
+    setImportError(null);
+    setImportInventory(null);
+    const api = ensureNativeApi();
+    void readPackageScriptInventory(api, projectCwd)
+      .then((inventory) => {
+        setImportInventory(inventory);
+        const resolution = resolvePackageManagerResolution(inventory);
+        setSelectedPackageManager(
+          resolution.preferredPackageManager ??
+            inventory.lockfilePackageManagers[0] ??
+            inventory.packageManagerField ??
+            "npm",
+        );
+      })
+      .catch((error) => {
+        setImportError(
+          error instanceof Error ? error.message : "Could not read package.json for this project.",
+        );
+      })
+      .finally(() => setImportLoading(false));
+  }, [projectCwd]);
+
+  const handleImportScripts = useCallback(async () => {
+    if (!selectedPackageManager) {
+      setImportError("Select a package manager before importing actions.");
+      return;
+    }
+    try {
+      await onImportScripts(availableImportDrafts);
+      setImportDialogOpen(false);
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : "Failed to import actions.");
+    }
+  }, [availableImportDrafts, onImportScripts, selectedPackageManager]);
+
   return (
     <>
       {primaryScript ? (
@@ -332,6 +401,11 @@ export default function ProjectScriptsControl({
                   </MenuItem>
                 );
               })}
+              <MenuSeparator />
+              <MenuItem className={dropdownItemClassName} onClick={openImportDialog}>
+                <ListChecksIcon className="size-4" />
+                Import package scripts
+              </MenuItem>
               <MenuItem className={dropdownItemClassName} onClick={openAddDialog}>
                 <PlusIcon className="size-4" />
                 Add action
@@ -340,12 +414,32 @@ export default function ProjectScriptsControl({
           </Menu>
         </Group>
       ) : (
-        <Button size="xs" variant="outline" onClick={openAddDialog} title="Add action">
-          <PlusIcon className="size-3.5" />
-          <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
-            Add action
-          </span>
-        </Button>
+        <Group aria-label="Project scripts">
+          <Button size="xs" variant="outline" onClick={openAddDialog} title="Add action">
+            <PlusIcon className="size-3.5" />
+            <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+              Add action
+            </span>
+          </Button>
+          <GroupSeparator className="hidden @sm/header-actions:block" />
+          <Menu highlightItemOnHover={false}>
+            <MenuTrigger
+              render={<Button size="icon-xs" variant="outline" aria-label="Action options" />}
+            >
+              <ChevronDownIcon className="size-4" />
+            </MenuTrigger>
+            <MenuPopup align="end">
+              <MenuItem className={dropdownItemClassName} onClick={openImportDialog}>
+                <ListChecksIcon className="size-4" />
+                Import package scripts
+              </MenuItem>
+              <MenuItem className={dropdownItemClassName} onClick={openAddDialog}>
+                <PlusIcon className="size-4" />
+                Add action
+              </MenuItem>
+            </MenuPopup>
+          </Menu>
+        </Group>
       )}
 
       <Dialog
@@ -500,6 +594,94 @@ export default function ProjectScriptsControl({
           </AlertDialogFooter>
         </AlertDialogPopup>
       </AlertDialog>
+
+      <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>Import Package Scripts</DialogTitle>
+            <DialogDescription>
+              Create project actions from the scripts defined in this project&apos;s{" "}
+              <code>package.json</code>.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            {importLoading ? (
+              <p className="text-sm text-muted-foreground">Reading package.json and lockfiles…</p>
+            ) : importError ? (
+              <p className="text-sm text-destructive">{importError}</p>
+            ) : importInventory ? (
+              <>
+                {packageManagerResolution?.warning ? (
+                  <p className="rounded-md border border-amber-500/30 bg-amber-500/8 px-3 py-2 text-sm text-amber-900 dark:text-amber-100">
+                    {packageManagerResolution.warning}
+                  </p>
+                ) : null}
+                <div className="space-y-1.5">
+                  <Label htmlFor="package-manager">Package manager</Label>
+                  <Select
+                    value={selectedPackageManager ?? undefined}
+                    onValueChange={(value) =>
+                      setSelectedPackageManager(value as ProjectPackageManager)
+                    }
+                    disabled={
+                      !packageManagerResolution?.requiresManualSelection &&
+                      packageManagerResolution?.preferredPackageManager !== null
+                    }
+                  >
+                    <SelectTrigger id="package-manager">
+                      <SelectValue placeholder="Select a package manager" />
+                    </SelectTrigger>
+                    <SelectPopup>
+                      <SelectItem value="bun">bun</SelectItem>
+                      <SelectItem value="pnpm">pnpm</SelectItem>
+                      <SelectItem value="yarn">yarn</SelectItem>
+                      <SelectItem value="npm">npm</SelectItem>
+                    </SelectPopup>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-sm font-medium text-foreground">
+                    {importInventory.packageName ?? "This project"} has{" "}
+                    {importInventory.scriptNames.length} package script
+                    {importInventory.scriptNames.length === 1 ? "" : "s"}.
+                  </p>
+                  {importInventory.scriptNames.length > 0 ? (
+                    <div className="max-h-40 overflow-y-auto rounded-md border border-border/70">
+                      {availableImportDrafts.map((script) => (
+                        <div
+                          key={script.name}
+                          className="border-t border-border/60 px-3 py-2 text-sm first:border-t-0"
+                        >
+                          <div className="font-medium text-foreground">{script.name}</div>
+                          <div className="font-mono text-muted-foreground text-xs">
+                            {script.command}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No runnable package scripts were found.
+                    </p>
+                  )}
+                </div>
+              </>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setImportDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleImportScripts()}
+              disabled={importLoading || availableImportDrafts.length === 0}
+            >
+              Import actions
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -105,6 +105,12 @@ import {
 } from "./Sidebar.logic";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { WorkspaceFileTree } from "~/components/WorkspaceFileTree";
+import {
+  buildProjectScriptDraftsFromPackageScripts,
+  materializeProjectScripts,
+  readPackageScriptInventory,
+  resolvePackageManagerResolution,
+} from "~/projectScriptDefaults";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 10;
@@ -533,6 +539,29 @@ export default function Sidebar() {
       const createdAt = new Date().toISOString();
       const title = cwd.split(/[/\\]/).findLast(isNonEmptyString) ?? cwd;
       try {
+        let projectScripts;
+        let packageScriptWarning: string | null = null;
+        try {
+          const inventory = await readPackageScriptInventory(api, cwd);
+          const packageManagerResolution = resolvePackageManagerResolution(inventory);
+          packageScriptWarning =
+            inventory.scriptNames.length > 0 ? packageManagerResolution.warning : null;
+          if (
+            inventory.scriptNames.length > 0 &&
+            packageManagerResolution.preferredPackageManager &&
+            !packageManagerResolution.requiresManualSelection
+          ) {
+            projectScripts = materializeProjectScripts(
+              buildProjectScriptDraftsFromPackageScripts({
+                scriptNames: inventory.scriptNames,
+                packageManager: packageManagerResolution.preferredPackageManager,
+              }),
+            );
+          }
+        } catch {
+          projectScripts = undefined;
+        }
+
         await api.orchestration.dispatchCommand({
           type: "project.create",
           commandId: newCommandId(),
@@ -540,8 +569,16 @@ export default function Sidebar() {
           title,
           workspaceRoot: cwd,
           defaultModel: DEFAULT_MODEL_BY_PROVIDER.codex,
+          ...(projectScripts ? { scripts: projectScripts } : {}),
           createdAt,
         });
+        if (packageScriptWarning) {
+          toastManager.add({
+            type: "warning",
+            title: "Project actions need a package manager choice",
+            description: packageScriptWarning,
+          });
+        }
         await handleNewThread(projectId, {
           envMode: appSettings.defaultThreadEnvMode,
         }).catch(() => undefined);

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -4,6 +4,7 @@ import {
   type ResolvedKeybindingsConfig,
 } from "@okcode/contracts";
 import { memo } from "react";
+import type { ProjectScriptDraft } from "~/projectScriptDefaults";
 import GitActionsControl from "../GitActionsControl";
 import {
   ArrowLeftRightIcon,
@@ -25,6 +26,7 @@ interface ChatHeaderProps {
   activeThreadId: ThreadId;
   activeThreadTitle: string;
   activeProjectName: string | undefined;
+  activeProjectCwd: string | undefined;
   isGitRepo: boolean;
   openInCwd: string | null;
   activeProjectScripts: ProjectScript[] | undefined;
@@ -43,6 +45,7 @@ interface ChatHeaderProps {
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
+  onImportProjectScripts: (scripts: ProjectScriptDraft[]) => Promise<void>;
   onToggleTerminal: () => void;
   onToggleDiff: () => void;
   onTogglePreview: () => void;
@@ -54,6 +57,7 @@ export const ChatHeader = memo(function ChatHeader({
   activeThreadId,
   activeThreadTitle,
   activeProjectName,
+  activeProjectCwd,
   isGitRepo,
   openInCwd,
   activeProjectScripts,
@@ -72,6 +76,7 @@ export const ChatHeader = memo(function ChatHeader({
   onAddProjectScript,
   onUpdateProjectScript,
   onDeleteProjectScript,
+  onImportProjectScripts,
   onToggleTerminal,
   onToggleDiff,
   onTogglePreview,
@@ -102,6 +107,7 @@ export const ChatHeader = memo(function ChatHeader({
       <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 @sm/header-actions:gap-3">
         {activeProjectScripts && (
           <ProjectScriptsControl
+            projectCwd={activeProjectCwd ?? ""}
             scripts={activeProjectScripts}
             keybindings={keybindings}
             preferredScriptId={preferredScriptId}
@@ -109,6 +115,7 @@ export const ChatHeader = memo(function ChatHeader({
             onAddScript={onAddProjectScript}
             onUpdateScript={onUpdateProjectScript}
             onDeleteScript={onDeleteProjectScript}
+            onImportScripts={onImportProjectScripts}
           />
         )}
         {activeProjectName && <OpenInPicker onToggleCodeViewer={onToggleCodeViewer} />}

--- a/apps/web/src/projectScriptDefaults.test.ts
+++ b/apps/web/src/projectScriptDefaults.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildProjectScriptDraftsFromPackageScripts,
+  materializeProjectScripts,
+  parsePackageScriptInventory,
+  resolvePackageManagerResolution,
+} from "./projectScriptDefaults";
+
+describe("projectScriptDefaults", () => {
+  it("parses package scripts and prefers the lockfile package manager", () => {
+    const inventory = parsePackageScriptInventory(
+      JSON.stringify({
+        name: "demo-app",
+        packageManager: "npm@10.0.0",
+        scripts: {
+          dev: "vite",
+          lint: "eslint .",
+          "test:e2e": "playwright test",
+        },
+      }),
+      [
+        { path: "package.json", kind: "file" },
+        { path: "bun.lock", kind: "file" },
+      ],
+    );
+
+    expect(inventory.packageName).toBe("demo-app");
+    expect(inventory.scriptNames).toEqual(["dev", "lint", "test:e2e"]);
+    expect(resolvePackageManagerResolution(inventory)).toEqual({
+      preferredPackageManager: "bun",
+      requiresManualSelection: false,
+      warning: null,
+    });
+  });
+
+  it("warns when multiple lockfiles are present", () => {
+    const inventory = parsePackageScriptInventory(
+      JSON.stringify({
+        scripts: {
+          dev: "vite",
+        },
+      }),
+      [
+        { path: "package.json", kind: "file" },
+        { path: "bun.lock", kind: "file" },
+        { path: "pnpm-lock.yaml", kind: "file" },
+      ],
+    );
+
+    const resolution = resolvePackageManagerResolution(inventory);
+    expect(resolution.preferredPackageManager).toBeNull();
+    expect(resolution.requiresManualSelection).toBe(true);
+    expect(resolution.warning).toContain("Multiple package manager lockfiles");
+  });
+
+  it("builds project script drafts for package scripts", () => {
+    expect(
+      buildProjectScriptDraftsFromPackageScripts({
+        scriptNames: ["dev", "lint", "test:e2e", "build"],
+        packageManager: "pnpm",
+      }),
+    ).toEqual([
+      {
+        name: "Dev",
+        command: "pnpm run dev",
+        icon: "play",
+        runOnWorktreeCreate: false,
+      },
+      {
+        name: "Lint",
+        command: "pnpm run lint",
+        icon: "lint",
+        runOnWorktreeCreate: false,
+      },
+      {
+        name: "Test E2e",
+        command: "pnpm run test:e2e",
+        icon: "test",
+        runOnWorktreeCreate: false,
+      },
+      {
+        name: "Build",
+        command: "pnpm run build",
+        icon: "build",
+        runOnWorktreeCreate: false,
+      },
+    ]);
+  });
+
+  it("upserts matching actions when materializing defaults", () => {
+    const nextScripts = materializeProjectScripts(
+      [
+        {
+          name: "Lint",
+          command: "bun run lint",
+          icon: "lint",
+          runOnWorktreeCreate: false,
+        },
+        {
+          name: "Build",
+          command: "bun run build",
+          icon: "build",
+          runOnWorktreeCreate: false,
+        },
+      ],
+      [
+        {
+          id: "lint",
+          name: "Lint",
+          command: "npm run lint",
+          icon: "play",
+          runOnWorktreeCreate: false,
+        },
+      ],
+    );
+
+    expect(nextScripts).toEqual([
+      {
+        id: "lint",
+        name: "Lint",
+        command: "bun run lint",
+        icon: "lint",
+        runOnWorktreeCreate: false,
+      },
+      {
+        id: "build",
+        name: "Build",
+        command: "bun run build",
+        icon: "build",
+        runOnWorktreeCreate: false,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/projectScriptDefaults.ts
+++ b/apps/web/src/projectScriptDefaults.ts
@@ -1,0 +1,204 @@
+import type {
+  NativeApi,
+  ProjectDirectoryEntry,
+  ProjectScript,
+  ProjectScriptIcon,
+} from "@okcode/contracts";
+
+import { nextProjectScriptId } from "./projectScripts";
+
+export type ProjectPackageManager = "bun" | "pnpm" | "yarn" | "npm";
+
+export interface ProjectScriptDraft {
+  name: string;
+  command: string;
+  icon: ProjectScriptIcon;
+  runOnWorktreeCreate: boolean;
+}
+
+export interface PackageScriptInventory {
+  packageName: string | null;
+  scriptNames: string[];
+  packageManagerField: ProjectPackageManager | null;
+  lockfilePackageManagers: ProjectPackageManager[];
+}
+
+export interface PackageManagerResolution {
+  preferredPackageManager: ProjectPackageManager | null;
+  requiresManualSelection: boolean;
+  warning: string | null;
+}
+
+const PACKAGE_MANAGER_LOCKFILES: Record<ProjectPackageManager, readonly string[]> = {
+  bun: ["bun.lock", "bun.lockb"],
+  pnpm: ["pnpm-lock.yaml"],
+  yarn: ["yarn.lock"],
+  npm: ["package-lock.json", "npm-shrinkwrap.json"],
+};
+
+const PACKAGE_MANAGER_PRIORITY: readonly ProjectPackageManager[] = ["bun", "pnpm", "yarn", "npm"];
+
+function parsePackageManagerField(value: unknown): ProjectPackageManager | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized.startsWith("bun@")) return "bun";
+  if (normalized.startsWith("pnpm@")) return "pnpm";
+  if (normalized.startsWith("yarn@")) return "yarn";
+  if (normalized.startsWith("npm@")) return "npm";
+  return null;
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/[:/_-]+/g)
+    .map((segment) => (segment.length > 0 ? `${segment[0]!.toUpperCase()}${segment.slice(1)}` : ""))
+    .filter((segment) => segment.length > 0)
+    .join(" ");
+}
+
+function resolveScriptIcon(scriptName: string): ProjectScriptIcon {
+  const normalized = scriptName.trim().toLowerCase();
+  if (/(^|:)(test|spec|check)(:|$)/.test(normalized)) return "test";
+  if (normalized.includes("lint")) return "lint";
+  if (/(^|:)(build|bundle|compile)(:|$)/.test(normalized)) return "build";
+  if (/(^|:)(setup|bootstrap|configure|config)(:|$)/.test(normalized)) return "configure";
+  if (/(^|:)(debug|inspect)(:|$)/.test(normalized)) return "debug";
+  return "play";
+}
+
+function quotePackageScriptName(scriptName: string): string {
+  return /^[a-z0-9:_-]+$/i.test(scriptName) ? scriptName : JSON.stringify(scriptName);
+}
+
+function commandForPackageScript(
+  packageManager: ProjectPackageManager,
+  scriptName: string,
+): string {
+  return `${packageManager} run ${quotePackageScriptName(scriptName)}`;
+}
+
+export function resolvePackageManagerResolution(
+  inventory: Pick<PackageScriptInventory, "lockfilePackageManagers" | "packageManagerField">,
+): PackageManagerResolution {
+  if (inventory.lockfilePackageManagers.length === 1) {
+    return {
+      preferredPackageManager: inventory.lockfilePackageManagers[0] ?? null,
+      requiresManualSelection: false,
+      warning: null,
+    };
+  }
+
+  if (inventory.lockfilePackageManagers.length > 1) {
+    const labels = inventory.lockfilePackageManagers.join(", ");
+    return {
+      preferredPackageManager: inventory.packageManagerField,
+      requiresManualSelection: true,
+      warning: `Multiple package manager lockfiles were detected (${labels}). Select the package manager to use for imported actions.`,
+    };
+  }
+
+  if (inventory.packageManagerField) {
+    return {
+      preferredPackageManager: inventory.packageManagerField,
+      requiresManualSelection: false,
+      warning: null,
+    };
+  }
+
+  return {
+    preferredPackageManager: null,
+    requiresManualSelection: true,
+    warning:
+      "No package manager lockfile was detected. Select the package manager to use for imported actions.",
+  };
+}
+
+export function parsePackageScriptInventory(
+  packageJsonContents: string,
+  rootEntries: ReadonlyArray<Pick<ProjectDirectoryEntry, "path" | "kind">>,
+): PackageScriptInventory {
+  const parsed = JSON.parse(packageJsonContents) as {
+    name?: unknown;
+    packageManager?: unknown;
+    scripts?: Record<string, unknown>;
+  };
+  const packageName =
+    typeof parsed.name === "string" && parsed.name.trim().length > 0 ? parsed.name : null;
+  const scripts = parsed.scripts ?? {};
+  const scriptNames = Object.entries(scripts)
+    .filter(
+      (entry): entry is [string, string] =>
+        typeof entry[0] === "string" && typeof entry[1] === "string",
+    )
+    .map(([name]) => name);
+  const fileNames = new Set(
+    rootEntries.filter((entry) => entry.kind === "file").map((entry) => entry.path),
+  );
+  const lockfilePackageManagers = PACKAGE_MANAGER_PRIORITY.filter((manager) =>
+    PACKAGE_MANAGER_LOCKFILES[manager].some((fileName) => fileNames.has(fileName)),
+  );
+
+  return {
+    packageName,
+    scriptNames,
+    packageManagerField: parsePackageManagerField(parsed.packageManager),
+    lockfilePackageManagers,
+  };
+}
+
+export function buildProjectScriptDraftsFromPackageScripts(input: {
+  scriptNames: ReadonlyArray<string>;
+  packageManager: ProjectPackageManager;
+}): ProjectScriptDraft[] {
+  return input.scriptNames.map((scriptName) => ({
+    name: toTitleCase(scriptName),
+    command: commandForPackageScript(input.packageManager, scriptName),
+    icon: resolveScriptIcon(scriptName),
+    runOnWorktreeCreate: false,
+  }));
+}
+
+export function materializeProjectScripts(
+  drafts: ReadonlyArray<ProjectScriptDraft>,
+  existing: ReadonlyArray<ProjectScript> = [],
+): ProjectScript[] {
+  const nextScripts = existing.map((script) => ({ ...script }));
+  const existingIds = nextScripts.map((script) => script.id);
+
+  for (const draft of drafts) {
+    const matchIndex = nextScripts.findIndex(
+      (script) => script.name.trim().toLowerCase() === draft.name.trim().toLowerCase(),
+    );
+    if (matchIndex >= 0) {
+      nextScripts[matchIndex] = {
+        ...nextScripts[matchIndex]!,
+        ...draft,
+      };
+      continue;
+    }
+
+    const id = nextProjectScriptId(draft.name, existingIds);
+    existingIds.push(id);
+    nextScripts.push({
+      id,
+      ...draft,
+    });
+  }
+
+  return nextScripts;
+}
+
+export async function readPackageScriptInventory(
+  api: NativeApi,
+  cwd: string,
+): Promise<PackageScriptInventory> {
+  const [packageJsonResult, directoryResult] = await Promise.all([
+    api.projects.readFile({
+      cwd,
+      relativePath: "package.json",
+    }),
+    api.projects.listDirectory({ cwd }),
+  ]);
+
+  return parsePackageScriptInventory(packageJsonResult.contents, directoryResult.entries);
+}

--- a/apps/web/src/projectScripts.test.ts
+++ b/apps/web/src/projectScripts.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   commandForProjectScript,
+  interpolateProjectScriptCommand,
   nextProjectScriptId,
   primaryProjectScript,
   projectScriptCwd,
+  projectScriptTemplateInputLabel,
+  projectScriptTemplateInputs,
   projectScriptRuntimeEnv,
   projectScriptIdFromCommand,
   setupProjectScript,
@@ -85,5 +88,25 @@ describe("projectScripts helpers", () => {
         worktreePath: null,
       }),
     ).toBe("/repo");
+  });
+
+  it("extracts and formats dynamic command inputs", () => {
+    expect(
+      projectScriptTemplateInputs("gh pr checkout {{pr_number}} --repo {{repo_name}}"),
+    ).toEqual(["pr_number", "repo_name"]);
+    expect(projectScriptTemplateInputLabel("repo_name")).toBe("Repo Name");
+  });
+
+  it("interpolates dynamic command inputs", () => {
+    expect(
+      interpolateProjectScriptCommand("gh pr checkout {{pr_number}}", {
+        pr_number: "42",
+      }),
+    ).toBe("gh pr checkout 42");
+    expect(() =>
+      interpolateProjectScriptCommand("gh pr checkout {{pr_number}}", {
+        pr_number: "",
+      }),
+    ).toThrow('Missing a value for "pr_number".');
   });
 });

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -6,7 +6,9 @@ import {
 } from "@okcode/contracts";
 import { Schema } from "effect";
 
-function normalizeScriptId(value: string): string {
+const PROJECT_SCRIPT_TEMPLATE_INPUT_PATTERN = /{{\s*([a-z][a-z0-9_-]*)\s*}}/gi;
+
+export function normalizeProjectScriptId(value: string): string {
   const cleaned = value
     .trim()
     .toLowerCase()
@@ -35,7 +37,7 @@ export function projectScriptIdFromCommand(command: string): string | null {
 
 export function nextProjectScriptId(name: string, existingIds: Iterable<string>): string {
   const taken = new Set(Array.from(existingIds));
-  const baseId = normalizeScriptId(name);
+  const baseId = normalizeProjectScriptId(name);
   if (!taken.has(baseId)) return baseId;
 
   let suffix = 2;
@@ -94,4 +96,41 @@ export function primaryProjectScript(scripts: ProjectScript[]): ProjectScript | 
 
 export function setupProjectScript(scripts: ProjectScript[]): ProjectScript | null {
   return scripts.find((script) => script.runOnWorktreeCreate) ?? null;
+}
+
+export function projectScriptTemplateInputs(command: string): string[] {
+  const matches = command.matchAll(PROJECT_SCRIPT_TEMPLATE_INPUT_PATTERN);
+  const seen = new Set<string>();
+  const inputs: string[] = [];
+
+  for (const match of matches) {
+    const inputId = match[1]?.trim().toLowerCase();
+    if (!inputId || seen.has(inputId)) continue;
+    seen.add(inputId);
+    inputs.push(inputId);
+  }
+
+  return inputs;
+}
+
+export function interpolateProjectScriptCommand(
+  command: string,
+  values: Record<string, string>,
+): string {
+  return command.replaceAll(PROJECT_SCRIPT_TEMPLATE_INPUT_PATTERN, (_match, rawInputId: string) => {
+    const inputId = rawInputId.trim().toLowerCase();
+    const value = values[inputId];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Missing a value for "${inputId}".`);
+    }
+    return value;
+  });
+}
+
+export function projectScriptTemplateInputLabel(inputId: string): string {
+  return inputId
+    .split(/[-_]+/g)
+    .map((segment) => (segment.length > 0 ? `${segment[0]!.toUpperCase()}${segment.slice(1)}` : ""))
+    .filter((segment) => segment.length > 0)
+    .join(" ");
 }

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -317,6 +317,7 @@ export const ProjectCreateCommand = Schema.Struct({
   title: TrimmedNonEmptyString,
   workspaceRoot: TrimmedNonEmptyString,
   defaultModel: Schema.optional(TrimmedNonEmptyString),
+  scripts: Schema.optional(Schema.Array(ProjectScript)),
   createdAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## Summary
- Add package script discovery so new projects can be created with inferred actions from `package.json` when a package manager is available.
- Add an import flow in the project actions UI to preview and import package scripts into project actions.
- Prompt for template inputs before running actions that contain placeholders, instead of executing unresolved commands.
- Simplify the markdown/file viewing path by removing the standalone markdown preview implementation and using the code viewer/editor flow consistently.
- Update orchestration to carry project scripts through `project.create` events and add coverage for the new behavior.

## Testing
- Not run (PR content only).
- Existing and new tests were added for orchestration and project script default/import logic.