### PR TITLE
Send terminal selections directly from composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2687,6 +2687,24 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, phase, setThreadError],
   );
 
+  const readLiveComposerDraftSnapshot = useCallback(() => {
+    const latestDraft = activeThread
+      ? useComposerDraftStore.getState().draftsByThreadId[activeThread.id]
+      : null;
+    const nextPrompt = latestDraft?.prompt ?? promptRef.current;
+    const nextImages = latestDraft?.images ?? composerImagesRef.current;
+    const nextTerminalContexts =
+      latestDraft?.terminalContexts ?? composerTerminalContextsRef.current;
+    promptRef.current = nextPrompt;
+    composerImagesRef.current = nextImages;
+    composerTerminalContextsRef.current = nextTerminalContexts;
+    return {
+      prompt: nextPrompt,
+      images: nextImages,
+      terminalContexts: nextTerminalContexts,
+    };
+  }, [activeThread]);
+
   const onSend = async (e?: { preventDefault: () => void }) => {
     e?.preventDefault();
     const api = readNativeApi();
@@ -2695,7 +2713,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       onAdvanceActivePendingUserInput();
       return;
     }
-    const promptForSend = promptRef.current;
+    const liveComposerDraft = readLiveComposerDraftSnapshot();
+    const promptForSend = liveComposerDraft.prompt;
+    const composerImagesForSend = liveComposerDraft.images;
+    const composerTerminalContextsForSend = liveComposerDraft.terminalContexts;
     const {
       trimmedPrompt: trimmed,
       sendableTerminalContexts: sendableComposerTerminalContexts,
@@ -2703,8 +2724,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
       hasSendableContent,
     } = deriveComposerSendState({
       prompt: promptForSend,
-      imageCount: composerImages.length,
-      terminalContexts: composerTerminalContexts,
+      imageCount: composerImagesForSend.length,
+      terminalContexts: composerTerminalContextsForSend,
     });
     if (showPlanFollowUpPrompt && activeProposedPlan) {
       const followUp = resolvePlanFollowUpSubmission({
@@ -2723,7 +2744,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       return;
     }
     const standaloneSlashCommand =
-      composerImages.length === 0 && sendableComposerTerminalContexts.length === 0
+      composerImagesForSend.length === 0 && sendableComposerTerminalContexts.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -2752,7 +2773,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
     // ── Queue message if a turn is already running ────────────────────
     if (phase === "running") {
-      const composerImagesSnapshot = [...composerImages];
+      const composerImagesSnapshot = [...composerImagesForSend];
       const messageTextForSend = appendTerminalContextsToPrompt(
         promptForSend,
         sendableComposerTerminalContexts,
@@ -2838,7 +2859,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     sendInFlightRef.current = true;
     beginSendPhase(baseBranchForWorktree ? "preparing-worktree" : "sending-turn");
 
-    const composerImagesSnapshot = [...composerImages];
+    const composerImagesSnapshot = [...composerImagesForSend];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
     const messageTextForSend = appendTerminalContextsToPrompt(
       promptForSend,
@@ -3078,6 +3099,21 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!turnStartSucceeded) {
       resetSendPhase();
     }
+  };
+
+  const sendSelectedTerminalContext = (selection: TerminalContextSelection) => {
+    if (!activeThread) {
+      return;
+    }
+    addComposerDraftTerminalContexts(activeThread.id, [
+      {
+        id: randomUUID(),
+        threadId: activeThread.id,
+        createdAt: new Date().toISOString(),
+        ...selection,
+      },
+    ]);
+    void onSend();
   };
 
   const onInterrupt = async () => {
@@ -4803,6 +4839,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             onCloseTerminal={closeTerminal}
             onHeightChange={setTerminalHeight}
             onAddTerminalContext={addTerminalContextToDraft}
+            onSendTerminalContext={sendSelectedTerminalContext}
             onPreviewUrl={onPreviewUrl}
           />
         );

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  dispatchTerminalShortcutSelection,
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalSelectionMouseUp,
   terminalSelectionActionDelayForClickCount,
@@ -71,5 +72,50 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(shouldHandleTerminalSelectionMouseUp(true, 0)).toBe(true);
     expect(shouldHandleTerminalSelectionMouseUp(false, 0)).toBe(false);
     expect(shouldHandleTerminalSelectionMouseUp(true, 1)).toBe(false);
+  });
+
+  it("routes shortcut selections to direct send when available", () => {
+    const addSelections: string[] = [];
+    const sendSelections: string[] = [];
+    dispatchTerminalShortcutSelection(
+      {
+        terminalId: "default",
+        terminalLabel: "Terminal 1",
+        lineStart: 12,
+        lineEnd: 14,
+        text: "git diff",
+      },
+      {
+        onAddTerminalContext: (selection) => {
+          addSelections.push(selection.text);
+        },
+        onSendTerminalContext: (selection) => {
+          sendSelections.push(selection.text);
+        },
+      },
+    );
+
+    expect(sendSelections).toEqual(["git diff"]);
+    expect(addSelections).toEqual([]);
+  });
+
+  it("falls back to add-to-chat when no direct-send handler exists", () => {
+    const addSelections: string[] = [];
+    dispatchTerminalShortcutSelection(
+      {
+        terminalId: "default",
+        terminalLabel: "Terminal 1",
+        lineStart: 7,
+        lineEnd: 7,
+        text: "bun lint",
+      },
+      {
+        onAddTerminalContext: (selection) => {
+          addSelections.push(selection.text);
+        },
+      },
+    );
+
+    expect(addSelections).toEqual(["bun lint"]);
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -185,6 +185,17 @@ export function shouldHandleTerminalSelectionMouseUp(
   return selectionGestureActive && button === 0;
 }
 
+export function dispatchTerminalShortcutSelection(
+  selection: TerminalContextSelection,
+  callbacks: {
+    onAddTerminalContext: (selection: TerminalContextSelection) => void;
+    onSendTerminalContext?: ((selection: TerminalContextSelection) => void) | undefined;
+  },
+): void {
+  const handler = callbacks.onSendTerminalContext ?? callbacks.onAddTerminalContext;
+  handler(selection);
+}
+
 interface TerminalViewportProps {
   threadId: ThreadId;
   terminalId: string;
@@ -193,6 +204,7 @@ interface TerminalViewportProps {
   runtimeEnv?: Record<string, string>;
   onSessionExited: () => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onSendTerminalContext?: ((selection: TerminalContextSelection) => void) | undefined;
   onPreviewUrl?: ((url: string) => void) | undefined;
   focusRequestId: number;
   autoFocus: boolean;
@@ -208,6 +220,7 @@ function TerminalViewport({
   runtimeEnv,
   onSessionExited,
   onAddTerminalContext,
+  onSendTerminalContext,
   onPreviewUrl,
   focusRequestId,
   autoFocus,
@@ -219,6 +232,7 @@ function TerminalViewport({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const onSessionExitedRef = useRef(onSessionExited);
   const onAddTerminalContextRef = useRef(onAddTerminalContext);
+  const onSendTerminalContextRef = useRef(onSendTerminalContext);
   const onPreviewUrlRef = useRef(onPreviewUrl);
   const terminalLabelRef = useRef(terminalLabel);
   const hasHandledExitRef = useRef(false);
@@ -241,6 +255,10 @@ function TerminalViewport({
   useEffect(() => {
     onAddTerminalContextRef.current = onAddTerminalContext;
   }, [onAddTerminalContext]);
+
+  useEffect(() => {
+    onSendTerminalContextRef.current = onSendTerminalContext;
+  }, [onSendTerminalContext]);
 
   useEffect(() => {
     onPreviewUrlRef.current = onPreviewUrl;
@@ -366,7 +384,10 @@ function TerminalViewport({
         event.stopPropagation();
         const action = readSelectionAction();
         if (action) {
-          onAddTerminalContextRef.current(action.selection);
+          dispatchTerminalShortcutSelection(action.selection, {
+            onAddTerminalContext: onAddTerminalContextRef.current,
+            onSendTerminalContext: onSendTerminalContextRef.current,
+          });
           terminalRef.current?.clearSelection();
           terminalRef.current?.focus();
         }
@@ -783,6 +804,7 @@ interface ThreadTerminalDrawerProps {
   onCloseTerminal: (terminalId: string) => void;
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onSendTerminalContext?: ((selection: TerminalContextSelection) => void) | undefined;
   onPreviewUrl?: ((url: string) => void) | undefined;
 }
 
@@ -834,6 +856,7 @@ export default function ThreadTerminalDrawer({
   onCloseTerminal,
   onHeightChange,
   onAddTerminalContext,
+  onSendTerminalContext,
   onPreviewUrl,
 }: ThreadTerminalDrawerProps) {
   const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
@@ -1136,6 +1159,7 @@ export default function ThreadTerminalDrawer({
                         {...(runtimeEnv ? { runtimeEnv } : {})}
                         onSessionExited={() => onCloseTerminal(terminalId)}
                         onAddTerminalContext={onAddTerminalContext}
+                        onSendTerminalContext={onSendTerminalContext}
                         onPreviewUrl={onPreviewUrl}
                         focusRequestId={focusRequestId}
                         autoFocus={terminalId === resolvedActiveTerminalId}


### PR DESCRIPTION
## Summary
- Added a direct-send path for terminal text selections so shortcut-based selections can submit straight from the composer when available.
- Updated `ChatView` to snapshot the live composer draft at send time, including terminal contexts, so selection sends use the latest state.
- Added coverage for the terminal drawer selection routing behavior, including direct-send and fallback-to-chat cases.

## Testing
- Not run (`bun fmt`)
- Not run (`bun lint`)
- Not run (`bun typecheck`)
- Not run (`bun run test`)