### PR TITLE
fix: new projects with no timestamps sort to top of sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -679,4 +679,26 @@ describe("sortProjectsForSidebar", () => {
 
     expect(timestamp).toBe(Date.parse("2026-03-09T10:10:00.000Z"));
   });
+
+  it("sorts new projects with no timestamps above older projects", () => {
+    const sorted = sortProjectsForSidebar(
+      [
+        makeProject({
+          id: ProjectId.makeUnsafe("project-old"),
+          name: "Old project",
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        }),
+        makeProject({
+          id: ProjectId.makeUnsafe("project-new"),
+          name: "New project",
+          createdAt: undefined,
+          updatedAt: undefined,
+        }),
+      ],
+      [],
+      "updated_at",
+    );
+
+    expect(sorted[0]!.id).toBe(ProjectId.makeUnsafe("project-new"));
+  });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -315,9 +315,9 @@ export function getProjectSortTimestamp(
   }
 
   if (sortOrder === "created_at") {
-    return toSortableTimestamp(project.createdAt) ?? Number.NEGATIVE_INFINITY;
+    return toSortableTimestamp(project.createdAt) ?? Date.now();
   }
-  return toSortableTimestamp(project.updatedAt ?? project.createdAt) ?? Number.NEGATIVE_INFINITY;
+  return toSortableTimestamp(project.updatedAt ?? project.createdAt) ?? Date.now();
 }
 
 export function sortProjectsForSidebar<TProject extends SidebarProject, TThread extends Thread>(


### PR DESCRIPTION
Fixes #11

## Problem

A newly created project with no threads sorts to the bottom of the sidebar because `getProjectSortTimestamp()` returns `Number.NEGATIVE_INFINITY` when both `createdAt` and `updatedAt` are undefined.

## Fix

Use `Date.now()` as the fallback instead of `Number.NEGATIVE_INFINITY`, so new empty projects sort to the top alongside recently-active projects.

## Changes

- `Sidebar.logic.ts`: replaced `Number.NEGATIVE_INFINITY` with `Date.now()` in both sort-order branches
- `Sidebar.logic.test.ts`: added test case verifying a project with undefined timestamps sorts above older projects

## Tests

All 33 tests pass (32 existing + 1 new).