### PR TITLE
Remove alpha branding from production surfaces

### DIFF
--- a/.plans/t3code-to-okcode-rebrand.md
+++ b/.plans/t3code-to-okcode-rebrand.md
@@ -277,7 +277,7 @@ This document tracked conversions from T3Code to OKCode. **Status: completed** (
 
 ## Legacy & follow-ups (intentional)
 
-- **Desktop migration:** `apps/desktop/src/main.ts` still recognizes legacy Electron userData folder names (`T3 Code (Dev)` / `T3 Code (Alpha)`), legacy `t3code` app data path, and `t3codeCommitHash` in `package.json` alongside `okcodeCommitHash`.
+- **Desktop migration:** `apps/desktop/src/main.ts` still recognizes legacy Electron userData folder names (`T3 Code (Dev)` / `T3 Code (Alpha)`) via `LEGACY_USER_DATA_DIR_NAME`, legacy `t3code` app data path, and `t3codeCommitHash` in `package.json` alongside `okcodeCommitHash`.
 - **Third-party test URLs:** Some server tests still use `github.com/pingdotgg/codething-mvp/...` as generic PR URL fixtures (not the old product repo).
 - **Short `t3-` temp prefixes:** A few tests/scripts still use `t3-` as a `mkdtemp` prefix (e.g. orchestration, provider tests). Renaming to `okcode-` is optional noise reduction, not required for the rebrand.
 

--- a/BRANDING.md
+++ b/BRANDING.md
@@ -10,8 +10,8 @@
 | Property                  | Value                                  |
 | ------------------------- | -------------------------------------- |
 | **App Name**              | OK Code                                |
-| **Stage Label**           | Alpha (production) / Dev (development) |
-| **Display Name**          | OK Code (Alpha)                        |
+| **Stage Label**           | Dev (development only)                 |
+| **Display Name**          | OK Code                                |
 | **Version**               | 0.0.1                                  |
 | **Tagline**               | `[TBD]`                                |
 | **One-liner Description** | `[TBD]`                                |

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -17,7 +17,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
-const APP_DISPLAY_NAME = isDevelopment ? "OK Code (Dev)" : "OK Code (Alpha)";
+const APP_DISPLAY_NAME = isDevelopment ? "OK Code (Dev)" : "OK Code";
 const APP_BUNDLE_ID = "com.okcode.okcode";
 const LAUNCHER_VERSION = 1;
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -73,7 +73,7 @@ const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "okcode";
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
-const APP_DISPLAY_NAME = isDevelopment ? "OK Code (Dev)" : "OK Code (Alpha)";
+const APP_DISPLAY_NAME = isDevelopment ? "OK Code (Dev)" : "OK Code";
 const APP_USER_MODEL_ID = "com.okcode.okcode";
 const USER_DATA_DIR_NAME = isDevelopment ? "okcode-dev" : "okcode";
 const LEGACY_USER_DATA_DIR_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
@@ -679,7 +679,7 @@ function resolveIconPath(ext: "ico" | "icns" | "png"): string | null {
  *
  * Electron derives the default userData path from `productName` in
  * package.json, which currently produces directories with spaces and
- * parentheses (e.g. `~/.config/OK Code (Alpha)` on Linux). This is
+ * parentheses (e.g. `~/.config/OK Code (Dev)` on Linux). This is
  * unfriendly for shell usage and violates Linux naming conventions.
  *
  * We override it to a clean lowercase name (`okcode`). If a legacy
@@ -887,7 +887,7 @@ function configureAutoUpdater(): void {
 
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
-  // Keep alpha branding, but force all installs onto the stable update track.
+  // Force all installs onto the stable update track.
   autoUpdater.channel = DESKTOP_UPDATE_CHANNEL;
   autoUpdater.allowPrerelease = DESKTOP_UPDATE_ALLOW_PRERELEASE;
   autoUpdater.allowDowngrade = false;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap"
       rel="stylesheet"
     />
-    <title>OK Code (Alpha)</title>
+    <title>OK Code</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -1,4 +1,6 @@
 export const APP_BASE_NAME = "OK Code";
-export const APP_STAGE_LABEL = import.meta.env.DEV ? "Dev" : "Alpha";
-export const APP_DISPLAY_NAME = `${APP_BASE_NAME} (${APP_STAGE_LABEL})`;
+export const APP_STAGE_LABEL = import.meta.env.DEV ? "Dev" : "";
+export const APP_DISPLAY_NAME = APP_STAGE_LABEL
+  ? `${APP_BASE_NAME} (${APP_STAGE_LABEL})`
+  : APP_BASE_NAME;
 export const APP_VERSION = import.meta.env.APP_VERSION || "0.0.0";


### PR DESCRIPTION
## Summary
- Remove the `Alpha` label from production-facing app branding in the desktop shell and web app.
- Keep the `Dev` label only for development builds, while production now uses plain `OK Code`.
- Update branding docs and rollout notes to reflect the new display-name behavior.

## Testing
- Not run
- Reviewed the diff for desktop, web, and branding text updates to confirm production strings now omit `Alpha`
- Confirmed legacy user data migration references were left intact