### PR TITLE
Add workspace search filters and CamelCase ranking

### DIFF
--- a/apps/server/src/workspaceEntries.test.ts
+++ b/apps/server/src/workspaceEntries.test.ts
@@ -133,6 +133,39 @@ describe("searchWorkspaceEntries", () => {
     assert.include(paths, "src/components/Composer.tsx");
   });
 
+  it("prefers CamelCase boundary matches over lowercase substrings", async () => {
+    const cwd = makeTempDir("okcode-workspace-camel-query-");
+    writeFile(cwd, "src/components/CodeViewerPanel.tsx");
+    writeFile(cwd, "docs/cvp-reference.md");
+    writeFile(cwd, "src/components/code-view-panel.txt");
+
+    const result = await searchWorkspaceEntries({ cwd, query: "CVP", limit: 10 });
+
+    assert.equal(result.entries[0]?.path, "src/components/CodeViewerPanel.tsx");
+  });
+
+  it("supports VS Code-style include and exclude glob filters", async () => {
+    const cwd = makeTempDir("okcode-workspace-glob-query-");
+    writeFile(cwd, "src/components/CodeViewerPanel.tsx");
+    writeFile(cwd, "src/components/CodeViewerPanel.test.tsx");
+    writeFile(cwd, "docs/CodeViewerPanel.md");
+    writeFile(cwd, "dist/CodeViewerPanel.tsx");
+
+    const result = await searchWorkspaceEntries({
+      cwd,
+      query: "",
+      includePattern: "src/**",
+      excludePattern: "**/*.test.tsx",
+      limit: 100,
+    });
+    const paths = result.entries.map((entry) => entry.path);
+
+    assert.include(paths, "src/components/CodeViewerPanel.tsx");
+    assert.notInclude(paths, "src/components/CodeViewerPanel.test.tsx");
+    assert.notInclude(paths, "docs/CodeViewerPanel.md");
+    assert.notInclude(paths, "dist/CodeViewerPanel.tsx");
+  });
+
   it("tracks truncation without sorting every fuzzy match", async () => {
     const cwd = makeTempDir("okcode-workspace-fuzzy-limit-");
     writeFile(cwd, "src/components/Composer.tsx");

--- a/apps/server/src/workspaceEntries.ts
+++ b/apps/server/src/workspaceEntries.ts
@@ -38,6 +38,7 @@ interface WorkspaceIndex {
 }
 
 interface SearchableWorkspaceEntry extends ProjectEntry {
+  name: string;
   normalizedPath: string;
   normalizedName: string;
 }
@@ -45,6 +46,20 @@ interface SearchableWorkspaceEntry extends ProjectEntry {
 interface RankedWorkspaceEntry {
   entry: SearchableWorkspaceEntry;
   score: number;
+}
+
+interface QueryTokenMatch {
+  score: number;
+  lastMatchIndex: number;
+}
+
+interface CompiledWorkspaceGlob {
+  matches: (relativePath: string) => boolean;
+}
+
+interface CompiledWorkspaceGlobExpression {
+  positive: CompiledWorkspaceGlob[];
+  negative: CompiledWorkspaceGlob[];
 }
 
 const workspaceIndexCache = new Map<string, WorkspaceIndex>();
@@ -72,87 +87,458 @@ function basenameOf(input: string): string {
 }
 
 function toSearchableWorkspaceEntry(entry: ProjectEntry): SearchableWorkspaceEntry {
+  const name = basenameOf(entry.path);
   const normalizedPath = entry.path.toLowerCase();
   return {
     ...entry,
+    name,
     normalizedPath,
-    normalizedName: basenameOf(normalizedPath),
+    normalizedName: name.toLowerCase(),
   };
 }
 
 function normalizeQuery(input: string): string {
-  return input
-    .trim()
-    .replace(/^[@./]+/, "")
-    .toLowerCase();
+  return input.trim().replace(/^[@./]+/, "");
 }
 
-function scoreSubsequenceMatch(value: string, query: string): number | null {
-  if (!query) return 0;
+function splitQueryTokens(input: string): string[] {
+  const normalizedQuery = normalizeQuery(input);
+  if (!normalizedQuery) return [];
+  return normalizedQuery.split(/\s+/).filter((token) => token.length > 0);
+}
 
-  let queryIndex = 0;
-  let firstMatchIndex = -1;
-  let previousMatchIndex = -1;
-  let gapPenalty = 0;
+function splitGlobPatternList(input?: string): string[] {
+  if (!input) return [];
+  return input
+    .split(/[\n,]+/)
+    .map((part) => part.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, ""))
+    .filter((part) => part.length > 0);
+}
 
-  for (let valueIndex = 0; valueIndex < value.length; valueIndex += 1) {
-    if (value[valueIndex] !== query[queryIndex]) {
+function findBraceClosingIndex(input: string, openIndex: number): number {
+  let depth = 0;
+  for (let index = openIndex; index < input.length; index += 1) {
+    if (input[index] === "{") {
+      depth += 1;
       continue;
     }
-
-    if (firstMatchIndex === -1) {
-      firstMatchIndex = valueIndex;
-    }
-    if (previousMatchIndex !== -1) {
-      gapPenalty += valueIndex - previousMatchIndex - 1;
-    }
-
-    previousMatchIndex = valueIndex;
-    queryIndex += 1;
-    if (queryIndex === query.length) {
-      const spanPenalty = valueIndex - firstMatchIndex + 1 - query.length;
-      const lengthPenalty = Math.min(64, value.length - query.length);
-      return firstMatchIndex * 2 + gapPenalty * 3 + spanPenalty + lengthPenalty;
+    if (input[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
     }
   }
-
-  return null;
+  return -1;
 }
 
-function scoreEntry(entry: SearchableWorkspaceEntry, query: string): number | null {
-  if (!query) {
-    return entry.kind === "directory" ? 0 : 1;
+function splitBraceAlternatives(input: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (character === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth = Math.max(0, depth - 1);
+    }
+    current += character;
   }
 
-  const { normalizedPath, normalizedName } = entry;
+  parts.push(current);
+  return parts;
+}
 
-  if (normalizedName === query) return 0;
-  if (normalizedPath === query) return 1;
-  if (normalizedName.startsWith(query)) return 2;
-  if (normalizedPath.startsWith(query)) return 3;
-  if (normalizedPath.includes(`/${query}`)) return 4;
-  if (normalizedName.includes(query)) return 5;
-  if (normalizedPath.includes(query)) return 6;
+function escapeRegExp(input: string): string {
+  return input.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
 
-  const nameFuzzyScore = scoreSubsequenceMatch(normalizedName, query);
-  if (nameFuzzyScore !== null) {
-    return 100 + nameFuzzyScore;
+function globToRegExpSource(pattern: string): string {
+  let source = "";
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === "*") {
+      if (pattern[index + 1] === "*") {
+        const followedBySlash = pattern[index + 2] === "/";
+        source += followedBySlash ? "(?:.*\\/)?" : ".*";
+        index += followedBySlash ? 2 : 1;
+        continue;
+      }
+      source += "[^/]*";
+      continue;
+    }
+    if (character === "?") {
+      source += "[^/]";
+      continue;
+    }
+    if (character === "{") {
+      const closingIndex = findBraceClosingIndex(pattern, index);
+      if (closingIndex > index) {
+        const alternatives = splitBraceAlternatives(pattern.slice(index + 1, closingIndex)).filter(
+          (part) => part.length > 0,
+        );
+        if (alternatives.length > 0) {
+          source += `(?:${alternatives.map(globToRegExpSource).join("|")})`;
+          index = closingIndex;
+          continue;
+        }
+      }
+    }
+    source += escapeRegExp(character ?? "");
   }
 
-  const pathFuzzyScore = scoreSubsequenceMatch(normalizedPath, query);
-  if (pathFuzzyScore !== null) {
-    return 200 + pathFuzzyScore;
+  return source;
+}
+
+function hasGlobMagic(pattern: string): boolean {
+  return /[*?{]/.test(pattern);
+}
+
+function compileWorkspaceGlob(pattern: string): CompiledWorkspaceGlob {
+  const normalizedPattern = pattern.trim().replace(/\\/g, "/").replace(/^\.\//, "");
+  if (!normalizedPattern || normalizedPattern === "**") {
+    return { matches: () => true };
   }
 
-  return null;
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3);
+    return {
+      matches: (relativePath) => relativePath === prefix || relativePath.startsWith(`${prefix}/`),
+    };
+  }
+
+  const includesSlash = normalizedPattern.includes("/");
+  const magic = hasGlobMagic(normalizedPattern);
+
+  if (!includesSlash && !magic) {
+    return {
+      matches: (relativePath) =>
+        relativePath === normalizedPattern || relativePath.split("/").includes(normalizedPattern),
+    };
+  }
+
+  if (!includesSlash) {
+    const segmentExpression = new RegExp(`^${globToRegExpSource(normalizedPattern)}$`, "i");
+    return {
+      matches: (relativePath) =>
+        relativePath.split("/").some((segment) => segmentExpression.test(segment)),
+    };
+  }
+
+  if (!magic) {
+    return {
+      matches: (relativePath) =>
+        relativePath === normalizedPattern || relativePath.startsWith(`${normalizedPattern}/`),
+    };
+  }
+
+  const pathExpression = new RegExp(`^${globToRegExpSource(normalizedPattern)}$`, "i");
+  return {
+    matches: (relativePath) => pathExpression.test(relativePath),
+  };
+}
+
+function compileWorkspaceGlobExpression(input?: string): CompiledWorkspaceGlobExpression {
+  const expression: CompiledWorkspaceGlobExpression = {
+    positive: [],
+    negative: [],
+  };
+
+  for (const pattern of splitGlobPatternList(input)) {
+    const isNegative = pattern.startsWith("!");
+    const normalizedPattern = isNegative ? pattern.slice(1).trim() : pattern;
+    if (!normalizedPattern) continue;
+    const target = isNegative ? expression.negative : expression.positive;
+    target.push(compileWorkspaceGlob(normalizedPattern));
+  }
+
+  return expression;
+}
+
+function matchesWorkspaceGlobExpression(
+  relativePath: string,
+  expression: CompiledWorkspaceGlobExpression,
+): boolean {
+  if (
+    expression.positive.length > 0 &&
+    !expression.positive.some((glob) => glob.matches(relativePath))
+  ) {
+    return false;
+  }
+  if (expression.negative.some((glob) => glob.matches(relativePath))) {
+    return false;
+  }
+  return true;
+}
+
+function shouldIncludeSearchableEntry(
+  entry: SearchableWorkspaceEntry,
+  includeExpression: CompiledWorkspaceGlobExpression,
+  excludeExpression: CompiledWorkspaceGlobExpression,
+): boolean {
+  if (!matchesWorkspaceGlobExpression(entry.path, includeExpression)) {
+    return false;
+  }
+  if (excludeExpression.positive.some((glob) => glob.matches(entry.path))) {
+    return false;
+  }
+  return true;
+}
+
+function isWordSeparator(character: string | undefined): boolean {
+  return (
+    character === "/" ||
+    character === "\\" ||
+    character === "-" ||
+    character === "_" ||
+    character === "." ||
+    character === " "
+  );
+}
+
+function isUppercaseAscii(character: string | undefined): boolean {
+  return Boolean(character && character >= "A" && character <= "Z");
+}
+
+function isLowercaseAscii(character: string | undefined): boolean {
+  return Boolean(character && character >= "a" && character <= "z");
+}
+
+function isDigit(character: string | undefined): boolean {
+  return Boolean(character && character >= "0" && character <= "9");
+}
+
+function isWordStart(value: string, index: number): boolean {
+  if (index <= 0) return true;
+  const current = value[index];
+  const previous = value[index - 1];
+  if (isWordSeparator(previous)) {
+    return true;
+  }
+  if (isLowercaseAscii(previous) && isUppercaseAscii(current)) {
+    return true;
+  }
+  return isDigit(previous) !== isDigit(current);
+}
+
+function countExactCaseMatches(value: string, queryToken: string, startIndex: number): number {
+  let exactCaseMatches = 0;
+  for (let index = 0; index < queryToken.length; index += 1) {
+    if (value[startIndex + index] === queryToken[index]) {
+      exactCaseMatches += 1;
+    }
+  }
+  return exactCaseMatches;
+}
+
+function countUppercaseQueryCharacters(queryToken: string): number {
+  let uppercaseCharacters = 0;
+  for (let index = 0; index < queryToken.length; index += 1) {
+    if (isUppercaseAscii(queryToken[index])) {
+      uppercaseCharacters += 1;
+    }
+  }
+  return uppercaseCharacters;
+}
+
+function findTightSubsequencePositions(
+  valueLower: string,
+  queryLower: string,
+  startIndex: number,
+): number[] | null {
+  if (!queryLower) return [];
+
+  const forwardPositions: number[] = [];
+  let queryIndex = 0;
+
+  for (
+    let valueIndex = Math.max(0, startIndex);
+    valueIndex < valueLower.length && queryIndex < queryLower.length;
+    valueIndex += 1
+  ) {
+    if (valueLower[valueIndex] !== queryLower[queryIndex]) {
+      continue;
+    }
+    forwardPositions[queryIndex] = valueIndex;
+    queryIndex += 1;
+  }
+
+  if (queryIndex !== queryLower.length) {
+    return null;
+  }
+
+  const positions = Array<number>(queryLower.length);
+  let valueIndex = forwardPositions[forwardPositions.length - 1] ?? startIndex;
+  for (
+    let reverseQueryIndex = queryLower.length - 1;
+    reverseQueryIndex >= 0;
+    reverseQueryIndex -= 1
+  ) {
+    while (valueIndex >= startIndex && valueLower[valueIndex] !== queryLower[reverseQueryIndex]) {
+      valueIndex -= 1;
+    }
+    if (valueIndex < startIndex) {
+      return null;
+    }
+    positions[reverseQueryIndex] = valueIndex;
+    valueIndex -= 1;
+  }
+
+  return positions;
+}
+
+function scoreExactTokenMatch(
+  value: string,
+  queryToken: string,
+  startIndex: number,
+): QueryTokenMatch {
+  const exactCaseMatches = countExactCaseMatches(value, queryToken, startIndex);
+  const uppercaseCaseMismatches = Math.max(
+    0,
+    countUppercaseQueryCharacters(queryToken) - exactCaseMatches,
+  );
+  let score = 1_450;
+  if (startIndex === 0) {
+    score += 140;
+  }
+  if (isWordStart(value, startIndex)) {
+    score += 140;
+  }
+  score += exactCaseMatches * 70;
+  score -= uppercaseCaseMismatches * 120;
+  score -= startIndex * 8;
+  score -= Math.max(0, value.length - queryToken.length);
+  return {
+    score,
+    lastMatchIndex: startIndex + queryToken.length - 1,
+  };
+}
+
+function scoreFuzzyTokenMatch(
+  value: string,
+  queryToken: string,
+  positions: readonly number[],
+): QueryTokenMatch {
+  const firstMatchIndex = positions[0] ?? 0;
+  const lastMatchIndex = positions[positions.length - 1] ?? firstMatchIndex;
+  let score = 1_150;
+  score -= firstMatchIndex * 8;
+  score -= (lastMatchIndex - firstMatchIndex + 1 - queryToken.length) * 12;
+  score -= Math.max(0, value.length - queryToken.length);
+
+  for (let index = 0; index < positions.length; index += 1) {
+    const position = positions[index] ?? 0;
+    if (isWordStart(value, position)) {
+      score += 90;
+    }
+    if (value[position] === queryToken[index]) {
+      score += 50;
+    }
+    if (index > 0 && position === (positions[index - 1] ?? -2) + 1) {
+      score += 60;
+    }
+  }
+
+  return {
+    score,
+    lastMatchIndex,
+  };
+}
+
+function scoreQueryTokenMatch(
+  value: string,
+  valueLower: string,
+  queryToken: string,
+  startIndex: number,
+): QueryTokenMatch | null {
+  if (!queryToken) {
+    return {
+      score: 0,
+      lastMatchIndex: Math.max(0, startIndex - 1),
+    };
+  }
+
+  const queryLower = queryToken.toLowerCase();
+  const exactIndex = valueLower.indexOf(queryLower, startIndex);
+  const exactMatch = exactIndex === -1 ? null : scoreExactTokenMatch(value, queryToken, exactIndex);
+
+  const positions = findTightSubsequencePositions(valueLower, queryLower, startIndex);
+  const fuzzyMatch = positions ? scoreFuzzyTokenMatch(value, queryToken, positions) : null;
+
+  if (!exactMatch) {
+    return fuzzyMatch;
+  }
+  if (!fuzzyMatch) {
+    return exactMatch;
+  }
+  return exactMatch.score >= fuzzyMatch.score ? exactMatch : fuzzyMatch;
+}
+
+function scoreQueryTokensOnValue(value: string, queryTokens: readonly string[]): number | null {
+  const valueLower = value.toLowerCase();
+  let score = 0;
+  let nextStartIndex = 0;
+
+  for (const queryToken of queryTokens) {
+    const tokenMatch = scoreQueryTokenMatch(value, valueLower, queryToken, nextStartIndex);
+    if (!tokenMatch) {
+      return null;
+    }
+    score += tokenMatch.score;
+    nextStartIndex = tokenMatch.lastMatchIndex + 1;
+  }
+
+  return score;
+}
+
+function scoreEntry(
+  entry: SearchableWorkspaceEntry,
+  queryTokens: readonly string[],
+): number | null {
+  if (queryTokens.length === 0) {
+    return entry.kind === "file" ? 250 : 200;
+  }
+
+  const nameScore = scoreQueryTokensOnValue(entry.name, queryTokens);
+  const pathScore = scoreQueryTokensOnValue(entry.path, queryTokens);
+  if (nameScore === null && pathScore === null) {
+    return null;
+  }
+
+  const bestScore = Math.max(
+    nameScore ?? Number.NEGATIVE_INFINITY,
+    pathScore ?? Number.NEGATIVE_INFINITY,
+  );
+  let score = bestScore;
+  if (nameScore !== null) {
+    score += 220;
+  }
+  if (pathScore !== null && nameScore !== null) {
+    score += 20;
+  }
+  if (entry.kind === "file") {
+    score += 30;
+  }
+  return score;
 }
 
 function compareRankedWorkspaceEntries(
   left: RankedWorkspaceEntry,
   right: RankedWorkspaceEntry,
 ): number {
-  const scoreDelta = left.score - right.score;
+  const scoreDelta = right.score - left.score;
   if (scoreDelta !== 0) return scoreDelta;
+  if (left.entry.kind !== right.entry.kind) {
+    return left.entry.kind === "file" ? -1 : 1;
+  }
   return left.entry.path.localeCompare(right.entry.path);
 }
 
@@ -618,13 +1004,19 @@ export async function searchWorkspaceEntries(
   input: ProjectSearchEntriesInput,
 ): Promise<ProjectSearchEntriesResult> {
   const index = await getWorkspaceIndex(input.cwd);
-  const normalizedQuery = normalizeQuery(input.query);
+  const queryTokens = splitQueryTokens(input.query);
+  const includeExpression = compileWorkspaceGlobExpression(input.includePattern);
+  const excludeExpression = compileWorkspaceGlobExpression(input.excludePattern);
   const limit = Math.max(0, Math.floor(input.limit));
   const rankedEntries: RankedWorkspaceEntry[] = [];
   let matchedEntryCount = 0;
 
   for (const entry of index.entries) {
-    const score = scoreEntry(entry, normalizedQuery);
+    if (!shouldIncludeSearchableEntry(entry, includeExpression, excludeExpression)) {
+      continue;
+    }
+
+    const score = scoreEntry(entry, queryTokens);
     if (score === null) {
       continue;
     }

--- a/apps/web/src/components/WorkspaceFileTree.tsx
+++ b/apps/web/src/components/WorkspaceFileTree.tsx
@@ -1,14 +1,25 @@
-import { type ProjectDirectoryEntry } from "@okcode/contracts";
+import { type ProjectDirectoryEntry, type ProjectEntry } from "@okcode/contracts";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRightIcon, FolderClosedIcon, FolderIcon, TriangleAlertIcon } from "lucide-react";
-import { memo, useCallback, useState } from "react";
+import {
+  ChevronRightIcon,
+  FolderClosedIcon,
+  FolderIcon,
+  SearchIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { memo, useCallback, useDeferredValue, useState } from "react";
 import { useCodeViewerStore } from "~/codeViewerStore";
 import { openInPreferredEditor } from "~/editorPreferences";
-import { projectListDirectoryQueryOptions } from "~/lib/projectReactQuery";
+import {
+  projectListDirectoryQueryOptions,
+  projectSearchEntriesQueryOptions,
+} from "~/lib/projectReactQuery";
 import { cn } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { VscodeEntryIcon } from "./chat/VscodeEntryIcon";
+import { Input } from "./ui/input";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "./ui/input-group";
 import { toastManager } from "./ui/toast";
 
 const TREE_ROW_LEFT_PADDING = 8;
@@ -20,6 +31,12 @@ export const WorkspaceFileTree = memo(function WorkspaceFileTree(props: {
   className?: string;
 }) {
   const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({});
+  const [searchQuery, setSearchQuery] = useState("");
+  const [includePattern, setIncludePattern] = useState("");
+  const [excludePattern, setExcludePattern] = useState("");
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const deferredIncludePattern = useDeferredValue(includePattern);
+  const deferredExcludePattern = useDeferredValue(excludePattern);
 
   const toggleDirectory = useCallback((pathValue: string) => {
     setExpandedDirectories((current) => ({
@@ -29,6 +46,21 @@ export const WorkspaceFileTree = memo(function WorkspaceFileTree(props: {
   }, []);
 
   const openFileInViewer = useCodeViewerStore((state) => state.openFile);
+  const searchActive =
+    deferredSearchQuery.trim().length > 0 ||
+    deferredIncludePattern.trim().length > 0 ||
+    deferredExcludePattern.trim().length > 0;
+
+  const searchResultsQuery = useQuery(
+    projectSearchEntriesQueryOptions({
+      cwd: props.cwd,
+      query: deferredSearchQuery,
+      includePattern: deferredIncludePattern,
+      excludePattern: deferredExcludePattern,
+      enabled: searchActive,
+      limit: 120,
+    }),
+  );
 
   const openFile = useCallback(
     (filePath: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => {
@@ -60,17 +92,176 @@ export const WorkspaceFileTree = memo(function WorkspaceFileTree(props: {
     [props.cwd, openFileInViewer],
   );
 
+  const revealDirectory = useCallback((pathValue: string) => {
+    setExpandedDirectories((current) => {
+      const next = { ...current };
+      for (const ancestorPath of ancestorPathsOf(pathValue)) {
+        next[ancestorPath] = true;
+      }
+      next[pathValue] = true;
+      return next;
+    });
+    setSearchQuery("");
+    setIncludePattern("");
+    setExcludePattern("");
+  }, []);
+
   return (
-    <div className={cn("space-y-0.5", props.className)}>
-      <WorkspaceFileTreeDirectory
-        cwd={props.cwd}
-        depth={0}
-        expandedDirectories={expandedDirectories}
-        onOpenFile={openFile}
-        onToggleDirectory={toggleDirectory}
-        resolvedTheme={props.resolvedTheme}
-      />
+    <div className={cn("space-y-2", props.className)}>
+      <div className="space-y-1.5 px-2">
+        <InputGroup className="h-8">
+          <InputGroupAddon>
+            <SearchIcon className="size-3.5 text-muted-foreground/65" />
+          </InputGroupAddon>
+          <InputGroupInput
+            size="sm"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search files"
+            spellCheck={false}
+            aria-label="Search files"
+          />
+        </InputGroup>
+        <div className="grid gap-1.5">
+          <Input
+            size="sm"
+            value={includePattern}
+            onChange={(event) => setIncludePattern(event.target.value)}
+            placeholder="Include: src/**, *.{ts,tsx}"
+            spellCheck={false}
+            aria-label="Files to include"
+          />
+          <Input
+            size="sm"
+            value={excludePattern}
+            onChange={(event) => setExcludePattern(event.target.value)}
+            placeholder="Exclude: dist/**, *.snap"
+            spellCheck={false}
+            aria-label="Files to exclude"
+          />
+        </div>
+        <p className="text-[10px] text-muted-foreground/55">
+          CamelCase, path-ordered, and glob-restricted search.
+        </p>
+      </div>
+
+      {searchActive ? (
+        <WorkspaceSearchResults
+          entries={searchResultsQuery.data?.entries ?? []}
+          error={searchResultsQuery.error}
+          isError={searchResultsQuery.isError}
+          isLoading={searchResultsQuery.isLoading}
+          onOpenFile={openFile}
+          onRevealDirectory={revealDirectory}
+          resolvedTheme={props.resolvedTheme}
+          truncated={searchResultsQuery.data?.truncated ?? false}
+        />
+      ) : (
+        <WorkspaceFileTreeDirectory
+          cwd={props.cwd}
+          depth={0}
+          expandedDirectories={expandedDirectories}
+          onOpenFile={openFile}
+          onToggleDirectory={toggleDirectory}
+          resolvedTheme={props.resolvedTheme}
+        />
+      )}
     </div>
+  );
+});
+
+const WorkspaceSearchResults = memo(function WorkspaceSearchResults(props: {
+  entries: readonly ProjectEntry[];
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  truncated: boolean;
+  resolvedTheme: "light" | "dark";
+  onOpenFile: (pathValue: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => void;
+  onRevealDirectory: (pathValue: string) => void;
+}) {
+  if (props.isLoading) {
+    return <div className="px-2 py-1 text-[11px] text-muted-foreground/60">Searching files…</div>;
+  }
+
+  if (props.isError) {
+    const message =
+      props.error instanceof Error ? props.error.message : "Unable to search workspace files.";
+    return (
+      <div className="flex items-center gap-1.5 px-2 py-1 text-[11px] text-amber-600 dark:text-amber-300/90">
+        <TriangleAlertIcon className="size-3.5 shrink-0" />
+        <span className="truncate">{message}</span>
+      </div>
+    );
+  }
+
+  if (props.entries.length === 0) {
+    return <div className="px-2 py-1 text-[11px] text-muted-foreground/60">No files matched.</div>;
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {props.entries.map((entry) => (
+        <WorkspaceSearchResultRow
+          key={`${entry.kind}:${entry.path}`}
+          entry={entry}
+          onOpenFile={props.onOpenFile}
+          onRevealDirectory={props.onRevealDirectory}
+          resolvedTheme={props.resolvedTheme}
+        />
+      ))}
+      {props.truncated ? (
+        <div className="px-2 py-1 text-[10px] text-muted-foreground/55">
+          Search results are truncated for large workspaces.
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+const WorkspaceSearchResultRow = memo(function WorkspaceSearchResultRow(props: {
+  entry: ProjectEntry;
+  resolvedTheme: "light" | "dark";
+  onOpenFile: (pathValue: string, event?: { metaKey?: boolean; ctrlKey?: boolean }) => void;
+  onRevealDirectory: (pathValue: string) => void;
+}) {
+  const parentPath = parentPathOf(props.entry.path);
+  const isDirectory = props.entry.kind === "directory";
+
+  return (
+    <button
+      type="button"
+      className="group flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent/60"
+      onClick={(event) => {
+        if (isDirectory) {
+          props.onRevealDirectory(props.entry.path);
+          return;
+        }
+        props.onOpenFile(props.entry.path, { metaKey: event.metaKey, ctrlKey: event.ctrlKey });
+      }}
+      title={props.entry.path}
+    >
+      <span className="mt-0.5 shrink-0">
+        {isDirectory ? (
+          <FolderClosedIcon className="size-3.5 text-muted-foreground/75" />
+        ) : (
+          <VscodeEntryIcon
+            pathValue={props.entry.path}
+            kind="file"
+            theme={props.resolvedTheme}
+            className="size-3.5 text-muted-foreground/70"
+          />
+        )}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-mono text-[11px] text-muted-foreground/85 group-hover:text-foreground/90">
+          {basenameOfPath(props.entry.path)}
+        </span>
+        <span className="block truncate text-[10px] text-muted-foreground/55">
+          {parentPath ?? "."}
+        </span>
+      </span>
+    </button>
   );
 });
 
@@ -247,4 +438,23 @@ const WorkspaceFileRow = memo(function WorkspaceFileRow(props: {
 function basenameOfPath(pathValue: string): string {
   const segments = pathValue.split("/");
   return segments[segments.length - 1] ?? pathValue;
+}
+
+function parentPathOf(pathValue: string): string | null {
+  const separatorIndex = pathValue.lastIndexOf("/");
+  if (separatorIndex === -1) {
+    return null;
+  }
+  return pathValue.slice(0, separatorIndex);
+}
+
+function ancestorPathsOf(pathValue: string): string[] {
+  const segments = pathValue.split("/").filter((segment) => segment.length > 0);
+  if (segments.length <= 1) return [];
+
+  const ancestors: string[] = [];
+  for (let index = 1; index < segments.length; index += 1) {
+    ancestors.push(segments.slice(0, index).join("/"));
+  }
+  return ancestors;
 }

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -8,8 +8,13 @@ import { ensureNativeApi } from "~/nativeApi";
 
 export const projectQueryKeys = {
   all: ["projects"] as const,
-  searchEntries: (cwd: string | null, query: string, limit: number) =>
-    ["projects", "search-entries", cwd, query, limit] as const,
+  searchEntries: (
+    cwd: string | null,
+    query: string,
+    includePattern: string,
+    excludePattern: string,
+    limit: number,
+  ) => ["projects", "search-entries", cwd, query, includePattern, excludePattern, limit] as const,
   listDirectory: (cwd: string | null, directoryPath: string | null) =>
     ["projects", "list-directory", cwd, directoryPath] as const,
   readFile: (cwd: string | null, relativePath: string | null) =>
@@ -30,13 +35,25 @@ const EMPTY_LIST_DIRECTORY_RESULT: ProjectListDirectoryResult = {
 export function projectSearchEntriesQueryOptions(input: {
   cwd: string | null;
   query: string;
+  includePattern?: string;
+  excludePattern?: string;
   enabled?: boolean;
   limit?: number;
   staleTime?: number;
 }) {
   const limit = input.limit ?? DEFAULT_SEARCH_ENTRIES_LIMIT;
+  const includePattern = input.includePattern?.trim() ?? "";
+  const excludePattern = input.excludePattern?.trim() ?? "";
+  const hasSearchFilters =
+    input.query.trim().length > 0 || includePattern.length > 0 || excludePattern.length > 0;
   return queryOptions({
-    queryKey: projectQueryKeys.searchEntries(input.cwd, input.query, limit),
+    queryKey: projectQueryKeys.searchEntries(
+      input.cwd,
+      input.query,
+      includePattern,
+      excludePattern,
+      limit,
+    ),
     queryFn: async () => {
       const api = ensureNativeApi();
       if (!input.cwd) {
@@ -46,9 +63,11 @@ export function projectSearchEntriesQueryOptions(input: {
         cwd: input.cwd,
         query: input.query,
         limit,
+        ...(includePattern ? { includePattern } : {}),
+        ...(excludePattern ? { excludePattern } : {}),
       });
     },
-    enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
+    enabled: (input.enabled ?? true) && input.cwd !== null && hasSearchFilters,
     staleTime: input.staleTime ?? DEFAULT_PROJECT_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
   });

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -1,14 +1,21 @@
 import { Schema } from "effect";
-import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas";
+import { PositiveInt, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas";
 
 const PROJECT_SEARCH_ENTRIES_MAX_LIMIT = 200;
+const PROJECT_SEARCH_FILTER_MAX_LENGTH = 512;
 const PROJECT_WRITE_FILE_PATH_MAX_LENGTH = 512;
 const PROJECT_DIRECTORY_PATH_MAX_LENGTH = 1024;
 
 export const ProjectSearchEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
-  query: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  query: TrimmedString.check(Schema.isMaxLength(256)),
   limit: PositiveInt.check(Schema.isLessThanOrEqualTo(PROJECT_SEARCH_ENTRIES_MAX_LIMIT)),
+  includePattern: Schema.optional(
+    TrimmedString.check(Schema.isMaxLength(PROJECT_SEARCH_FILTER_MAX_LENGTH)),
+  ),
+  excludePattern: Schema.optional(
+    TrimmedString.check(Schema.isMaxLength(PROJECT_SEARCH_FILTER_MAX_LENGTH)),
+  ),
 });
 export type ProjectSearchEntriesInput = typeof ProjectSearchEntriesInput.Type;
 


### PR DESCRIPTION
## Summary
- Adds workspace search filtering with `includePattern` and `excludePattern` support, including VS Code-style glob behavior.
- Improves search ranking to prefer CamelCase boundary matches, exact token matches, and path-ordered results.
- Updates the workspace file tree UI with search, include/exclude inputs, and search result rendering for files and directories.
- Extends the shared project search contract so the server and web can pass search filters consistently.

## Testing
- `Not run` in this summary generation context.
- Added server-side coverage for CamelCase ranking preference.
- Added server-side coverage for include/exclude glob filtering behavior.
- Recommend verifying `bun fmt`, `bun lint`, and `bun typecheck` before merge.