### PR TITLE
Add encrypted persistence for environment variables

### DIFF
--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -30,6 +30,19 @@ export class PersistenceDecodeError extends Schema.TaggedErrorClass<PersistenceD
   }
 }
 
+export class PersistenceCryptoError extends Schema.TaggedErrorClass<PersistenceCryptoError>()(
+  "PersistenceCryptoError",
+  {
+    operation: Schema.String,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message(): string {
+    return `Crypto error in ${this.operation}: ${this.detail}`;
+  }
+}
+
 export function toPersistenceSqlError(operation: string) {
   return (cause: unknown): PersistenceSqlError =>
     new PersistenceSqlError({
@@ -57,8 +70,19 @@ export function toPersistenceDecodeCauseError(operation: string) {
     });
 }
 
+export function toPersistenceCryptoError(operation: string) {
+  return (cause: unknown): PersistenceCryptoError =>
+    new PersistenceCryptoError({
+      operation,
+      detail: `Failed to execute ${operation}`,
+      cause,
+    });
+}
+
 export const isPersistenceError = (u: unknown) =>
-  Schema.is(PersistenceSqlError)(u) || Schema.is(PersistenceDecodeError)(u);
+  Schema.is(PersistenceSqlError)(u) ||
+  Schema.is(PersistenceDecodeError)(u) ||
+  Schema.is(PersistenceCryptoError)(u);
 
 // ===============================
 // Provider Session Repository Errors

--- a/apps/server/src/persistence/Services/EnvironmentVariables.ts
+++ b/apps/server/src/persistence/Services/EnvironmentVariables.ts
@@ -1,0 +1,464 @@
+/**
+ * EnvironmentVariablesRepository - Encrypted environment variable persistence.
+ *
+ * Stores project-scoped and global env vars encrypted at rest and exposes
+ * plaintext lists for the UI plus merged runtime env snapshots for process
+ * launchers.
+ *
+ * @module EnvironmentVariablesRepository
+ */
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  EnvironmentVariableEntry,
+  GlobalEnvironmentVariablesResult,
+  ProjectEnvironmentVariablesInput,
+  ProjectEnvironmentVariablesResult,
+  SaveGlobalEnvironmentVariablesInput,
+  SaveProjectEnvironmentVariablesInput,
+} from "@okcode/contracts";
+import { Option, Schema, ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+import type { EnvironmentVariablesError } from "../Errors.ts";
+
+export interface EnvironmentVariablesShape {
+  /**
+   * Read globally scoped environment variables.
+   */
+  readonly getGlobal: () => Effect.Effect<
+    GlobalEnvironmentVariablesResult,
+    EnvironmentVariablesError
+  >;
+
+  /**
+   * Replace all globally scoped environment variables.
+   */
+  readonly saveGlobal: (
+    input: SaveGlobalEnvironmentVariablesInput,
+  ) => Effect.Effect<GlobalEnvironmentVariablesResult, EnvironmentVariablesError>;
+
+  /**
+   * Read environment variables attached to a project.
+   */
+  readonly getProject: (
+    input: ProjectEnvironmentVariablesInput,
+  ) => Effect.Effect<ProjectEnvironmentVariablesResult, EnvironmentVariablesError>;
+
+  /**
+   * Replace all environment variables attached to a project.
+   */
+  readonly saveProject: (
+    input: SaveProjectEnvironmentVariablesInput,
+  ) => Effect.Effect<ProjectEnvironmentVariablesResult, EnvironmentVariablesError>;
+
+  /**
+   * Resolve the merged runtime environment for a project.
+   *
+   * Project-scoped values override global values.
+   */
+  readonly resolveEnvironment: (
+    input?: ProjectEnvironmentVariablesInput,
+  ) => Effect.Effect<Record<string, string>, EnvironmentVariablesError>;
+}
+
+export class EnvironmentVariables extends ServiceMap.Service<
+  EnvironmentVariables,
+  EnvironmentVariablesShape
+>()("okcode/persistence/Services/EnvironmentVariables/EnvironmentVariables") {}
+
+export const GLOBAL_ENVIRONMENT_SCOPE = "global" as const;
+export const PROJECT_ENVIRONMENT_SCOPE = "project" as const;
+
+export const GlobalEnvironmentVariableRow = Schema.Struct({
+  key: Schema.String,
+  encryptedValue: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+});
+
+export const ProjectEnvironmentVariableRow = Schema.Struct({
+  projectId: Schema.String,
+  key: Schema.String,
+  encryptedValue: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+});
+
+const SECRET_PAYLOAD_VERSION = "v1";
+const SECRET_KEY_BYTES = 32;
+const SECRET_IV_BYTES = 12;
+
+type EnvironmentVariableScope = typeof GLOBAL_ENVIRONMENT_SCOPE | typeof PROJECT_ENVIRONMENT_SCOPE;
+
+type NormalizedEnvironmentVariableEntry = EnvironmentVariableEntry;
+
+function toEnvironmentVariableScopePrefix(scope: EnvironmentVariableScope): string {
+  return scope === GLOBAL_ENVIRONMENT_SCOPE ? "global" : "project";
+}
+
+function encodeSecretPayload(input: {
+  readonly key: Buffer;
+  readonly scope: EnvironmentVariableScope;
+  readonly projectId?: string | undefined;
+  readonly envKey: string;
+  readonly value: string;
+}): string {
+  const iv = randomBytes(SECRET_IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", input.key, iv);
+  cipher.setAAD(
+    Buffer.from(
+      [
+        toEnvironmentVariableScopePrefix(input.scope),
+        input.projectId ?? "",
+        input.envKey,
+      ].join("\0"),
+      "utf8",
+    ),
+  );
+
+  const ciphertext = Buffer.concat([
+    cipher.update(input.value, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return [
+    SECRET_PAYLOAD_VERSION,
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(":");
+}
+
+function decodeSecretPayload(input: {
+  readonly key: Buffer;
+  readonly scope: EnvironmentVariableScope;
+  readonly projectId?: string | undefined;
+  readonly envKey: string;
+  readonly encryptedValue: string;
+}): string {
+  const parts = input.encryptedValue.split(":");
+  if (parts.length !== 4 || parts[0] !== SECRET_PAYLOAD_VERSION) {
+    throw new Error("Unsupported secret payload version.");
+  }
+
+  const [, ivRaw, authTagRaw, ciphertextRaw] = parts;
+  if (!ivRaw || !authTagRaw || !ciphertextRaw) {
+    throw new Error("Invalid encrypted payload.");
+  }
+
+  const iv = Buffer.from(ivRaw, "base64");
+  const authTag = Buffer.from(authTagRaw, "base64");
+  const ciphertext = Buffer.from(ciphertextRaw, "base64");
+  const decipher = createDecipheriv("aes-256-gcm", input.key, iv);
+  decipher.setAAD(
+    Buffer.from(
+      [
+        toEnvironmentVariableScopePrefix(input.scope),
+        input.projectId ?? "",
+        input.envKey,
+      ].join("\0"),
+      "utf8",
+    ),
+  );
+  decipher.setAuthTag(authTag);
+  return `${decipher.update(ciphertext, undefined, "utf8")}${decipher.final("utf8")}`;
+}
+
+function normalizeEnvironmentEntries(
+  entries: ReadonlyArray<EnvironmentVariableEntry>,
+): ReadonlyArray<NormalizedEnvironmentVariableEntry> {
+  const byKey = new Map<string, string>();
+  for (const entry of entries) {
+    byKey.set(entry.key.trim(), entry.value);
+  }
+  return Array.from(byKey.entries())
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ({ key, value }));
+}
+
+function entriesToRecord(entries: ReadonlyArray<EnvironmentVariableEntry>): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const entry of entries) {
+    record[entry.key] = entry.value;
+  }
+  return record;
+}
+
+async function readOrCreateSecretKey(secretKeyPath: string): Promise<Buffer> {
+  try {
+    const existing = await fs.readFile(secretKeyPath, "utf8");
+    const decoded = Buffer.from(existing.trim(), "base64");
+    if (decoded.byteLength !== SECRET_KEY_BYTES) {
+      throw new Error("Invalid vault key length.");
+    }
+    return decoded;
+  } catch (error) {
+    const maybeCode = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (maybeCode !== "ENOENT") {
+      throw error;
+    }
+
+    await fs.mkdir(path.dirname(secretKeyPath), { recursive: true });
+    const key = randomBytes(SECRET_KEY_BYTES);
+    try {
+      await fs.writeFile(secretKeyPath, `${key.toString("base64")}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      });
+    } catch (writeError) {
+      const writeCode = (writeError as NodeJS.ErrnoException | undefined)?.code;
+      if (writeCode === "EEXIST") {
+        const existing = await fs.readFile(secretKeyPath, "utf8");
+        const decoded = Buffer.from(existing.trim(), "base64");
+        if (decoded.byteLength !== SECRET_KEY_BYTES) {
+          throw new Error("Invalid vault key length.");
+        }
+        return decoded;
+      }
+      throw writeError;
+    }
+    return key;
+  }
+}
+
+function toPersistenceCryptoError(operation: string): EnvironmentVariablesError {
+  return new Error(`Crypto error in ${operation}.`);
+}
+
+function toPersistenceSqlError(operation: string): EnvironmentVariablesError {
+  return new Error(`SQL error in ${operation}.`);
+}
+
+function toPersistenceDecodeError(operation: string): EnvironmentVariablesError {
+  return new Error(`Decode error in ${operation}.`);
+}
+
+const makeEnvironmentVariables = Effect.gen(function* () {
+  const sql = yield* (await import("effect/unstable/sql/SqlClient")).SqlClient;
+  const { ServerConfig } = await import("../../config.ts");
+
+  const { stateDir } = yield* ServerConfig;
+  const secretKeyPath = path.join(stateDir, "environment-vault.key");
+  let secretKeyPromise: Promise<Buffer> | null = null;
+
+  const getSecretKey = () => {
+    if (!secretKeyPromise) {
+      secretKeyPromise = readOrCreateSecretKey(secretKeyPath).catch((error) => {
+        secretKeyPromise = null;
+        throw error;
+      });
+    }
+    return secretKeyPromise;
+  };
+
+  const globalRows = Schema.Array(GlobalEnvironmentVariableRow);
+  const projectRows = Schema.Array(ProjectEnvironmentVariableRow);
+
+  const listGlobalRows = async () =>
+    sql`
+      SELECT
+        env_key AS "key",
+        encrypted_value AS "encryptedValue",
+        created_at AS "createdAt",
+        updated_at AS "updatedAt"
+      FROM global_environment_variables
+      ORDER BY env_key ASC
+    `;
+
+  const listProjectRows = async (projectId: string) =>
+    sql`
+      SELECT
+        project_id AS "projectId",
+        env_key AS "key",
+        encrypted_value AS "encryptedValue",
+        created_at AS "createdAt",
+        updated_at AS "updatedAt"
+      FROM project_environment_variables
+      WHERE project_id = ${projectId}
+      ORDER BY env_key ASC
+    `;
+
+  const decodeRows = async <S extends Schema.Top>(rows: unknown, schema: S) =>
+    Schema.decodeUnknownEffect(schema)(rows);
+
+  const readGlobalEntries = Effect.fnUntraced(function* () {
+    const rows = yield* Effect.tryPromise({
+      try: listGlobalRows,
+      catch: (cause) => toPersistenceSqlError("EnvironmentVariables.getGlobal:query"),
+    });
+    const parsedRows = yield* decodeRows(rows, globalRows).pipe(
+      Effect.mapError(() => toPersistenceDecodeError("EnvironmentVariables.getGlobal:decodeRows")),
+    );
+    const key = yield* Effect.tryPromise({
+      try: getSecretKey,
+      catch: (cause) => toPersistenceCryptoError("EnvironmentVariables.getGlobal:secretKey"),
+    });
+    return parsedRows.map((row) => ({
+      key: row.key,
+      value: decodeSecretPayload({
+        key,
+        scope: GLOBAL_ENVIRONMENT_SCOPE,
+        envKey: row.key,
+        encryptedValue: row.encryptedValue,
+      }),
+    }));
+  });
+
+  const readProjectEntries = Effect.fnUntraced(function* (projectId: string) {
+    const rows = yield* Effect.tryPromise({
+      try: () => listProjectRows(projectId),
+      catch: () => toPersistenceSqlError("EnvironmentVariables.getProject:query"),
+    });
+    const parsedRows = yield* decodeRows(rows, projectRows).pipe(
+      Effect.mapError(() => toPersistenceDecodeError("EnvironmentVariables.getProject:decodeRows")),
+    );
+    const key = yield* Effect.tryPromise({
+      try: getSecretKey,
+      catch: () => toPersistenceCryptoError("EnvironmentVariables.getProject:secretKey"),
+    });
+    return parsedRows.map((row) => ({
+      key: row.key,
+      value: decodeSecretPayload({
+        key,
+        scope: PROJECT_ENVIRONMENT_SCOPE,
+        projectId,
+        envKey: row.key,
+        encryptedValue: row.encryptedValue,
+      }),
+    }));
+  });
+
+  const writeEntries = Effect.fnUntraced(function* (input: {
+    readonly scope: EnvironmentVariableScope;
+    readonly projectId?: string | undefined;
+    readonly entries: ReadonlyArray<EnvironmentVariableEntry>;
+  }) {
+    const normalizedEntries = normalizeEnvironmentEntries(input.entries);
+    const secretKey = yield* Effect.tryPromise({
+      try: getSecretKey,
+      catch: () => toPersistenceCryptoError("EnvironmentVariables.save:secretKey"),
+    });
+    const now = new Date().toISOString();
+    const encryptedRows = normalizedEntries.map((entry) => ({
+      key: entry.key,
+      encryptedValue: encodeSecretPayload({
+        key: secretKey,
+        scope: input.scope,
+        ...(input.projectId ? { projectId: input.projectId } : {}),
+        envKey: entry.key,
+        value: entry.value,
+      }),
+      createdAt: now,
+      updatedAt: now,
+      ...(input.projectId ? { projectId: input.projectId } : {}),
+    }));
+
+    const query = input.scope === GLOBAL_ENVIRONMENT_SCOPE
+      ? sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              DELETE FROM global_environment_variables
+            `;
+            for (const row of encryptedRows) {
+              yield* sql`
+                INSERT INTO global_environment_variables (
+                  env_key,
+                  encrypted_value,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  ${row.key},
+                  ${row.encryptedValue},
+                  ${row.createdAt},
+                  ${row.updatedAt}
+                )
+              `;
+            }
+          }),
+        )
+      : sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`
+              DELETE FROM project_environment_variables
+              WHERE project_id = ${input.projectId}
+            `;
+            for (const row of encryptedRows) {
+              yield* sql`
+                INSERT INTO project_environment_variables (
+                  project_id,
+                  env_key,
+                  encrypted_value,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  ${input.projectId},
+                  ${row.key},
+                  ${row.encryptedValue},
+                  ${row.createdAt},
+                  ${row.updatedAt}
+                )
+              `;
+            }
+          }),
+        );
+
+    yield* query.pipe(
+      Effect.mapError(() => toPersistenceSqlError("EnvironmentVariables.save:query")),
+    );
+    return normalizedEntries;
+  });
+
+  const getGlobal: EnvironmentVariablesShape["getGlobal"] = () =>
+    readGlobalEntries().pipe(
+      Effect.map((entries) => ({ entries })),
+    );
+
+  const saveGlobal: EnvironmentVariablesShape["saveGlobal"] = (input) =>
+    writeEntries({
+      scope: GLOBAL_ENVIRONMENT_SCOPE,
+      entries: input.entries,
+    }).pipe(
+      Effect.map((entries) => ({ entries })),
+    );
+
+  const getProject: EnvironmentVariablesShape["getProject"] = (input) =>
+    readProjectEntries(input.projectId).pipe(
+      Effect.map((entries) => ({ projectId: input.projectId, entries })),
+    );
+
+  const saveProject: EnvironmentVariablesShape["saveProject"] = (input) =>
+    writeEntries({
+      scope: PROJECT_ENVIRONMENT_SCOPE,
+      projectId: input.projectId,
+      entries: input.entries,
+    }).pipe(
+      Effect.map((entries) => ({ projectId: input.projectId, entries })),
+    );
+
+  const resolveEnvironment: EnvironmentVariablesShape["resolveEnvironment"] = (input) =>
+    Effect.gen(function* () {
+      const globalEntries = yield* readGlobalEntries();
+      const projectEntries = input ? yield* readProjectEntries(input.projectId) : [];
+      return entriesToRecord([...globalEntries, ...projectEntries]);
+    });
+
+  return {
+    getGlobal,
+    saveGlobal,
+    getProject,
+    saveProject,
+    resolveEnvironment,
+  } satisfies EnvironmentVariablesShape;
+});
+
+export const EnvironmentVariablesLive = Effect.gen(function* () {
+  const env = yield* makeEnvironmentVariables;
+  return env;
+});
+

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -1,0 +1,63 @@
+import { Schema } from "effect";
+
+import { ProjectId } from "./baseSchemas";
+
+export const ENVIRONMENT_VARIABLE_KEY_MAX_LENGTH = 128;
+export const ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH = 65_536;
+export const ENVIRONMENT_VARIABLE_MAX_COUNT = 128;
+export const RUNTIME_ENV_MAX_PROPERTIES = 256;
+
+export const EnvironmentVariableKey = Schema.String.check(
+  Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
+).check(Schema.isMaxLength(ENVIRONMENT_VARIABLE_KEY_MAX_LENGTH));
+export type EnvironmentVariableKey = typeof EnvironmentVariableKey.Type;
+
+export const EnvironmentVariableValue = Schema.String.check(
+  Schema.isMaxLength(ENVIRONMENT_VARIABLE_VALUE_MAX_LENGTH),
+);
+export type EnvironmentVariableValue = typeof EnvironmentVariableValue.Type;
+
+export const EnvironmentVariableEntry = Schema.Struct({
+  key: EnvironmentVariableKey,
+  value: EnvironmentVariableValue,
+});
+export type EnvironmentVariableEntry = typeof EnvironmentVariableEntry.Type;
+
+export const EnvironmentVariableEntries = Schema.Array(EnvironmentVariableEntry).check(
+  Schema.isMaxLength(ENVIRONMENT_VARIABLE_MAX_COUNT),
+);
+export type EnvironmentVariableEntries = typeof EnvironmentVariableEntries.Type;
+
+export const RuntimeEnvironmentVariables = Schema.Record(
+  EnvironmentVariableKey,
+  EnvironmentVariableValue,
+).check(Schema.isMaxLength(RUNTIME_ENV_MAX_PROPERTIES));
+export type RuntimeEnvironmentVariables = typeof RuntimeEnvironmentVariables.Type;
+
+export const GlobalEnvironmentVariablesResult = Schema.Struct({
+  entries: EnvironmentVariableEntries,
+});
+export type GlobalEnvironmentVariablesResult = typeof GlobalEnvironmentVariablesResult.Type;
+
+export const ProjectEnvironmentVariablesInput = Schema.Struct({
+  projectId: ProjectId,
+});
+export type ProjectEnvironmentVariablesInput = typeof ProjectEnvironmentVariablesInput.Type;
+
+export const ProjectEnvironmentVariablesResult = Schema.Struct({
+  projectId: ProjectId,
+  entries: EnvironmentVariableEntries,
+});
+export type ProjectEnvironmentVariablesResult = typeof ProjectEnvironmentVariablesResult.Type;
+
+export const SaveGlobalEnvironmentVariablesInput = Schema.Struct({
+  entries: EnvironmentVariableEntries,
+});
+export type SaveGlobalEnvironmentVariablesInput = typeof SaveGlobalEnvironmentVariablesInput.Type;
+
+export const SaveProjectEnvironmentVariablesInput = Schema.Struct({
+  projectId: ProjectId,
+  entries: EnvironmentVariableEntries,
+});
+export type SaveProjectEnvironmentVariablesInput =
+  typeof SaveProjectEnvironmentVariablesInput.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,3 +12,4 @@ export * from "./prReview";
 export * from "./orchestration";
 export * from "./editor";
 export * from "./project";
+export * from "./environment";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -57,6 +57,13 @@ import type {
 } from "./prReview";
 import type { ServerConfig } from "./server";
 import type {
+  GlobalEnvironmentVariablesResult,
+  ProjectEnvironmentVariablesInput,
+  ProjectEnvironmentVariablesResult,
+  SaveGlobalEnvironmentVariablesInput,
+  SaveProjectEnvironmentVariablesInput,
+} from "./environment";
+import type {
   TerminalClearInput,
   TerminalCloseInput,
   TerminalEvent,
@@ -282,6 +289,16 @@ export interface NativeApi {
   };
   server: {
     getConfig: () => Promise<ServerConfig>;
+    getGlobalEnvironmentVariables: () => Promise<GlobalEnvironmentVariablesResult>;
+    saveGlobalEnvironmentVariables: (
+      input: SaveGlobalEnvironmentVariablesInput,
+    ) => Promise<GlobalEnvironmentVariablesResult>;
+    getProjectEnvironmentVariables: (
+      input: ProjectEnvironmentVariablesInput,
+    ) => Promise<ProjectEnvironmentVariablesResult>;
+    saveProjectEnvironmentVariables: (
+      input: SaveProjectEnvironmentVariablesInput,
+    ) => Promise<ProjectEnvironmentVariablesResult>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
   };
   orchestration: {

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
 import { TrimmedNonEmptyString } from "./baseSchemas";
+import { RuntimeEnvironmentVariables } from "./environment";
 import { ProviderModelOptions } from "./model";
 import {
   ApprovalRequestId,
@@ -57,6 +58,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
   providerOptions: Schema.optional(ProviderStartOptions),
+  env: Schema.optional(RuntimeEnvironmentVariables),
   runtimeMode: RuntimeMode,
 });
 export type ProviderSessionStartInput = typeof ProviderSessionStartInput.Type;

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
 import { TrimmedNonEmptyString } from "./baseSchemas";
+import { RuntimeEnvironmentVariables } from "./environment";
 
 export const DEFAULT_TERMINAL_ID = "default";
 
@@ -11,13 +12,6 @@ const TerminalRowsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(5)).ch
   Schema.isLessThanOrEqualTo(200),
 );
 const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
-const TerminalEnvKeySchema = Schema.String.check(
-  Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
-).check(Schema.isMaxLength(128));
-const TerminalEnvValueSchema = Schema.String.check(Schema.isMaxLength(8_192));
-const TerminalEnvSchema = Schema.Record(TerminalEnvKeySchema, TerminalEnvValueSchema).check(
-  Schema.isMaxProperties(128),
-);
 
 const TerminalIdWithDefaultSchema = TerminalIdSchema.pipe(
   Schema.withDecodingDefault(() => DEFAULT_TERMINAL_ID),
@@ -39,7 +33,7 @@ export const TerminalOpenInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   cols: Schema.optional(TerminalColsSchema),
   rows: Schema.optional(TerminalRowsSchema),
-  env: Schema.optional(TerminalEnvSchema),
+  env: Schema.optional(RuntimeEnvironmentVariables),
 });
 export type TerminalOpenInput = Schema.Codec.Encoded<typeof TerminalOpenInput>;
 
@@ -64,7 +58,7 @@ export const TerminalRestartInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   cols: TerminalColsSchema,
   rows: TerminalRowsSchema,
-  env: Schema.optional(TerminalEnvSchema),
+  env: Schema.optional(RuntimeEnvironmentVariables),
 });
 export type TerminalRestartInput = Schema.Codec.Encoded<typeof TerminalRestartInput>;
 

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -61,6 +61,11 @@ import {
 } from "./terminal";
 import { KeybindingRule } from "./keybindings";
 import {
+  ProjectEnvironmentVariablesInput,
+  SaveGlobalEnvironmentVariablesInput,
+  SaveProjectEnvironmentVariablesInput,
+} from "./environment";
+import {
   ProjectListDirectoryInput,
   ProjectReadFileInput,
   ProjectSearchEntriesInput,
@@ -123,6 +128,10 @@ export const WS_METHODS = {
 
   // Server meta
   serverGetConfig: "server.getConfig",
+  serverGetGlobalEnvironmentVariables: "server.getGlobalEnvironmentVariables",
+  serverSaveGlobalEnvironmentVariables: "server.saveGlobalEnvironmentVariables",
+  serverGetProjectEnvironmentVariables: "server.getProjectEnvironmentVariables",
+  serverSaveProjectEnvironmentVariables: "server.saveProjectEnvironmentVariables",
   serverUpsertKeybinding: "server.upsertKeybinding",
   serverPickFolder: "server.pickFolder",
 } as const;
@@ -209,6 +218,16 @@ const WebSocketRequestBody = Schema.Union([
 
   // Server meta
   tagRequestBody(WS_METHODS.serverGetConfig, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.serverGetGlobalEnvironmentVariables, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.serverSaveGlobalEnvironmentVariables, SaveGlobalEnvironmentVariablesInput),
+  tagRequestBody(
+    WS_METHODS.serverGetProjectEnvironmentVariables,
+    ProjectEnvironmentVariablesInput,
+  ),
+  tagRequestBody(
+    WS_METHODS.serverSaveProjectEnvironmentVariables,
+    SaveProjectEnvironmentVariablesInput,
+  ),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
   tagRequestBody(WS_METHODS.serverPickFolder, Schema.Struct({})),
 ]);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,6 +35,10 @@
     "./preview": {
       "types": "./src/preview.ts",
       "import": "./src/preview.ts"
+    },
+    "./environment": {
+      "types": "./src/environment.ts",
+      "import": "./src/environment.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/environment.ts
+++ b/packages/shared/src/environment.ts
@@ -1,0 +1,148 @@
+import path from "node:path";
+
+import type { OrchestrationReadModel, ProjectId } from "@okcode/contracts";
+
+export type EnvironmentRecord = Record<string, string>;
+
+export interface ProjectContext {
+  readonly projectId: ProjectId;
+  readonly projectRoot: string;
+  readonly worktreePath: string | null;
+}
+
+export function compactNodeProcessEnv(env: NodeJS.ProcessEnv): EnvironmentRecord {
+  const compacted: EnvironmentRecord = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== "string") continue;
+    compacted[key] = value;
+  }
+  return compacted;
+}
+
+export function mergeEnvironmentRecords(
+  ...records: Array<EnvironmentRecord | undefined | null>
+): EnvironmentRecord {
+  return Object.assign(
+    {},
+    ...records.flatMap((record) => (record ? [record] : [])),
+  ) as EnvironmentRecord;
+}
+
+export function mergeNodeProcessEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  extraEnv?: EnvironmentRecord,
+): NodeJS.ProcessEnv {
+  const merged: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (typeof value !== "string") continue;
+    merged[key] = value;
+  }
+  if (extraEnv) {
+    for (const [key, value] of Object.entries(extraEnv)) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+export function projectScriptRuntimeEnv(input: {
+  project: {
+    cwd: string;
+  };
+  worktreePath?: string | null;
+  baseEnv?: EnvironmentRecord;
+  extraEnv?: EnvironmentRecord;
+}): EnvironmentRecord {
+  const env = mergeEnvironmentRecords(input.baseEnv);
+  env.OKCODE_PROJECT_ROOT = input.project.cwd;
+  if (input.worktreePath) {
+    env.OKCODE_WORKTREE_PATH = input.worktreePath;
+  }
+  return mergeEnvironmentRecords(env, input.extraEnv);
+}
+
+function isWithinPath(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  if (relative.length === 0) {
+    return true;
+  }
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+export function resolveProjectContextByCwd(
+  readModel: OrchestrationReadModel,
+  cwd: string,
+): ProjectContext | null {
+  const normalizedCwd = path.resolve(cwd);
+  const projectById = new Map(readModel.projects.map((project) => [project.id, project] as const));
+
+  let bestMatch:
+    | (ProjectContext & {
+        readonly matchLength: number;
+        readonly hasWorktreePath: boolean;
+      })
+    | null = null;
+
+  const consider = (input: {
+    readonly projectId: ProjectId;
+    readonly projectRoot: string;
+    readonly worktreePath: string | null;
+    readonly matchPath: string;
+  }) => {
+    const normalizedMatchPath = path.resolve(input.matchPath);
+    if (!isWithinPath(normalizedCwd, normalizedMatchPath)) {
+      return;
+    }
+
+    const candidate: ProjectContext & {
+      readonly matchLength: number;
+      readonly hasWorktreePath: boolean;
+    } = {
+      projectId: input.projectId,
+      projectRoot: path.resolve(input.projectRoot),
+      worktreePath: input.worktreePath,
+      matchLength: normalizedMatchPath.length,
+      hasWorktreePath: input.worktreePath !== null,
+    };
+
+    if (
+      bestMatch === null ||
+      candidate.matchLength > bestMatch.matchLength ||
+      (candidate.matchLength === bestMatch.matchLength &&
+        candidate.hasWorktreePath &&
+        !bestMatch.hasWorktreePath)
+    ) {
+      bestMatch = candidate;
+    }
+  };
+
+  for (const project of readModel.projects) {
+    consider({
+      projectId: project.id,
+      projectRoot: project.workspaceRoot,
+      worktreePath: null,
+      matchPath: project.workspaceRoot,
+    });
+  }
+
+  for (const thread of readModel.threads) {
+    if (!thread.worktreePath) continue;
+    const project = projectById.get(thread.projectId);
+    consider({
+      projectId: thread.projectId,
+      projectRoot: project?.workspaceRoot ?? thread.worktreePath,
+      worktreePath: thread.worktreePath,
+      matchPath: thread.worktreePath,
+    });
+  }
+
+  if (!bestMatch) {
+    return null;
+  }
+
+  return {
+    projectId: bestMatch.projectId,
+    projectRoot: bestMatch.projectRoot,
+    worktreePath: bestMatch.worktreePath,
+  };
+}


### PR DESCRIPTION
## Summary
- Add encrypted-at-rest persistence for global and project-scoped environment variables.
- Introduce shared environment-variable contracts, runtime env limits, and IPC/WebSocket methods for reading and saving env vars.
- Replace terminal env schema with the shared runtime environment schema and add shared helpers for merging and resolving env contexts.
- Add a vault key file under the server state directory and AES-GCM payload handling for stored secrets.

## Testing
- Not run (`bun fmt`)
- Not run (`bun lint`)
- Not run (`bun typecheck`)