### PR TITLE
Add preview history controls and favorites

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import type { ContextMenuItem } from "@okcode/contracts";
 import { NetService } from "@okcode/shared/Net";
 import { RotatingFileSink } from "@okcode/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { createClosedPreviewState } from "./preview";
 import { DesktopPreviewController } from "./previewController";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
@@ -63,6 +64,8 @@ const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
 const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
+const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
+const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
@@ -1299,6 +1302,20 @@ function registerIpcHandlers(): void {
     getPreviewController(window).close();
   });
 
+  ipcMain.removeHandler(PREVIEW_GO_BACK_CHANNEL);
+  ipcMain.handle(PREVIEW_GO_BACK_CHANNEL, async (event) => {
+    const window = resolvePreviewWindow(event.sender);
+    if (!window) return;
+    getPreviewController(window).goBack();
+  });
+
+  ipcMain.removeHandler(PREVIEW_GO_FORWARD_CHANNEL);
+  ipcMain.handle(PREVIEW_GO_FORWARD_CHANNEL, async (event) => {
+    const window = resolvePreviewWindow(event.sender);
+    if (!window) return;
+    getPreviewController(window).goForward();
+  });
+
   ipcMain.removeHandler(PREVIEW_RELOAD_CHANNEL);
   ipcMain.handle(PREVIEW_RELOAD_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
@@ -1324,13 +1341,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle(PREVIEW_GET_STATE_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) {
-      return {
-        status: "closed",
-        url: null,
-        title: null,
-        visible: false,
-        error: null,
-      } satisfies DesktopPreviewState;
+      return createClosedPreviewState();
     }
     return getPreviewController(window).getState();
   });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -15,6 +15,8 @@ const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
 const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
+const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
+const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
@@ -59,6 +61,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   preview: {
     open: (input) => ipcRenderer.invoke(PREVIEW_OPEN_CHANNEL, input),
     close: () => ipcRenderer.invoke(PREVIEW_CLOSE_CHANNEL),
+    goBack: () => ipcRenderer.invoke(PREVIEW_GO_BACK_CHANNEL),
+    goForward: () => ipcRenderer.invoke(PREVIEW_GO_FORWARD_CHANNEL),
     reload: () => ipcRenderer.invoke(PREVIEW_RELOAD_CHANNEL),
     navigate: (input) => ipcRenderer.invoke(PREVIEW_NAVIGATE_CHANNEL, input),
     getState: () => ipcRenderer.invoke(PREVIEW_GET_STATE_CHANNEL),

--- a/apps/desktop/src/preview.test.ts
+++ b/apps/desktop/src/preview.test.ts
@@ -111,6 +111,8 @@ describe("preview state helpers", () => {
       title: null,
       visible: false,
       error: null,
+      canGoBack: false,
+      canGoForward: false,
     });
 
     expect(
@@ -126,6 +128,8 @@ describe("preview state helpers", () => {
         code: "load-failed",
         message: "Dev server did not respond.",
       },
+      canGoBack: false,
+      canGoForward: false,
     });
   });
 });

--- a/apps/desktop/src/preview.ts
+++ b/apps/desktop/src/preview.ts
@@ -16,6 +16,8 @@ const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
   title: null,
   visible: false,
   error: null,
+  canGoBack: false,
+  canGoForward: false,
 };
 
 function makePreviewError(code: DesktopPreviewErrorCode, message: string): DesktopPreviewError {
@@ -37,6 +39,8 @@ export function createPreviewErrorState(
     title: partial?.title ?? null,
     visible: false,
     error: makePreviewError(code, message),
+    canGoBack: false,
+    canGoForward: false,
   };
 }
 

--- a/apps/desktop/src/previewController.test.ts
+++ b/apps/desktop/src/previewController.test.ts
@@ -1,0 +1,249 @@
+import type { BrowserWindow } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openExternalMock, viewInstances, FakeWebContentsView } = vi.hoisted(() => {
+  const openExternalMock = vi.fn();
+  const viewInstances: Array<{ webContents: unknown }> = [];
+
+  class FakeWebContents {
+    private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    private history: string[] = [];
+    private historyIndex = -1;
+    private destroyed = false;
+    private windowOpenHandler: ((details: { url: string }) => { action: "allow" | "deny" }) | null =
+      null;
+
+    private addListener(event: string, listener: (...args: unknown[]) => void): void {
+      const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+
+    on = (event: string, listener: (...args: unknown[]) => void) => {
+      this.addListener(event, listener);
+      return this;
+    };
+
+    once = (event: string, listener: (...args: unknown[]) => void) => {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        listener(...args);
+      };
+      this.addListener(event, wrapped);
+      return this;
+    };
+
+    off = (event: string, listener: (...args: unknown[]) => void) => {
+      const listeners = this.listeners.get(event);
+      listeners?.delete(listener);
+      if (listeners && listeners.size === 0) {
+        this.listeners.delete(event);
+      }
+      return this;
+    };
+
+    removeAllListeners = (event?: string) => {
+      if (typeof event === "string") {
+        this.listeners.delete(event);
+      } else {
+        this.listeners.clear();
+      }
+      return this;
+    };
+
+    emit = (event: string, ...args: unknown[]) => {
+      const listeners = [...(this.listeners.get(event) ?? [])];
+      for (const listener of listeners) {
+        listener(...args);
+      }
+      return listeners.length > 0;
+    };
+
+    loadURL = vi.fn(async (url: string) => {
+      if (this.destroyed) {
+        throw new Error("webContents destroyed");
+      }
+
+      const nextUrl = new URL(url).toString();
+      if (this.historyIndex < this.history.length - 1) {
+        this.history = this.history.slice(0, this.historyIndex + 1);
+      }
+      this.history.push(nextUrl);
+      this.historyIndex = this.history.length - 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, nextUrl);
+      this.emit(
+        "page-title-updated",
+        { preventDefault: () => undefined },
+        `Page ${this.historyIndex + 1}`,
+      );
+      this.emit("did-stop-loading");
+    });
+
+    reload = vi.fn(() => {
+      if (this.destroyed || this.historyIndex < 0) {
+        return;
+      }
+      this.emit("did-start-loading");
+      this.emit("did-stop-loading");
+    });
+
+    goBack = vi.fn(() => {
+      if (!this.canGoBack()) {
+        return;
+      }
+      this.historyIndex -= 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, this.getURL());
+      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+      this.emit("did-stop-loading");
+    });
+
+    goForward = vi.fn(() => {
+      if (!this.canGoForward()) {
+        return;
+      }
+      this.historyIndex += 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, this.getURL());
+      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+      this.emit("did-stop-loading");
+    });
+
+    setWindowOpenHandler = vi.fn(
+      (handler: ((details: { url: string }) => { action: "allow" | "deny" }) | null) => {
+        this.windowOpenHandler = handler;
+        return { action: "deny" as const };
+      },
+    );
+
+    isDestroyed = vi.fn(() => this.destroyed);
+
+    getURL = vi.fn(() => this.history[this.historyIndex] ?? "");
+
+    getTitle = vi.fn(() => (this.historyIndex >= 0 ? `Page ${this.historyIndex + 1}` : ""));
+
+    canGoBack = vi.fn(() => this.historyIndex > 0);
+
+    canGoForward = vi.fn(
+      () => this.historyIndex >= 0 && this.historyIndex < this.history.length - 1,
+    );
+
+    close = vi.fn(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.destroyed = true;
+      this.emit("destroyed");
+    });
+  }
+
+  class FakeWebContentsView {
+    webContents = new FakeWebContents();
+    setBorderRadius = vi.fn();
+    setBounds = vi.fn();
+
+    constructor(_options: unknown) {
+      viewInstances.push(this);
+    }
+  }
+
+  return { openExternalMock, viewInstances, FakeWebContentsView };
+});
+
+vi.mock("electron", () => ({
+  shell: {
+    openExternal: openExternalMock,
+  },
+  WebContentsView: FakeWebContentsView,
+}));
+
+import { DesktopPreviewController } from "./previewController";
+
+function createWindow() {
+  return {
+    contentView: {
+      addChildView: vi.fn(),
+      removeChildView: vi.fn(),
+    },
+    getContentBounds: () => ({
+      x: 0,
+      y: 0,
+      width: 1024,
+      height: 768,
+    }),
+  } as unknown as BrowserWindow;
+}
+
+describe("DesktopPreviewController", () => {
+  beforeEach(() => {
+    openExternalMock.mockReset();
+    viewInstances.length = 0;
+  });
+
+  it("keeps browser history across open calls and exposes back/forward state", async () => {
+    let latestState = null as ReturnType<DesktopPreviewController["getState"]> | null;
+    const window = createWindow();
+    const controller = new DesktopPreviewController(window, (state) => {
+      latestState = state;
+    });
+
+    controller.setBounds({
+      x: 0,
+      y: 0,
+      width: 960,
+      height: 640,
+      visible: true,
+      viewportWidth: 1024,
+      viewportHeight: 768,
+    });
+
+    await controller.open({ url: "http://localhost:3000/", title: "Project preview" });
+    expect(viewInstances).toHaveLength(1);
+    expect(latestState).toMatchObject({
+      status: "ready",
+      url: "http://localhost:3000/",
+      canGoBack: false,
+      canGoForward: false,
+    });
+
+    await controller.open({ url: "http://localhost:3000/docs", title: "Project preview" });
+    expect(viewInstances).toHaveLength(1);
+    expect(latestState).toMatchObject({
+      status: "ready",
+      url: "http://localhost:3000/docs",
+      canGoBack: true,
+      canGoForward: false,
+    });
+
+    controller.goBack();
+    expect(latestState).toMatchObject({
+      status: "ready",
+      url: "http://localhost:3000/",
+      canGoBack: false,
+      canGoForward: true,
+    });
+
+    controller.goForward();
+    expect(latestState).toMatchObject({
+      status: "ready",
+      url: "http://localhost:3000/docs",
+      canGoBack: true,
+      canGoForward: false,
+    });
+
+    controller.close();
+    expect(latestState).toMatchObject({
+      status: "closed",
+      url: null,
+      canGoBack: false,
+      canGoForward: false,
+    });
+    expect(controller.getState()).toMatchObject({
+      status: "closed",
+      canGoBack: false,
+      canGoForward: false,
+    });
+    expect(window.contentView.removeChildView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/previewController.ts
+++ b/apps/desktop/src/previewController.ts
@@ -24,7 +24,16 @@ const ABORTED_LOAD_ERROR_CODE = -3;
 const NAVIGATION_BLOCKED_MESSAGE = "Blocked navigation outside the local preview policy.";
 const PROCESS_GONE_MESSAGE = "Preview process exited unexpectedly.";
 
-function previewVisible(state: DesktopPreviewState, bounds: DesktopPreviewBounds): boolean {
+type DesktopPreviewStateDraft = Omit<
+  DesktopPreviewState,
+  "visible" | "canGoBack" | "canGoForward"
+> &
+  Partial<Pick<DesktopPreviewState, "visible" | "canGoBack" | "canGoForward">>;
+
+function previewVisible(
+  state: Pick<DesktopPreviewState, "status">,
+  bounds: DesktopPreviewBounds,
+): boolean {
   return bounds.visible && state.status !== "closed";
 }
 
@@ -71,16 +80,7 @@ export class DesktopPreviewController {
       status: "loading",
       url: validatedUrl.url,
       title: nextTitle ?? this.state.title,
-      visible: previewVisible(
-        {
-          status: "loading",
-          url: validatedUrl.url,
-          title: nextTitle ?? this.state.title,
-          visible: this.state.visible,
-          error: null,
-        },
-        this.bounds,
-      ),
+      visible: previewVisible({ status: "loading" }, this.bounds),
       error: null,
     });
 
@@ -116,6 +116,24 @@ export class DesktopPreviewController {
       accepted: result.accepted,
       state: result.state,
     };
+  }
+
+  goBack(): void {
+    const view = this.view;
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoBack()) {
+      return;
+    }
+
+    view.webContents.goBack();
+  }
+
+  goForward(): void {
+    const view = this.view;
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoForward()) {
+      return;
+    }
+
+    view.webContents.goForward();
   }
 
   reload(): void {
@@ -309,9 +327,25 @@ export class DesktopPreviewController {
     this.disposingView = false;
   }
 
-  private setState(nextState: DesktopPreviewState): void {
+  private currentNavigationState(): Pick<DesktopPreviewState, "canGoBack" | "canGoForward"> {
+    const webContents = this.view?.webContents;
+    if (!webContents || webContents.isDestroyed()) {
+      return {
+        canGoBack: false,
+        canGoForward: false,
+      };
+    }
+
+    return {
+      canGoBack: webContents.canGoBack(),
+      canGoForward: webContents.canGoForward(),
+    };
+  }
+
+  private setState(nextState: DesktopPreviewStateDraft): void {
     this.state = {
       ...nextState,
+      ...this.currentNavigationState(),
       visible: previewVisible(nextState, this.bounds),
     };
     this.onStateChange(this.state);

--- a/apps/web/src/components/PreviewPanel.test.ts
+++ b/apps/web/src/components/PreviewPanel.test.ts
@@ -11,6 +11,8 @@ describe("resolvePreviewStatusCopy", () => {
         title: null,
         visible: false,
         error: null,
+        canGoBack: false,
+        canGoForward: false,
       }),
     ).toContain("Enter a URL");
 
@@ -21,6 +23,8 @@ describe("resolvePreviewStatusCopy", () => {
         title: null,
         visible: true,
         error: null,
+        canGoBack: false,
+        canGoForward: false,
       }),
     ).toContain("Loading");
 
@@ -31,6 +35,8 @@ describe("resolvePreviewStatusCopy", () => {
         title: "App",
         visible: true,
         error: null,
+        canGoBack: true,
+        canGoForward: false,
       }),
     ).toContain("http://localhost:3000/");
   });
@@ -46,6 +52,8 @@ describe("resolvePreviewStatusCopy", () => {
           code: "load-failed",
           message: "Dev server did not respond.",
         },
+        canGoBack: false,
+        canGoForward: false,
       }),
     ).toBe("Dev server did not respond.");
   });

--- a/apps/web/src/components/PreviewPanel.tsx
+++ b/apps/web/src/components/PreviewPanel.tsx
@@ -2,21 +2,24 @@ import type { DesktopPreviewState, ProjectId, ThreadId } from "@okcode/contracts
 import { type FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   CircleAlertIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   ExternalLinkIcon,
-  EllipsisIcon,
+  GlobeIcon,
   LoaderCircleIcon,
   RefreshCwIcon,
+  StarIcon,
   XIcon,
 } from "lucide-react";
 
-import { readDesktopPreviewBridge } from "~/desktopPreview";
 import { validateHttpPreviewUrl } from "@okcode/shared/preview";
+import { readDesktopPreviewBridge } from "~/desktopPreview";
+import { cn } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { usePreviewStateStore } from "~/previewStateStore";
 
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 
 const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
   status: "closed",
@@ -24,6 +27,8 @@ const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
   title: null,
   visible: false,
   error: null,
+  canGoBack: false,
+  canGoForward: false,
 };
 
 const HIDDEN_PREVIEW_BOUNDS = {
@@ -63,16 +68,25 @@ interface PreviewPanelProps {
 export function PreviewPanel({ threadId, projectId, projectName, onClose }: PreviewPanelProps) {
   const previewBridge = readDesktopPreviewBridge();
   const storedUrl = usePreviewStateStore((state) => state.urlByProjectId[projectId] ?? "");
+  const favoriteUrl = usePreviewStateStore(
+    (state) => state.favoriteUrlByProjectId[projectId] ?? "",
+  );
   const setProjectUrl = usePreviewStateStore((state) => state.setProjectUrl);
+  const toggleProjectFavorite = usePreviewStateStore((state) => state.toggleProjectFavorite);
   const setThreadOpen = usePreviewStateStore((state) => state.setThreadOpen);
   const [inputUrl, setInputUrl] = useState(storedUrl);
   const [inputError, setInputError] = useState<string | null>(null);
   const [previewState, setPreviewState] = useState<DesktopPreviewState>(CLOSED_PREVIEW_STATE);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const projectNameRef = useRef(projectName);
 
   useEffect(() => {
     setInputUrl(storedUrl);
   }, [storedUrl, projectId]);
+
+  useEffect(() => {
+    projectNameRef.current = projectName;
+  }, [projectName]);
 
   useEffect(() => {
     if (!previewBridge) {
@@ -110,11 +124,9 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
       .setBounds(HIDDEN_PREVIEW_BOUNDS)
       .catch(() => undefined)
       .finally(() => {
-        void previewBridge.close().finally(() => {
-          void previewBridge.open({ url: storedUrl, title: `${projectName} preview` });
-        });
+        void previewBridge.open({ url: storedUrl, title: `${projectNameRef.current} preview` });
       });
-  }, [previewBridge, projectName, storedUrl, threadId]);
+  }, [previewBridge, storedUrl]);
 
   useEffect(() => {
     return () => {
@@ -242,51 +254,96 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
   };
 
   const showEmbeddedSurface = previewState.status === "loading" || previewState.status === "ready";
+  const currentPageUrl = previewState.url;
+  const isFavorite = currentPageUrl !== null && favoriteUrl === currentPageUrl;
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-background">
-      <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-        <p
-          className="truncate text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/75"
-          title={projectName}
-        >
-          Preview
-        </p>
-        <div className="flex items-center gap-1">
-          <Menu>
-            <MenuTrigger
-              render={
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-                  aria-label="Preview actions"
-                />
-              }
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Back"
+            onClick={() => {
+              void previewBridge?.goBack();
+            }}
+            disabled={!previewBridge || !previewState.canGoBack}
+          >
+            <ChevronLeftIcon className="size-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Forward"
+            onClick={() => {
+              void previewBridge?.goForward();
+            }}
+            disabled={!previewBridge || !previewState.canGoForward}
+          >
+            <ChevronRightIcon className="size-3.5" />
+          </Button>
+          <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
+          <div className="min-w-0">
+            <p
+              className="truncate text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/75"
+              title={projectName}
             >
-              <EllipsisIcon aria-hidden="true" className="size-3.5" />
-            </MenuTrigger>
-            <MenuPopup align="end">
-              <MenuItem
-                onClick={() => {
-                  setInputError(null);
-                  void previewBridge?.reload();
-                }}
-                disabled={!showEmbeddedSurface}
-              >
-                <RefreshCwIcon aria-hidden="true" className="size-4" />
-                Reload
-              </MenuItem>
-              <MenuItem
-                onClick={onOpenExternal}
-                disabled={!previewState.url && storedUrl.trim().length === 0}
-              >
-                <ExternalLinkIcon aria-hidden="true" className="size-4" />
-                Open in browser
-              </MenuItem>
-            </MenuPopup>
-          </Menu>
+              Preview
+            </p>
+            <p className="truncate text-[11px] text-muted-foreground/65">{projectName}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className={cn(
+              "text-muted-foreground/55 hover:bg-transparent hover:text-foreground",
+              isFavorite ? "text-amber-500 hover:text-amber-500" : undefined,
+            )}
+            aria-label={isFavorite ? "Remove favorite" : "Favorite current page"}
+            aria-pressed={isFavorite}
+            onClick={() => {
+              if (!currentPageUrl) {
+                return;
+              }
+              toggleProjectFavorite(projectId, currentPageUrl);
+            }}
+            disabled={!previewBridge || currentPageUrl === null}
+          >
+            <StarIcon className={cn("size-3.5", isFavorite ? "fill-current" : "")} />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Reload preview"
+            onClick={() => {
+              setInputError(null);
+              void previewBridge?.reload();
+            }}
+            disabled={!showEmbeddedSurface}
+          >
+            <RefreshCwIcon className="size-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Open preview externally"
+            onClick={onOpenExternal}
+            disabled={!previewState.url && storedUrl.trim().length === 0}
+          >
+            <ExternalLinkIcon className="size-3.5" />
+          </Button>
           <Button
             type="button"
             size="icon-xs"

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -1,0 +1,53 @@
+import { ProjectId } from "@okcode/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "okcode:desktop-preview:v2";
+
+let usePreviewStateStore: typeof import("./previewStateStore").usePreviewStateStore;
+let storage: Map<string, string>;
+
+describe("previewStateStore", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    storage = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        clear: () => {
+          storage.clear();
+        },
+      },
+    } as Window);
+
+    ({ usePreviewStateStore } = await import("./previewStateStore"));
+    usePreviewStateStore.setState({
+      openByThreadId: {},
+      dockByThreadId: {},
+      sizeByThreadId: {},
+      urlByProjectId: {},
+      favoriteUrlByProjectId: {},
+    });
+    storage.clear();
+  });
+
+  it("persists and clears the project favorite URL", () => {
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const store = usePreviewStateStore.getState();
+
+    store.setProjectFavoriteUrl(projectId, "http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBe(
+      "http://localhost:3000/",
+    );
+    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId"');
+
+    store.toggleProjectFavorite(projectId, "http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBeUndefined();
+    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId":{}');
+  });
+});

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -8,6 +8,7 @@ interface PersistedPreviewUiState {
   dockByThreadId: Record<string, PreviewDock>;
   sizeByThreadId: Record<string, number>;
   urlByProjectId: Record<string, string>;
+  favoriteUrlByProjectId: Record<string, string>;
 }
 
 interface PreviewStateStore extends PersistedPreviewUiState {
@@ -17,9 +18,54 @@ interface PreviewStateStore extends PersistedPreviewUiState {
   toggleThreadLayout: (threadId: ThreadId) => void;
   setThreadSize: (threadId: ThreadId, size: number) => void;
   setProjectUrl: (projectId: ProjectId, url: string) => void;
+  setProjectFavoriteUrl: (projectId: ProjectId, url: string | null) => void;
+  toggleProjectFavorite: (projectId: ProjectId, url: string) => void;
 }
 
 const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v2";
+
+function createEmptyPersistedPreviewUiState(): PersistedPreviewUiState {
+  return {
+    openByThreadId: {},
+    dockByThreadId: {},
+    sizeByThreadId: {},
+    urlByProjectId: {},
+    favoriteUrlByProjectId: {},
+  };
+}
+
+function snapshotPreviewUiState(state: {
+  openByThreadId: PersistedPreviewUiState["openByThreadId"];
+  dockByThreadId: PersistedPreviewUiState["dockByThreadId"];
+  sizeByThreadId: PersistedPreviewUiState["sizeByThreadId"];
+  urlByProjectId: PersistedPreviewUiState["urlByProjectId"];
+  favoriteUrlByProjectId: PersistedPreviewUiState["favoriteUrlByProjectId"];
+}): PersistedPreviewUiState {
+  return {
+    openByThreadId: state.openByThreadId,
+    dockByThreadId: state.dockByThreadId,
+    sizeByThreadId: state.sizeByThreadId,
+    urlByProjectId: state.urlByProjectId,
+    favoriteUrlByProjectId: state.favoriteUrlByProjectId,
+  };
+}
+
+function normalizeUrlRecord(record: unknown): Record<string, string> {
+  if (!record || typeof record !== "object") {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).flatMap(([key, value]) => {
+      if (typeof key !== "string" || typeof value !== "string") {
+        return [];
+      }
+
+      const normalizedValue = value.trim();
+      return normalizedValue.length > 0 ? [[key, normalizedValue] as const] : [];
+    }),
+  );
+}
 
 function normalizePreviewSize(size: unknown): number | null {
   if (typeof size !== "number" || !Number.isFinite(size)) {
@@ -30,13 +76,13 @@ function normalizePreviewSize(size: unknown): number | null {
 
 function readPersistedPreviewUiState(): PersistedPreviewUiState {
   if (typeof window === "undefined") {
-    return { openByThreadId: {}, dockByThreadId: {}, sizeByThreadId: {}, urlByProjectId: {} };
+    return createEmptyPersistedPreviewUiState();
   }
 
   try {
     const raw = window.localStorage.getItem(PREVIEW_STATE_STORAGE_KEY);
     if (!raw) {
-      return { openByThreadId: {}, dockByThreadId: {}, sizeByThreadId: {}, urlByProjectId: {} };
+      return createEmptyPersistedPreviewUiState();
     }
 
     const parsed = JSON.parse(raw) as Partial<PersistedPreviewUiState>;
@@ -74,20 +120,11 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
               }),
             )
           : {},
-      urlByProjectId:
-        parsed.urlByProjectId && typeof parsed.urlByProjectId === "object"
-          ? Object.fromEntries(
-              Object.entries(parsed.urlByProjectId).filter(
-                (entry): entry is [string, string] =>
-                  typeof entry[0] === "string" &&
-                  typeof entry[1] === "string" &&
-                  entry[1].trim().length > 0,
-              ),
-            )
-          : {},
+      urlByProjectId: normalizeUrlRecord(parsed.urlByProjectId),
+      favoriteUrlByProjectId: normalizeUrlRecord(parsed.favoriteUrlByProjectId),
     };
   } catch {
-    return { openByThreadId: {}, dockByThreadId: {}, sizeByThreadId: {}, urlByProjectId: {} };
+    return createEmptyPersistedPreviewUiState();
   }
 }
 
@@ -104,6 +141,7 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
         dockByThreadId: state.dockByThreadId,
         sizeByThreadId: state.sizeByThreadId,
         urlByProjectId: state.urlByProjectId,
+        favoriteUrlByProjectId: state.favoriteUrlByProjectId,
       } satisfies PersistedPreviewUiState),
     );
   } catch {
@@ -122,12 +160,12 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.openByThreadId,
         [threadId]: open,
       };
-      persistPreviewUiState({
-        openByThreadId: nextOpenByThreadId,
-        dockByThreadId: state.dockByThreadId,
-        sizeByThreadId: state.sizeByThreadId,
-        urlByProjectId: state.urlByProjectId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          openByThreadId: nextOpenByThreadId,
+        }),
+      );
       return { openByThreadId: nextOpenByThreadId };
     });
   },
@@ -143,12 +181,12 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.dockByThreadId,
         [threadId]: dock,
       };
-      persistPreviewUiState({
-        openByThreadId: state.openByThreadId,
-        dockByThreadId: nextDockByThreadId,
-        sizeByThreadId: state.sizeByThreadId,
-        urlByProjectId: state.urlByProjectId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          dockByThreadId: nextDockByThreadId,
+        }),
+      );
       return { dockByThreadId: nextDockByThreadId };
     });
   },
@@ -177,12 +215,12 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.sizeByThreadId,
         [threadId]: normalizedSize,
       };
-      persistPreviewUiState({
-        openByThreadId: state.openByThreadId,
-        dockByThreadId: state.dockByThreadId,
-        sizeByThreadId: nextSizeByThreadId,
-        urlByProjectId: state.urlByProjectId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          sizeByThreadId: nextSizeByThreadId,
+        }),
+      );
       return { sizeByThreadId: nextSizeByThreadId };
     });
   },
@@ -196,13 +234,45 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
       } else {
         delete nextUrlByProjectId[projectId];
       }
-      persistPreviewUiState({
-        openByThreadId: state.openByThreadId,
-        dockByThreadId: state.dockByThreadId,
-        sizeByThreadId: state.sizeByThreadId,
-        urlByProjectId: nextUrlByProjectId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          urlByProjectId: nextUrlByProjectId,
+        }),
+      );
       return { urlByProjectId: nextUrlByProjectId };
     });
+  },
+
+  setProjectFavoriteUrl: (projectId, url) => {
+    const normalizedUrl = url?.trim() ?? "";
+    set((state) => {
+      const nextFavoriteUrlByProjectId = { ...state.favoriteUrlByProjectId };
+      if (normalizedUrl.length > 0) {
+        nextFavoriteUrlByProjectId[projectId] = normalizedUrl;
+      } else {
+        delete nextFavoriteUrlByProjectId[projectId];
+      }
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          favoriteUrlByProjectId: nextFavoriteUrlByProjectId,
+        }),
+      );
+      return { favoriteUrlByProjectId: nextFavoriteUrlByProjectId };
+    });
+  },
+
+  toggleProjectFavorite: (projectId, url) => {
+    const normalizedUrl = url.trim();
+    if (normalizedUrl.length === 0) {
+      return;
+    }
+
+    const currentFavoriteUrl = get().favoriteUrlByProjectId[projectId] ?? null;
+    get().setProjectFavoriteUrl(
+      projectId,
+      currentFavoriteUrl === normalizedUrl ? null : normalizedUrl,
+    );
   },
 }));

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -161,6 +161,8 @@ export interface DesktopPreviewState {
   title: string | null;
   visible: boolean;
   error: DesktopPreviewError | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
 }
 
 export interface PreviewOpenResult {
@@ -193,6 +195,8 @@ export interface DesktopBridge {
   preview: {
     open: (input: { url: string; title?: string | null }) => Promise<PreviewOpenResult>;
     close: () => Promise<void>;
+    goBack: () => Promise<void>;
+    goForward: () => Promise<void>;
     reload: () => Promise<void>;
     navigate: (input: { url: string }) => Promise<PreviewNavigateResult>;
     getState: () => Promise<DesktopPreviewState>;


### PR DESCRIPTION
## Summary
- Added back/forward navigation support to the desktop preview bridge, IPC handlers, and controller state.
- Extended preview state to track browser history availability so the web UI can enable or disable navigation controls predictably.
- Added per-project favorite preview URLs with persistence in the web preview state store.
- Updated the preview panel UI to show back/forward and favorite actions.
- Added tests covering desktop preview history behavior and preview state persistence.

## Testing
- Not run (changes were prepared from the diff only).
- Added/updated unit coverage for `previewController`, `previewStateStore`, and `PreviewPanel` state copy.