### PR TITLE
Add PR-specific actions to the git menu

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -7,17 +7,17 @@
 
 ## 1. Brand Identity
 
-| Property                  | Value                                  |
-| ------------------------- | -------------------------------------- |
-| **App Name**              | OK Code                                |
-| **Stage Label**           | Dev (development only)                 |
-| **Display Name**          | OK Code                                |
-| **Version**               | 0.0.1                                  |
-| **Tagline**               | `[TBD]`                                |
-| **One-liner Description** | `[TBD]`                                |
-| **Parent Organization**   | OpenKnots                              |
-| **Website URL**           | `[TBD]`                                |
-| **Repository**            | `OpenKnots/okcode`                     |
+| Property                  | Value                  |
+| ------------------------- | ---------------------- |
+| **App Name**              | OK Code                |
+| **Stage Label**           | Dev (development only) |
+| **Display Name**          | OK Code                |
+| **Version**               | 0.0.1                  |
+| **Tagline**               | `[TBD]`                |
+| **One-liner Description** | `[TBD]`                |
+| **Parent Organization**   | OpenKnots              |
+| **Website URL**           | `[TBD]`                |
+| **Repository**            | `OpenKnots/okcode`     |
 
 ### Brand Voice & Tone
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, it } from "vitest";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  buildPullRequestMenuItems,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
@@ -47,7 +48,28 @@ describe("when: branch is clean and has an open PR", () => {
       }),
       false,
     );
-    assert.deepInclude(quick, { kind: "open_pr", label: "View PR", disabled: false });
+    assert.deepInclude(quick, { kind: "open_pr", label: "View PR #10", disabled: false });
+  });
+
+  it("buildPullRequestMenuItems exposes PR handling actions", () => {
+    const items = buildPullRequestMenuItems(
+      status({
+        pr: {
+          number: 10,
+          title: "Open PR",
+          url: "https://example.com/pr/10",
+          baseBranch: "main",
+          headBranch: "feature/test",
+          state: "open",
+        },
+      }),
+    );
+
+    assert.deepEqual(items, [
+      { id: "open_in_browser", label: "Open in browser" },
+      { id: "copy_pr_number", label: "Copy PR number" },
+      { id: "copy_pr_link", label: "Copy PR link" },
+    ]);
   });
 
   it("buildMenuItems disables commit/push and enables open PR", () => {
@@ -83,7 +105,7 @@ describe("when: branch is clean and has an open PR", () => {
       },
       {
         id: "pr",
-        label: "View PR",
+        label: "View PR #11",
         disabled: false,
         icon: "pr",
         kind: "open_pr",
@@ -242,7 +264,7 @@ describe("when: branch is clean, ahead, and has an open PR", () => {
       },
       {
         id: "pr",
-        label: "View PR",
+        label: "View PR #12",
         disabled: false,
         icon: "pr",
         kind: "open_pr",
@@ -684,7 +706,7 @@ describe("when: branch has no upstream configured", () => {
     );
     assert.deepInclude(quick, {
       kind: "open_pr",
-      label: "View PR",
+      label: "View PR #14",
       disabled: false,
     });
   });

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -18,6 +18,13 @@ export interface GitActionMenuItem {
   dialogAction?: GitDialogAction;
 }
 
+export type GitPullRequestMenuItemId = "open_in_browser" | "copy_pr_number" | "copy_pr_link";
+
+export interface GitPullRequestMenuItem {
+  id: GitPullRequestMenuItemId;
+  label: string;
+}
+
 export interface GitQuickAction {
   label: string;
   disabled: boolean;
@@ -60,6 +67,10 @@ function truncateText(
   return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
 }
 
+export function formatOpenPullRequestLabel(prNumber: number | undefined): string {
+  return prNumber ? `View PR #${prNumber}` : "View PR";
+}
+
 export function buildGitActionProgressStages(input: {
   action: GitStackedAction;
   hasCustomCommitMessage: boolean;
@@ -88,6 +99,18 @@ export function buildGitActionProgressStages(input: {
 
 const withDescription = (title: string, description: string | undefined) =>
   description ? { title, description } : { title };
+
+export function buildPullRequestMenuItems(
+  gitStatus: GitStatusResult | null,
+): GitPullRequestMenuItem[] {
+  if (gitStatus?.pr?.state !== "open") return [];
+
+  return [
+    { id: "open_in_browser", label: "Open in browser" },
+    { id: "copy_pr_number", label: "Copy PR number" },
+    { id: "copy_pr_link", label: "Copy PR link" },
+  ];
+}
 
 export function summarizeGitResult(result: GitRunStackedActionResult): {
   title: string;
@@ -192,7 +215,7 @@ export function buildMenuItems(
     hasOpenPr
       ? {
           id: "pr",
-          label: "View PR",
+          label: formatOpenPullRequestLabel(gitStatus.pr?.number),
           disabled: !canOpenPr,
           icon: "pr",
           kind: "open_pr",
@@ -274,7 +297,11 @@ export function resolveQuickAction(
   if (!gitStatus.hasUpstream) {
     if (!hasOriginRemote) {
       if (hasOpenPr && !isAhead) {
-        return { label: "View PR", disabled: false, kind: "open_pr" };
+        return {
+          label: formatOpenPullRequestLabel(gitStatus.pr?.number),
+          disabled: false,
+          kind: "open_pr",
+        };
       }
       return {
         label: "Push",
@@ -285,7 +312,11 @@ export function resolveQuickAction(
     }
     if (!isAhead) {
       if (hasOpenPr) {
-        return { label: "View PR", disabled: false, kind: "open_pr" };
+        return {
+          label: formatOpenPullRequestLabel(gitStatus.pr?.number),
+          disabled: false,
+          kind: "open_pr",
+        };
       }
       return {
         label: "Push",
@@ -335,7 +366,11 @@ export function resolveQuickAction(
   }
 
   if (hasOpenPr && gitStatus.hasUpstream) {
-    return { label: "View PR", disabled: false, kind: "open_pr" };
+    return {
+      label: formatOpenPullRequestLabel(gitStatus.pr?.number),
+      disabled: false,
+      kind: "open_pr",
+    };
   }
 
   return {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -16,13 +16,16 @@ import {
   CircleAlertIcon,
   CloudUploadIcon,
   ExternalLinkIcon,
+  CopyIcon,
   GitCommitIcon,
   InfoIcon,
+  LinkIcon,
 } from "lucide-react";
 import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
   buildMenuItems,
+  buildPullRequestMenuItems,
   type GitActionIconName,
   type GitActionMenuItem,
   type GitQuickAction,
@@ -32,6 +35,7 @@ import {
   resolveGitFailureRetryLabel,
   resolveQuickAction,
   resolveSyncAction,
+  formatOpenPullRequestLabel,
   summarizeGitFailure,
   summarizeGitResult,
 } from "./GitActionsControl.logic";
@@ -51,6 +55,7 @@ import {
 import { Group, GroupSeparator } from "~/components/ui/group";
 import {
   Menu,
+  MenuGroupLabel,
   MenuItem,
   MenuPopup,
   MenuSeparator,
@@ -63,6 +68,7 @@ import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Textarea } from "~/components/ui/textarea";
 import { toastManager } from "~/components/ui/toast";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { openInPreferredEditor } from "~/editorPreferences";
 import {
   gitBranchesQueryOptions,
@@ -232,7 +238,7 @@ function getMenuActionDisabledReason({
   }
 
   if (hasOpenPr) {
-    return "View PR is currently unavailable.";
+    return "PR is currently unavailable.";
   }
   if (!hasBranch) {
     return "Detached HEAD: checkout a branch before creating a PR.";
@@ -332,6 +338,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
   }, [isGitStatusOutOfSync, queryClient]);
 
   const gitStatusForActions = isGitStatusOutOfSync ? null : gitStatus;
+  const openPullRequest = gitStatusForActions?.pr?.state === "open" ? gitStatusForActions.pr : null;
 
   const allFiles = gitStatusForActions?.workingTree.files ?? [];
   const selectedFiles = allFiles.filter((f) => !excludedFiles.has(f.path));
@@ -364,6 +371,10 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasOriginRemote),
     [gitStatusForActions, hasOriginRemote, isGitActionRunning],
   );
+  const pullRequestMenuItems = useMemo(
+    () => buildPullRequestMenuItems(gitStatusForActions),
+    [gitStatusForActions],
+  );
   const quickAction = useMemo(
     () =>
       resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultBranch, hasOriginRemote),
@@ -386,6 +397,29 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         includesCommit: pendingDefaultBranchAction.includesCommit,
       })
     : null;
+
+  const { copyToClipboard: copyPullRequestValue } = useCopyToClipboard<{
+    successTitle: string;
+    successDescription: string;
+    errorTitle: string;
+  }>({
+    onCopy: (ctx) => {
+      toastManager.add({
+        type: "success",
+        title: ctx.successTitle,
+        description: ctx.successDescription,
+        data: threadToastData,
+      });
+    },
+    onError: (error, ctx) => {
+      toastManager.add({
+        type: "error",
+        title: ctx.errorTitle,
+        description: error instanceof Error ? error.message : "An error occurred.",
+        data: threadToastData,
+      });
+    },
+  });
 
   useEffect(() => {
     const api = readNativeApi();
@@ -478,7 +512,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
       });
       return;
     }
-    const prUrl = gitStatusForActions?.pr?.state === "open" ? gitStatusForActions.pr.url : null;
+    const prUrl = openPullRequest?.url ?? null;
     if (!prUrl) {
       toastManager.add({
         type: "error",
@@ -495,7 +529,26 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         data: threadToastData,
       });
     });
-  }, [gitStatusForActions, threadToastData]);
+  }, [openPullRequest, threadToastData]);
+
+  const copyOpenPullRequestNumber = useCallback(() => {
+    if (!openPullRequest) return;
+    const prNumber = `#${openPullRequest.number}`;
+    copyPullRequestValue(prNumber, {
+      successTitle: "PR number copied",
+      successDescription: prNumber,
+      errorTitle: "Failed to copy PR number",
+    });
+  }, [copyPullRequestValue, openPullRequest]);
+
+  const copyOpenPullRequestLink = useCallback(() => {
+    if (!openPullRequest) return;
+    copyPullRequestValue(openPullRequest.url, {
+      successTitle: "PR link copied",
+      successDescription: openPullRequest.url,
+      errorTitle: "Failed to copy PR link",
+    });
+  }, [copyPullRequestValue, openPullRequest]);
 
   const runGitActionWithToast = useEffectEvent(
     async ({
@@ -594,6 +647,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         const existingOpenPrUrl =
           actionStatus?.pr?.state === "open" ? actionStatus.pr.url : undefined;
         const prUrl = result.pr.url ?? existingOpenPrUrl;
+        const prNumber = result.pr.number ?? actionStatus?.pr?.number;
         const shouldOfferPushCta = action === "commit" && result.commit.status === "created";
         const shouldOfferOpenPrCta =
           (action === "commit_push" || action === "commit_push_pr") &&
@@ -637,7 +691,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
             : shouldOfferOpenPrCta
               ? {
                   actionProps: {
-                    children: "View PR",
+                    children: formatOpenPullRequestLabel(prNumber),
                     onClick: () => {
                       const api = readNativeApi();
                       if (!api) return;
@@ -1093,6 +1147,41 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
               <ChevronDownIcon aria-hidden="true" className="size-4" />
             </MenuTrigger>
             <MenuPopup align="end" className="w-full">
+              {openPullRequest && pullRequestMenuItems.length > 0 ? (
+                <>
+                  <MenuGroupLabel inset>PR #{openPullRequest.number}</MenuGroupLabel>
+                  {pullRequestMenuItems.map((item) => {
+                    if (item.id === "open_in_browser") {
+                      return (
+                        <MenuItem
+                          key={item.id}
+                          onClick={() => {
+                            void openExistingPr();
+                          }}
+                        >
+                          <ExternalLinkIcon className="size-3.5" />
+                          {item.label}
+                        </MenuItem>
+                      );
+                    }
+                    if (item.id === "copy_pr_number") {
+                      return (
+                        <MenuItem key={item.id} onClick={copyOpenPullRequestNumber}>
+                          <CopyIcon className="size-3.5" />
+                          {item.label}
+                        </MenuItem>
+                      );
+                    }
+                    return (
+                      <MenuItem key={item.id} onClick={copyOpenPullRequestLink}>
+                        <LinkIcon className="size-3.5" />
+                        {item.label}
+                      </MenuItem>
+                    );
+                  })}
+                  {gitActionMenuItems.length > 0 ? <MenuSeparator /> : null}
+                </>
+              ) : null}
               {gitActionMenuItems.map((item) => {
                 const disabledReason = getMenuActionDisabledReason({
                   item,

--- a/apps/web/src/themes.css
+++ b/apps/web/src/themes.css
@@ -242,4 +242,3 @@
   --warning: #f5c542;
   --warning-foreground: #e8b830;
 }
-

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -150,7 +150,7 @@ If narrowing to a stronger first shortlist, these feel the most distinctive:
 - **Solar Witch**
 - **Cursor Dark**
 - **Cathedral Circuit**
-These avoid the “just another editor theme” problem best.
+  These avoid the “just another editor theme” problem best.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a PR-specific section to the git actions menu when an open PR is available.
- Supports opening the PR in a browser, copying the PR number, and copying the PR link.
- Updates PR labels throughout the control to include the PR number, improving clarity in the quick action and menu.
- Adds and updates logic tests for the new PR menu items and label formatting.

## Testing
- Not run (not requested).
- Existing test coverage updated in `GitActionsControl.logic.test.ts` for open-PR labels and PR menu items.