### PR TITLE
Auto-archive projects and simplify preview state

### DIFF
--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -6,6 +6,7 @@ import type {
   ProjectId,
   ThreadId,
 } from "@okcode/contracts";
+import { MAX_PROJECTS, MAX_THREADS_PER_PROJECT } from "@okcode/contracts";
 import { Effect } from "effect";
 
 import { OrchestrationCommandInvariantError } from "./Errors.ts";
@@ -118,4 +119,55 @@ export function requireNonNegativeInteger(input: {
       `${input.field} must be an integer greater than or equal to 0.`,
     ),
   );
+}
+
+// ── Active entity helpers ────────────────────────────────────────────
+
+export function listActiveProjects(
+  readModel: OrchestrationReadModel,
+): ReadonlyArray<OrchestrationProject> {
+  return readModel.projects.filter((project) => project.deletedAt === null);
+}
+
+export function listActiveThreadsByProjectId(
+  readModel: OrchestrationReadModel,
+  projectId: ProjectId,
+): ReadonlyArray<OrchestrationThread> {
+  return readModel.threads.filter(
+    (thread) => thread.projectId === projectId && thread.deletedAt === null,
+  );
+}
+
+/**
+ * Returns the oldest active projects that must be archived to stay within
+ * MAX_PROJECTS when a new project is about to be created.
+ * Sorted by updatedAt ascending (oldest first).
+ */
+export function getProjectsToArchive(
+  readModel: OrchestrationReadModel,
+): ReadonlyArray<OrchestrationProject> {
+  const active = listActiveProjects(readModel);
+  if (active.length < MAX_PROJECTS) return [];
+  const overflow = active.length - MAX_PROJECTS + 1;
+  return [...active]
+    .toSorted((a, b) => a.updatedAt.localeCompare(b.updatedAt) || a.id.localeCompare(b.id))
+    .slice(0, overflow);
+}
+
+/**
+ * Returns the oldest active threads in the given project that must be
+ * archived to stay within MAX_THREADS_PER_PROJECT when a new thread is
+ * about to be created.
+ * Sorted by updatedAt ascending (oldest first).
+ */
+export function getThreadsToArchive(
+  readModel: OrchestrationReadModel,
+  projectId: ProjectId,
+): ReadonlyArray<OrchestrationThread> {
+  const active = listActiveThreadsByProjectId(readModel, projectId);
+  if (active.length < MAX_THREADS_PER_PROJECT) return [];
+  const overflow = active.length - MAX_THREADS_PER_PROJECT + 1;
+  return [...active]
+    .toSorted((a, b) => a.updatedAt.localeCompare(b.updatedAt) || a.id.localeCompare(b.id))
+    .slice(0, overflow);
 }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -7,6 +7,8 @@ import { Effect } from "effect";
 
 import { OrchestrationCommandInvariantError } from "./Errors.ts";
 import {
+  getProjectsToArchive,
+  getThreadsToArchive,
   requireProject,
   requireProjectAbsent,
   requireThread,
@@ -65,7 +67,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         projectId: command.projectId,
       });
 
-      return {
+      const projectCreatedEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...withEventBase({
           aggregateKind: "project",
           aggregateId: command.projectId,
@@ -83,6 +85,29 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           updatedAt: command.createdAt,
         },
       };
+
+      // Auto-archive oldest projects when limit is reached
+      const projectsToArchive = getProjectsToArchive(readModel);
+      if (projectsToArchive.length === 0) {
+        return projectCreatedEvent;
+      }
+
+      const archiveEvents: Omit<OrchestrationEvent, "sequence">[] = projectsToArchive.map(
+        (project) => ({
+          ...withEventBase({
+            aggregateKind: "project" as const,
+            aggregateId: project.id,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          }),
+          type: "project.deleted" as const,
+          payload: {
+            projectId: project.id,
+            deletedAt: command.createdAt,
+          },
+        }),
+      );
+      return [...archiveEvents, projectCreatedEvent];
     }
 
     case "project.meta.update": {
@@ -144,7 +169,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
-      return {
+
+      const threadCreatedEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
@@ -165,6 +191,29 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           updatedAt: command.createdAt,
         },
       };
+
+      // Auto-archive oldest threads in the project when limit is reached
+      const threadsToArchive = getThreadsToArchive(readModel, command.projectId);
+      if (threadsToArchive.length === 0) {
+        return threadCreatedEvent;
+      }
+
+      const archiveEvents: Omit<OrchestrationEvent, "sequence">[] = threadsToArchive.map(
+        (thread) => ({
+          ...withEventBase({
+            aggregateKind: "thread" as const,
+            aggregateId: thread.id,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          }),
+          type: "thread.deleted" as const,
+          payload: {
+            threadId: thread.id,
+            deletedAt: command.createdAt,
+          },
+        }),
+      );
+      return [...archiveEvents, threadCreatedEvent];
     }
 
     case "thread.delete": {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -91,6 +91,20 @@ export type ProviderApprovalDecision = typeof ProviderApprovalDecision.Type;
 export const ProviderUserInputAnswers = Schema.Record(Schema.String, Schema.Unknown);
 export type ProviderUserInputAnswers = typeof ProviderUserInputAnswers.Type;
 
+/**
+ * Maximum number of active (non-deleted) projects allowed.
+ * When this limit is reached, the oldest project is automatically archived
+ * (soft-deleted) to make room for the new one.
+ */
+export const MAX_PROJECTS = 50;
+
+/**
+ * Maximum number of active (non-deleted) threads allowed per project.
+ * When this limit is reached, the oldest thread in the project is
+ * automatically archived (soft-deleted) to make room for the new one.
+ */
+export const MAX_THREADS_PER_PROJECT = 100;
+
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
 export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;


### PR DESCRIPTION
## Summary
- Auto-archives the oldest projects and threads when capacity is reached, with new orchestration invariants and command handling.
- Simplifies desktop preview state by removing back/forward navigation and tightening preview visibility/state management.
- Removes the marketing site component split in favor of a single page implementation and updates font loading strategy.
- Cleans up now-unused environment variable, IPC, and shared contract code across server, web, and shared packages.

## Testing
- Not run (not requested).
- Expected validation for this change set: `bun fmt`, `bun lint`, and `bun typecheck`.
- Existing and updated unit coverage was adjusted for preview and git/action logic.