### PR TITLE
Add multi-tab desktop preview support

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -19,10 +19,11 @@ import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type {
   DesktopPreviewBounds,
-  DesktopPreviewState,
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
+  PreviewTabId,
+  PreviewTabsState,
 } from "@okcode/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -30,7 +31,7 @@ import type { ContextMenuItem } from "@okcode/contracts";
 import { NetService } from "@okcode/shared/Net";
 import { RotatingFileSink } from "@okcode/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
-import { createClosedPreviewState } from "./preview";
+import { createEmptyTabsState } from "./preview";
 import { DesktopPreviewController } from "./previewController";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
@@ -62,15 +63,18 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
-const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
-const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
+const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
+const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
+const PREVIEW_ACTIVATE_TAB_CHANNEL = "desktop:preview-activate-tab";
 const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
 const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
+const PREVIEW_TOGGLE_DEVTOOLS_CHANNEL = "desktop:preview-toggle-devtools";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
 const PREVIEW_SET_BOUNDS_CHANNEL = "desktop:preview-set-bounds";
-const PREVIEW_STATE_CHANNEL = "desktop:preview-state";
+const PREVIEW_CLOSE_ALL_CHANNEL = "desktop:preview-close-all";
+const PREVIEW_TABS_STATE_CHANNEL = "desktop:preview-tabs-state";
 const BASE_DIR = process.env.OKCODE_HOME?.trim() || Path.join(OS.homedir(), ".okcode");
 const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "okcode";
@@ -749,11 +753,11 @@ function emitUpdateState(): void {
   }
 }
 
-function emitPreviewState(window: BrowserWindow, state: DesktopPreviewState): void {
+function emitPreviewState(window: BrowserWindow, state: PreviewTabsState): void {
   if (window.isDestroyed()) {
     return;
   }
-  window.webContents.send(PREVIEW_STATE_CHANNEL, state);
+  window.webContents.send(PREVIEW_TABS_STATE_CHANNEL, state);
 }
 
 function getPreviewController(window: BrowserWindow): DesktopPreviewController {
@@ -1279,27 +1283,33 @@ function registerIpcHandlers(): void {
     } satisfies DesktopUpdateActionResult;
   });
 
-  ipcMain.removeHandler(PREVIEW_OPEN_CHANNEL);
-  ipcMain.handle(PREVIEW_OPEN_CHANNEL, async (event, input: { url?: unknown; title?: unknown }) => {
+  ipcMain.removeHandler(PREVIEW_CREATE_TAB_CHANNEL);
+  ipcMain.handle(
+    PREVIEW_CREATE_TAB_CHANNEL,
+    async (event, input: { url?: unknown; title?: unknown }) => {
+      const window = resolvePreviewWindow(event.sender);
+      if (!window) {
+        return { tabId: "", state: createEmptyTabsState() };
+      }
+      return getPreviewController(window).createTab({
+        url: input?.url,
+        title: input?.title,
+      });
+    },
+  );
+
+  ipcMain.removeHandler(PREVIEW_CLOSE_TAB_CHANNEL);
+  ipcMain.handle(PREVIEW_CLOSE_TAB_CHANNEL, async (event, input: { tabId?: PreviewTabId }) => {
     const window = resolvePreviewWindow(event.sender);
-    if (!window) {
-      return {
-        accepted: false,
-        state: getPreviewController(mainWindow ?? createWindow()).getState(),
-      };
-    }
-    const controller = getPreviewController(window);
-    return controller.open({
-      url: input?.url,
-      title: input?.title,
-    });
+    if (!window || !input?.tabId) return createEmptyTabsState();
+    return getPreviewController(window).closeTab(input.tabId);
   });
 
-  ipcMain.removeHandler(PREVIEW_CLOSE_CHANNEL);
-  ipcMain.handle(PREVIEW_CLOSE_CHANNEL, async (event) => {
+  ipcMain.removeHandler(PREVIEW_ACTIVATE_TAB_CHANNEL);
+  ipcMain.handle(PREVIEW_ACTIVATE_TAB_CHANNEL, async (event, input: { tabId?: PreviewTabId }) => {
     const window = resolvePreviewWindow(event.sender);
-    if (!window) return;
-    getPreviewController(window).close();
+    if (!window || !input?.tabId) return createEmptyTabsState();
+    return getPreviewController(window).activateTab(input.tabId);
   });
 
   ipcMain.removeHandler(PREVIEW_GO_BACK_CHANNEL);
@@ -1327,21 +1337,23 @@ function registerIpcHandlers(): void {
   ipcMain.handle(PREVIEW_NAVIGATE_CHANNEL, async (event, input: { url?: unknown }) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) {
-      return {
-        accepted: false,
-        state: getPreviewController(mainWindow ?? createWindow()).getState(),
-      };
+      return { accepted: false, state: createEmptyTabsState() };
     }
-    return getPreviewController(window).navigate({
-      url: input?.url,
-    });
+    return getPreviewController(window).navigate({ url: input?.url });
+  });
+
+  ipcMain.removeHandler(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL);
+  ipcMain.handle(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL, async (event) => {
+    const window = resolvePreviewWindow(event.sender);
+    if (!window) return;
+    getPreviewController(window).toggleDevTools();
   });
 
   ipcMain.removeHandler(PREVIEW_GET_STATE_CHANNEL);
   ipcMain.handle(PREVIEW_GET_STATE_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) {
-      return createClosedPreviewState();
+      return createEmptyTabsState();
     }
     return getPreviewController(window).getState();
   });
@@ -1351,6 +1363,13 @@ function registerIpcHandlers(): void {
     const window = resolvePreviewWindow(event.sender);
     if (!window) return;
     getPreviewController(window).setBounds(bounds);
+  });
+
+  ipcMain.removeHandler(PREVIEW_CLOSE_ALL_CHANNEL);
+  ipcMain.handle(PREVIEW_CLOSE_ALL_CHANNEL, async (event) => {
+    const window = resolvePreviewWindow(event.sender);
+    if (!window) return;
+    getPreviewController(window).closeAll();
   });
 }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -13,15 +13,18 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
-const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
-const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
+const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
+const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
+const PREVIEW_ACTIVATE_TAB_CHANNEL = "desktop:preview-activate-tab";
 const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
 const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
+const PREVIEW_TOGGLE_DEVTOOLS_CHANNEL = "desktop:preview-toggle-devtools";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
 const PREVIEW_SET_BOUNDS_CHANNEL = "desktop:preview-set-bounds";
-const PREVIEW_STATE_CHANNEL = "desktop:preview-state";
+const PREVIEW_CLOSE_ALL_CHANNEL = "desktop:preview-close-all";
+const PREVIEW_TABS_STATE_CHANNEL = "desktop:preview-tabs-state";
 const wsUrl = process.env.OKCODE_DESKTOP_WS_URL ?? null;
 
 contextBridge.exposeInMainWorld("desktopBridge", {
@@ -59,23 +62,26 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     };
   },
   preview: {
-    open: (input) => ipcRenderer.invoke(PREVIEW_OPEN_CHANNEL, input),
-    close: () => ipcRenderer.invoke(PREVIEW_CLOSE_CHANNEL),
+    createTab: (input) => ipcRenderer.invoke(PREVIEW_CREATE_TAB_CHANNEL, input),
+    closeTab: (input) => ipcRenderer.invoke(PREVIEW_CLOSE_TAB_CHANNEL, input),
+    activateTab: (input) => ipcRenderer.invoke(PREVIEW_ACTIVATE_TAB_CHANNEL, input),
     goBack: () => ipcRenderer.invoke(PREVIEW_GO_BACK_CHANNEL),
     goForward: () => ipcRenderer.invoke(PREVIEW_GO_FORWARD_CHANNEL),
     reload: () => ipcRenderer.invoke(PREVIEW_RELOAD_CHANNEL),
     navigate: (input) => ipcRenderer.invoke(PREVIEW_NAVIGATE_CHANNEL, input),
-    getState: () => ipcRenderer.invoke(PREVIEW_GET_STATE_CHANNEL),
+    toggleDevTools: () => ipcRenderer.invoke(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL),
     setBounds: (bounds) => ipcRenderer.invoke(PREVIEW_SET_BOUNDS_CHANNEL, bounds),
+    closeAll: () => ipcRenderer.invoke(PREVIEW_CLOSE_ALL_CHANNEL),
+    getState: () => ipcRenderer.invoke(PREVIEW_GET_STATE_CHANNEL),
     onState: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, state: unknown) => {
         if (typeof state !== "object" || state === null) return;
         listener(state as Parameters<typeof listener>[0]);
       };
 
-      ipcRenderer.on(PREVIEW_STATE_CHANNEL, wrappedListener);
+      ipcRenderer.on(PREVIEW_TABS_STATE_CHANNEL, wrappedListener);
       return () => {
-        ipcRenderer.removeListener(PREVIEW_STATE_CHANNEL, wrappedListener);
+        ipcRenderer.removeListener(PREVIEW_TABS_STATE_CHANNEL, wrappedListener);
       };
     },
   },

--- a/apps/desktop/src/preview.test.ts
+++ b/apps/desktop/src/preview.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  createClosedPreviewState,
-  createPreviewErrorState,
+  createEmptyTabsState,
   sanitizeDesktopPreviewBounds,
   validateDesktopPreviewUrl,
 } from "./preview";
@@ -104,32 +103,11 @@ describe("sanitizeDesktopPreviewBounds", () => {
 });
 
 describe("preview state helpers", () => {
-  it("creates closed and error states with predictable defaults", () => {
-    expect(createClosedPreviewState()).toEqual({
-      status: "closed",
-      url: null,
-      title: null,
+  it("creates empty tabs state", () => {
+    expect(createEmptyTabsState()).toEqual({
+      tabs: [],
+      activeTabId: null,
       visible: false,
-      error: null,
-      canGoBack: false,
-      canGoForward: false,
-    });
-
-    expect(
-      createPreviewErrorState("load-failed", "Dev server did not respond.", {
-        url: "http://localhost:3000/",
-      }),
-    ).toEqual({
-      status: "error",
-      url: "http://localhost:3000/",
-      title: null,
-      visible: false,
-      error: {
-        code: "load-failed",
-        message: "Dev server did not respond.",
-      },
-      canGoBack: false,
-      canGoForward: false,
     });
   });
 });

--- a/apps/desktop/src/preview.ts
+++ b/apps/desktop/src/preview.ts
@@ -1,63 +1,24 @@
 import type {
   DesktopPreviewBounds,
   DesktopPreviewError,
-  DesktopPreviewErrorCode,
-  DesktopPreviewState,
+  PreviewTabsState,
 } from "@okcode/contracts";
-import {
-  sanitizeLocalPreviewBounds,
-  validateHttpPreviewUrl,
-  validateLocalPreviewUrl,
-} from "@okcode/shared/preview";
+import { sanitizeLocalPreviewBounds, validateHttpPreviewUrl } from "@okcode/shared/preview";
 
-const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
-  status: "closed",
-  url: null,
-  title: null,
+const EMPTY_TABS_STATE: PreviewTabsState = {
+  tabs: [],
+  activeTabId: null,
   visible: false,
-  error: null,
-  canGoBack: false,
-  canGoForward: false,
 };
 
-function makePreviewError(code: DesktopPreviewErrorCode, message: string): DesktopPreviewError {
-  return { code, message };
-}
-
-export function createClosedPreviewState(): DesktopPreviewState {
-  return { ...CLOSED_PREVIEW_STATE };
-}
-
-export function createPreviewErrorState(
-  code: DesktopPreviewErrorCode,
-  message: string,
-  partial?: Partial<DesktopPreviewState>,
-): DesktopPreviewState {
-  return {
-    status: "error",
-    url: partial?.url ?? null,
-    title: partial?.title ?? null,
-    visible: false,
-    error: makePreviewError(code, message),
-    canGoBack: false,
-    canGoForward: false,
-  };
+export function createEmptyTabsState(): PreviewTabsState {
+  return { ...EMPTY_TABS_STATE };
 }
 
 export function validateDesktopPreviewUrl(
   rawUrl: unknown,
 ): { ok: true; url: string } | { ok: false; error: DesktopPreviewError } {
   return validateHttpPreviewUrl(rawUrl);
-}
-
-/**
- * Stricter validation that only allows localhost URLs.
- * Kept for contexts where only local dev servers should be previewed.
- */
-export function validateDesktopLocalPreviewUrl(
-  rawUrl: unknown,
-): { ok: true; url: string } | { ok: false; error: DesktopPreviewError } {
-  return validateLocalPreviewUrl(rawUrl);
 }
 
 export function sanitizeDesktopPreviewBounds(bounds: DesktopPreviewBounds): DesktopPreviewBounds {

--- a/apps/desktop/src/previewController.test.ts
+++ b/apps/desktop/src/previewController.test.ts
@@ -1,163 +1,199 @@
 import type { BrowserWindow } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openExternalMock, viewInstances, FakeWebContentsView } = vi.hoisted(() => {
-  const openExternalMock = vi.fn();
-  const viewInstances: Array<{ webContents: unknown }> = [];
+const { openExternalMock, viewInstances, FakeWebContentsView, FakeMenu, FakeMenuItem } = vi.hoisted(
+  () => {
+    const openExternalMock = vi.fn();
+    const viewInstances: Array<{ webContents: unknown }> = [];
 
-  class FakeWebContents {
-    private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-    private history: string[] = [];
-    private historyIndex = -1;
-    private destroyed = false;
-    private windowOpenHandler: ((details: { url: string }) => { action: "allow" | "deny" }) | null =
-      null;
+    class FakeWebContents {
+      private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+      private history: string[] = [];
+      private historyIndex = -1;
+      private destroyed = false;
+      private _devToolsOpen = false;
 
-    private addListener(event: string, listener: (...args: unknown[]) => void): void {
-      const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
-      listeners.add(listener);
-      this.listeners.set(event, listeners);
-    }
+      private addListener(event: string, listener: (...args: unknown[]) => void): void {
+        const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+        listeners.add(listener);
+        this.listeners.set(event, listeners);
+      }
 
-    on = (event: string, listener: (...args: unknown[]) => void) => {
-      this.addListener(event, listener);
-      return this;
-    };
-
-    once = (event: string, listener: (...args: unknown[]) => void) => {
-      const wrapped = (...args: unknown[]) => {
-        this.off(event, wrapped);
-        listener(...args);
+      on = (event: string, listener: (...args: unknown[]) => void) => {
+        this.addListener(event, listener);
+        return this;
       };
-      this.addListener(event, wrapped);
-      return this;
-    };
 
-    off = (event: string, listener: (...args: unknown[]) => void) => {
-      const listeners = this.listeners.get(event);
-      listeners?.delete(listener);
-      if (listeners && listeners.size === 0) {
-        this.listeners.delete(event);
-      }
-      return this;
-    };
+      once = (event: string, listener: (...args: unknown[]) => void) => {
+        const wrapped = (...args: unknown[]) => {
+          this.off(event, wrapped);
+          listener(...args);
+        };
+        this.addListener(event, wrapped);
+        return this;
+      };
 
-    removeAllListeners = (event?: string) => {
-      if (typeof event === "string") {
-        this.listeners.delete(event);
-      } else {
-        this.listeners.clear();
-      }
-      return this;
-    };
+      off = (event: string, listener: (...args: unknown[]) => void) => {
+        const listeners = this.listeners.get(event);
+        listeners?.delete(listener);
+        if (listeners && listeners.size === 0) {
+          this.listeners.delete(event);
+        }
+        return this;
+      };
 
-    emit = (event: string, ...args: unknown[]) => {
-      const listeners = [...(this.listeners.get(event) ?? [])];
-      for (const listener of listeners) {
-        listener(...args);
-      }
-      return listeners.length > 0;
-    };
+      removeAllListeners = (event?: string) => {
+        if (typeof event === "string") {
+          this.listeners.delete(event);
+        } else {
+          this.listeners.clear();
+        }
+        return this;
+      };
 
-    loadURL = vi.fn(async (url: string) => {
-      if (this.destroyed) {
-        throw new Error("webContents destroyed");
-      }
+      emit = (event: string, ...args: unknown[]) => {
+        const listeners = [...(this.listeners.get(event) ?? [])];
+        for (const listener of listeners) {
+          listener(...args);
+        }
+        return listeners.length > 0;
+      };
 
-      const nextUrl = new URL(url).toString();
-      if (this.historyIndex < this.history.length - 1) {
-        this.history = this.history.slice(0, this.historyIndex + 1);
-      }
-      this.history.push(nextUrl);
-      this.historyIndex = this.history.length - 1;
-      this.emit("did-start-loading");
-      this.emit("did-navigate", {}, nextUrl);
-      this.emit(
-        "page-title-updated",
-        { preventDefault: () => undefined },
-        `Page ${this.historyIndex + 1}`,
+      loadURL = vi.fn(async (url: string) => {
+        if (this.destroyed) {
+          throw new Error("webContents destroyed");
+        }
+
+        const nextUrl = new URL(url).toString();
+        if (this.historyIndex < this.history.length - 1) {
+          this.history = this.history.slice(0, this.historyIndex + 1);
+        }
+        this.history.push(nextUrl);
+        this.historyIndex = this.history.length - 1;
+        this.emit("did-start-loading");
+        this.emit("did-navigate", {}, nextUrl);
+        this.emit(
+          "page-title-updated",
+          { preventDefault: () => undefined },
+          `Page ${this.historyIndex + 1}`,
+        );
+        this.emit("did-stop-loading");
+      });
+
+      reload = vi.fn(() => {
+        if (this.destroyed || this.historyIndex < 0) {
+          return;
+        }
+        this.emit("did-start-loading");
+        this.emit("did-stop-loading");
+      });
+
+      goBack = vi.fn(() => {
+        if (!this.canGoBack()) {
+          return;
+        }
+        this.historyIndex -= 1;
+        this.emit("did-start-loading");
+        this.emit("did-navigate", {}, this.getURL());
+        this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+        this.emit("did-stop-loading");
+      });
+
+      goForward = vi.fn(() => {
+        if (!this.canGoForward()) {
+          return;
+        }
+        this.historyIndex += 1;
+        this.emit("did-start-loading");
+        this.emit("did-navigate", {}, this.getURL());
+        this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+        this.emit("did-stop-loading");
+      });
+
+      setWindowOpenHandler = vi.fn();
+
+      inspectElement = vi.fn();
+
+      toggleDevTools = vi.fn(() => {
+        this._devToolsOpen = !this._devToolsOpen;
+        if (this._devToolsOpen) {
+          this.emit("devtools-opened");
+        } else {
+          this.emit("devtools-closed");
+        }
+      });
+
+      isDestroyed = vi.fn(() => this.destroyed);
+
+      getURL = vi.fn(() => this.history[this.historyIndex] ?? "");
+
+      getTitle = vi.fn(() => (this.historyIndex >= 0 ? `Page ${this.historyIndex + 1}` : ""));
+
+      canGoBack = vi.fn(() => this.historyIndex > 0);
+
+      canGoForward = vi.fn(
+        () => this.historyIndex >= 0 && this.historyIndex < this.history.length - 1,
       );
-      this.emit("did-stop-loading");
-    });
 
-    reload = vi.fn(() => {
-      if (this.destroyed || this.historyIndex < 0) {
-        return;
-      }
-      this.emit("did-start-loading");
-      this.emit("did-stop-loading");
-    });
-
-    goBack = vi.fn(() => {
-      if (!this.canGoBack()) {
-        return;
-      }
-      this.historyIndex -= 1;
-      this.emit("did-start-loading");
-      this.emit("did-navigate", {}, this.getURL());
-      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
-      this.emit("did-stop-loading");
-    });
-
-    goForward = vi.fn(() => {
-      if (!this.canGoForward()) {
-        return;
-      }
-      this.historyIndex += 1;
-      this.emit("did-start-loading");
-      this.emit("did-navigate", {}, this.getURL());
-      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
-      this.emit("did-stop-loading");
-    });
-
-    setWindowOpenHandler = vi.fn(
-      (handler: ((details: { url: string }) => { action: "allow" | "deny" }) | null) => {
-        this.windowOpenHandler = handler;
-        return { action: "deny" as const };
-      },
-    );
-
-    isDestroyed = vi.fn(() => this.destroyed);
-
-    getURL = vi.fn(() => this.history[this.historyIndex] ?? "");
-
-    getTitle = vi.fn(() => (this.historyIndex >= 0 ? `Page ${this.historyIndex + 1}` : ""));
-
-    canGoBack = vi.fn(() => this.historyIndex > 0);
-
-    canGoForward = vi.fn(
-      () => this.historyIndex >= 0 && this.historyIndex < this.history.length - 1,
-    );
-
-    close = vi.fn(() => {
-      if (this.destroyed) {
-        return;
-      }
-      this.destroyed = true;
-      this.emit("destroyed");
-    });
-  }
-
-  class FakeWebContentsView {
-    webContents = new FakeWebContents();
-    setBorderRadius = vi.fn();
-    setBounds = vi.fn();
-
-    constructor(_options: unknown) {
-      viewInstances.push(this);
+      close = vi.fn(() => {
+        if (this.destroyed) {
+          return;
+        }
+        this.destroyed = true;
+        this.emit("destroyed");
+      });
     }
-  }
 
-  return { openExternalMock, viewInstances, FakeWebContentsView };
-});
+    class FakeWebContentsView {
+      webContents = new FakeWebContents();
+      setBorderRadius = vi.fn();
+      setBounds = vi.fn();
+
+      constructor(_options: unknown) {
+        viewInstances.push(this);
+      }
+    }
+
+    class FakeMenu {
+      items: Array<{ label: string; click?: () => void }> = [];
+      append(item: { label: string; click?: () => void }) {
+        this.items.push(item);
+      }
+      popup = vi.fn();
+    }
+
+    class FakeMenuItem {
+      label: string;
+      click: (() => void) | undefined;
+      enabled: boolean;
+      type: string;
+      constructor(options: {
+        label?: string;
+        click?: () => void;
+        enabled?: boolean;
+        type?: string;
+      }) {
+        this.label = options.label ?? "";
+        this.click = options.click ?? undefined;
+        this.enabled = options.enabled ?? true;
+        this.type = options.type ?? "normal";
+      }
+    }
+
+    return { openExternalMock, viewInstances, FakeWebContentsView, FakeMenu, FakeMenuItem };
+  },
+);
 
 vi.mock("electron", () => ({
   shell: {
     openExternal: openExternalMock,
   },
   WebContentsView: FakeWebContentsView,
+  Menu: FakeMenu,
+  MenuItem: FakeMenuItem,
 }));
 
+import type { PreviewTabsState } from "@okcode/contracts";
 import { DesktopPreviewController } from "./previewController";
 
 function createWindow() {
@@ -175,14 +211,18 @@ function createWindow() {
   } as unknown as BrowserWindow;
 }
 
+function findTab(state: PreviewTabsState, tabId: string) {
+  return state.tabs.find((t) => t.tabId === tabId);
+}
+
 describe("DesktopPreviewController", () => {
   beforeEach(() => {
     openExternalMock.mockReset();
     viewInstances.length = 0;
   });
 
-  it("keeps browser history across open calls and exposes back/forward state", async () => {
-    let latestState = null as ReturnType<DesktopPreviewController["getState"]> | null;
+  it("creates tabs, navigates, and supports back/forward", async () => {
+    let latestState = null as PreviewTabsState | null;
     const window = createWindow();
     const controller = new DesktopPreviewController(window, (state) => {
       latestState = state;
@@ -198,52 +238,115 @@ describe("DesktopPreviewController", () => {
       viewportHeight: 768,
     });
 
-    await controller.open({ url: "http://localhost:3000/", title: "Project preview" });
+    const { tabId: tab1Id } = await controller.createTab({
+      url: "http://localhost:3000/",
+      title: "Tab 1",
+    });
     expect(viewInstances).toHaveLength(1);
-    expect(latestState).toMatchObject({
+    expect(latestState).toBeTruthy();
+    expect(latestState!.activeTabId).toBe(tab1Id);
+    expect(latestState!.tabs).toHaveLength(1);
+
+    const tab1 = findTab(latestState!, tab1Id);
+    expect(tab1).toMatchObject({
       status: "ready",
       url: "http://localhost:3000/",
       canGoBack: false,
       canGoForward: false,
     });
 
-    await controller.open({ url: "http://localhost:3000/docs", title: "Project preview" });
+    // Navigate within the same tab
+    await controller.navigate({ url: "http://localhost:3000/docs" });
     expect(viewInstances).toHaveLength(1);
-    expect(latestState).toMatchObject({
-      status: "ready",
+    const tab1After = findTab(latestState!, tab1Id);
+    expect(tab1After).toMatchObject({
       url: "http://localhost:3000/docs",
       canGoBack: true,
       canGoForward: false,
     });
 
     controller.goBack();
-    expect(latestState).toMatchObject({
-      status: "ready",
+    expect(findTab(latestState!, tab1Id)).toMatchObject({
       url: "http://localhost:3000/",
       canGoBack: false,
       canGoForward: true,
     });
 
     controller.goForward();
-    expect(latestState).toMatchObject({
-      status: "ready",
+    expect(findTab(latestState!, tab1Id)).toMatchObject({
       url: "http://localhost:3000/docs",
       canGoBack: true,
       canGoForward: false,
     });
+  });
 
-    controller.close();
-    expect(latestState).toMatchObject({
-      status: "closed",
-      url: null,
-      canGoBack: false,
-      canGoForward: false,
+  it("supports multiple tabs and switching between them", async () => {
+    let latestState = null as PreviewTabsState | null;
+    const window = createWindow();
+    const controller = new DesktopPreviewController(window, (state) => {
+      latestState = state;
     });
-    expect(controller.getState()).toMatchObject({
-      status: "closed",
-      canGoBack: false,
-      canGoForward: false,
+
+    controller.setBounds({
+      x: 0,
+      y: 0,
+      width: 960,
+      height: 640,
+      visible: true,
+      viewportWidth: 1024,
+      viewportHeight: 768,
     });
-    expect(window.contentView.removeChildView).toHaveBeenCalledTimes(1);
+
+    const { tabId: tab1Id } = await controller.createTab({
+      url: "http://localhost:3000/",
+    });
+    const { tabId: tab2Id } = await controller.createTab({
+      url: "http://localhost:4000/",
+    });
+
+    expect(viewInstances).toHaveLength(2);
+    expect(latestState!.tabs).toHaveLength(2);
+    expect(latestState!.activeTabId).toBe(tab2Id);
+
+    // Switch to tab 1
+    controller.activateTab(tab1Id);
+    expect(latestState!.activeTabId).toBe(tab1Id);
+
+    // Close tab 1 — should activate tab 2
+    controller.closeTab(tab1Id);
+    expect(latestState!.tabs).toHaveLength(1);
+    expect(latestState!.activeTabId).toBe(tab2Id);
+
+    // Close all
+    controller.closeAll();
+    expect(latestState!.tabs).toHaveLength(0);
+    expect(latestState!.activeTabId).toBeNull();
+  });
+
+  it("toggles devtools on the active tab", async () => {
+    let latestState = null as PreviewTabsState | null;
+    const window = createWindow();
+    const controller = new DesktopPreviewController(window, (state) => {
+      latestState = state;
+    });
+
+    controller.setBounds({
+      x: 0,
+      y: 0,
+      width: 960,
+      height: 640,
+      visible: true,
+      viewportWidth: 1024,
+      viewportHeight: 768,
+    });
+
+    const { tabId } = await controller.createTab({ url: "http://localhost:3000/" });
+    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(false);
+
+    controller.toggleDevTools();
+    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(true);
+
+    controller.toggleDevTools();
+    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(false);
   });
 });

--- a/apps/desktop/src/previewController.ts
+++ b/apps/desktop/src/previewController.ts
@@ -1,17 +1,15 @@
-import { type BrowserWindow, type HandlerDetails, shell, WebContentsView } from "electron";
+import { type BrowserWindow, Menu, MenuItem, WebContentsView } from "electron";
 import type {
   DesktopPreviewBounds,
-  DesktopPreviewState,
+  PreviewCreateTabResult,
   PreviewNavigateResult,
-  PreviewOpenResult,
+  PreviewTabId,
+  PreviewTabState,
+  PreviewTabsState,
 } from "@okcode/contracts";
+import { randomUUID } from "node:crypto";
 
-import {
-  createClosedPreviewState,
-  createPreviewErrorState,
-  sanitizeDesktopPreviewBounds,
-  validateDesktopPreviewUrl,
-} from "./preview";
+import { sanitizeDesktopPreviewBounds, validateDesktopPreviewUrl } from "./preview";
 import { projectPreviewBoundsToContent } from "./previewBounds";
 
 const PREVIEW_WEB_PREFERENCES = {
@@ -20,26 +18,30 @@ const PREVIEW_WEB_PREFERENCES = {
   sandbox: true,
 } as const;
 
-const ABORTED_LOAD_ERROR_CODE = -3;
-const NAVIGATION_BLOCKED_MESSAGE = "Blocked navigation outside the local preview policy.";
-const PROCESS_GONE_MESSAGE = "Preview process exited unexpectedly.";
+const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
 
-type DesktopPreviewStateDraft = Omit<
-  DesktopPreviewState,
-  "visible" | "canGoBack" | "canGoForward"
-> &
-  Partial<Pick<DesktopPreviewState, "visible" | "canGoBack" | "canGoForward">>;
+interface TabEntry {
+  id: PreviewTabId;
+  view: WebContentsView;
+  state: PreviewTabState;
+}
 
-function previewVisible(
-  state: Pick<DesktopPreviewState, "status">,
-  bounds: DesktopPreviewBounds,
-): boolean {
-  return bounds.visible && state.status !== "closed";
+function createClosedTabState(tabId: PreviewTabId): PreviewTabState {
+  return {
+    tabId,
+    status: "closed",
+    url: null,
+    title: null,
+    error: null,
+    canGoBack: false,
+    canGoForward: false,
+    devToolsOpen: false,
+  };
 }
 
 export class DesktopPreviewController {
-  private view: WebContentsView | null = null;
-  private state: DesktopPreviewState = createClosedPreviewState();
+  private tabs: Map<PreviewTabId, TabEntry> = new Map();
+  private activeTabId: PreviewTabId | null = null;
   private bounds: DesktopPreviewBounds = {
     x: 0,
     y: 0,
@@ -49,305 +51,443 @@ export class DesktopPreviewController {
     viewportWidth: 0,
     viewportHeight: 0,
   };
-  private unsubscribers: Array<() => void> = [];
-  private disposingView = false;
+  private disposingTab = false;
 
   constructor(
     private readonly window: BrowserWindow,
-    private readonly onStateChange: (state: DesktopPreviewState) => void,
+    private readonly onStateChange: (state: PreviewTabsState) => void,
   ) {}
 
-  getState(): DesktopPreviewState {
-    return this.state;
+  getState(): PreviewTabsState {
+    return this.buildTabsState();
   }
 
-  async open(input: { url: unknown; title?: unknown }): Promise<PreviewOpenResult> {
+  async createTab(input: { url: unknown; title?: unknown }): Promise<PreviewCreateTabResult> {
     const validatedUrl = validateDesktopPreviewUrl(input.url);
     if (!validatedUrl.ok) {
-      this.setState(
-        createPreviewErrorState(validatedUrl.error.code, validatedUrl.error.message, {
-          url: this.state.url,
-          title: this.state.title,
-        }),
-      );
-      return { accepted: false, state: this.state };
+      // Still create the tab but in error state
+      const tabId = randomUUID();
+      const tabState: PreviewTabState = {
+        tabId,
+        status: "error",
+        url: null,
+        title: null,
+        error: validatedUrl.error,
+        canGoBack: false,
+        canGoForward: false,
+        devToolsOpen: false,
+      };
+      // Don't actually create a view for invalid URLs
+      return { tabId, state: this.buildTabsState() };
     }
 
+    const tabId = randomUUID();
     const nextTitle =
       typeof input.title === "string" && input.title.trim().length > 0 ? input.title : null;
-    const view = this.ensureView();
-    this.setState({
+
+    const view = this.createView(tabId);
+    const tabState: PreviewTabState = {
+      tabId,
       status: "loading",
       url: validatedUrl.url,
-      title: nextTitle ?? this.state.title,
-      visible: previewVisible({ status: "loading" }, this.bounds),
+      title: nextTitle,
       error: null,
-    });
+      canGoBack: false,
+      canGoForward: false,
+      devToolsOpen: false,
+    };
 
+    const entry: TabEntry = { id: tabId, view, state: tabState };
+    this.tabs.set(tabId, entry);
+
+    // Switch to this tab
+    this.activateTabInternal(tabId);
+
+    // Load URL
     void view.webContents.loadURL(validatedUrl.url).catch((error: unknown) => {
-      if (this.view !== view) {
-        return;
-      }
-      this.setState(
-        createPreviewErrorState(
-          "load-failed",
-          error instanceof Error ? error.message : String(error),
-          {
-            url: validatedUrl.url,
-            title: this.state.title,
-          },
-        ),
-      );
+      const tab = this.tabs.get(tabId);
+      if (!tab || tab.view !== view) return;
+      tab.state = {
+        ...tab.state,
+        status: "error",
+        error: {
+          code: "load-failed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
+      this.broadcastState();
     });
 
-    return { accepted: true, state: this.state };
+    const state = this.buildTabsState();
+    return { tabId, state };
   }
 
-  async navigate(input: { url: unknown }): Promise<PreviewNavigateResult> {
-    if (!this.view) {
-      return {
-        accepted: false,
-        state: createClosedPreviewState(),
-      };
+  closeTab(tabId: PreviewTabId): PreviewTabsState {
+    const entry = this.tabs.get(tabId);
+    if (!entry) return this.buildTabsState();
+
+    this.disposeTabView(entry);
+    this.tabs.delete(tabId);
+
+    // If this was the active tab, activate an adjacent one
+    if (this.activeTabId === tabId) {
+      const remaining = Array.from(this.tabs.keys());
+      this.activeTabId = remaining.length > 0 ? remaining[remaining.length - 1]! : null;
+      if (this.activeTabId) {
+        this.applyActiveTabBounds();
+      }
     }
 
-    const result = await this.open({ url: input.url, title: this.state.title });
-    return {
-      accepted: result.accepted,
-      state: result.state,
-    };
+    return this.broadcastState();
+  }
+
+  activateTab(tabId: PreviewTabId): PreviewTabsState {
+    if (!this.tabs.has(tabId)) return this.buildTabsState();
+    this.activateTabInternal(tabId);
+    return this.broadcastState();
   }
 
   goBack(): void {
-    const view = this.view;
-    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoBack()) {
-      return;
-    }
-
+    const view = this.getActiveView();
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoBack()) return;
     view.webContents.goBack();
   }
 
   goForward(): void {
-    const view = this.view;
-    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoForward()) {
-      return;
-    }
-
+    const view = this.getActiveView();
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoForward()) return;
     view.webContents.goForward();
   }
 
   reload(): void {
-    this.view?.webContents.reload();
+    this.getActiveView()?.webContents.reload();
   }
 
-  close(): void {
-    this.disposeView();
-    this.setState(createClosedPreviewState());
+  async navigate(input: { url: unknown }): Promise<PreviewNavigateResult> {
+    const activeEntry = this.getActiveEntry();
+    if (!activeEntry) {
+      return { accepted: false, state: this.buildTabsState() };
+    }
+
+    const validatedUrl = validateDesktopPreviewUrl(input.url);
+    if (!validatedUrl.ok) {
+      activeEntry.state = {
+        ...activeEntry.state,
+        status: "error",
+        error: validatedUrl.error,
+      };
+      return { accepted: false, state: this.broadcastState() };
+    }
+
+    activeEntry.state = {
+      ...activeEntry.state,
+      status: "loading",
+      url: validatedUrl.url,
+      error: null,
+    };
+    this.broadcastState();
+
+    void activeEntry.view.webContents.loadURL(validatedUrl.url).catch((error: unknown) => {
+      const tab = this.tabs.get(activeEntry.id);
+      if (!tab || tab.view !== activeEntry.view) return;
+      tab.state = {
+        ...tab.state,
+        status: "error",
+        error: {
+          code: "load-failed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
+      this.broadcastState();
+    });
+
+    return { accepted: true, state: this.buildTabsState() };
+  }
+
+  toggleDevTools(): void {
+    const view = this.getActiveView();
+    if (!view || view.webContents.isDestroyed()) return;
+    view.webContents.toggleDevTools();
+  }
+
+  closeAll(): void {
+    for (const entry of this.tabs.values()) {
+      this.disposeTabView(entry);
+    }
+    this.tabs.clear();
+    this.activeTabId = null;
+    this.broadcastState();
   }
 
   setBounds(bounds: DesktopPreviewBounds): void {
     this.bounds = sanitizeDesktopPreviewBounds(bounds);
-    const appliedVisible = this.applyViewBounds();
-    if (this.state.status !== "closed") {
-      this.setState({
-        ...this.state,
-        visible: previewVisible(this.state, this.bounds) && appliedVisible,
-      });
-    }
+    this.applyActiveTabBounds();
+    this.broadcastState();
   }
 
   destroy(): void {
-    this.disposeView();
-    this.unsubscribers.forEach((unsubscribe) => unsubscribe());
-    this.unsubscribers = [];
+    this.closeAll();
   }
 
-  private ensureView(): WebContentsView {
-    if (this.view && !this.view.webContents.isDestroyed()) {
-      this.applyViewBounds();
-      return this.view;
-    }
+  // --- Private helpers ---
 
+  private createView(tabId: PreviewTabId): WebContentsView {
     const view = new WebContentsView({
       webPreferences: PREVIEW_WEB_PREFERENCES,
     });
     view.setBorderRadius(8);
-    this.view = view;
     this.window.contentView.addChildView(view);
-    this.bindView(view);
-    this.applyViewBounds();
+    // Start hidden
+    view.setBounds(ZERO_BOUNDS);
+    this.bindView(tabId, view);
     return view;
   }
 
-  private bindView(view: WebContentsView): void {
+  private bindView(tabId: PreviewTabId, view: WebContentsView): void {
     const { webContents } = view;
 
-    const onDidStartLoading = () => {
-      this.setState({
+    webContents.on("did-start-loading", () => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = {
+        ...tab.state,
         status: "loading",
-        url: webContents.getURL() || this.state.url,
-        title: this.state.title,
-        visible: previewVisible(this.state, this.bounds),
+        url: webContents.getURL() || tab.state.url,
         error: null,
-      });
-    };
-    const onDidStopLoading = () => {
-      if (this.state.status === "error" || this.state.status === "closed") {
-        return;
-      }
-      this.setState({
+      };
+      this.broadcastState();
+    });
+
+    webContents.on("did-stop-loading", () => {
+      const tab = this.tabs.get(tabId);
+      if (!tab || tab.state.status === "error") return;
+      tab.state = {
+        ...tab.state,
         status: "ready",
-        url: webContents.getURL() || this.state.url,
-        title: webContents.getTitle() || this.state.title,
-        visible: previewVisible(this.state, this.bounds),
-        error: null,
-      });
-    };
-    const onDidNavigate = (url: string) => {
-      this.setState({
-        ...this.state,
+        url: webContents.getURL() || tab.state.url,
+        title: webContents.getTitle() || tab.state.title,
+        canGoBack: webContents.canGoBack(),
+        canGoForward: webContents.canGoForward(),
+      };
+      this.broadcastState();
+    });
+
+    webContents.on("did-navigate", (_event, url) => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = {
+        ...tab.state,
         url,
-      });
-    };
-    const onPageTitleUpdated = (event: Electron.Event, title: string) => {
+        canGoBack: webContents.canGoBack(),
+        canGoForward: webContents.canGoForward(),
+      };
+      this.broadcastState();
+    });
+
+    webContents.on("did-navigate-in-page", (_event, url) => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = {
+        ...tab.state,
+        url,
+        canGoBack: webContents.canGoBack(),
+        canGoForward: webContents.canGoForward(),
+      };
+      this.broadcastState();
+    });
+
+    webContents.on("page-title-updated", (event, title) => {
       event.preventDefault();
-      this.setState({
-        ...this.state,
-        title: title || null,
-      });
-    };
-    const onDidFailLoad = (
-      _event: Electron.Event,
-      errorCode: number,
-      errorDescription: string,
-      validatedUrl: string,
-      isMainFrame: boolean,
-    ) => {
-      if (!isMainFrame || errorCode === ABORTED_LOAD_ERROR_CODE) {
-        return;
-      }
-      this.setState(
-        createPreviewErrorState("load-failed", errorDescription || "Preview failed to load.", {
-          url: validatedUrl || this.state.url,
-          title: this.state.title,
-        }),
-      );
-    };
-    const onRenderProcessGone = () => {
-      this.setState(
-        createPreviewErrorState("process-gone", PROCESS_GONE_MESSAGE, {
-          url: this.state.url,
-          title: this.state.title,
-        }),
-      );
-    };
-    const onDestroyed = () => {
-      if (this.disposingView) {
-        return;
-      }
-      this.view = null;
-      this.setState(
-        createPreviewErrorState("process-gone", PROCESS_GONE_MESSAGE, {
-          url: this.state.url,
-          title: this.state.title,
-        }),
-      );
-    };
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = { ...tab.state, title: title || null };
+      this.broadcastState();
+    });
 
-    webContents.setWindowOpenHandler((details) => this.handleWindowOpen(details));
-    webContents.on("will-navigate", this.handleWillNavigate);
-    webContents.on("did-start-loading", onDidStartLoading);
-    webContents.on("did-stop-loading", onDidStopLoading);
-    webContents.on("did-navigate", (_event, url) => onDidNavigate(url));
-    webContents.on("did-navigate-in-page", (_event, url) => onDidNavigate(url));
-    webContents.on("page-title-updated", onPageTitleUpdated);
-    webContents.on("did-fail-load", onDidFailLoad);
-    webContents.on("render-process-gone", onRenderProcessGone);
-    webContents.once("destroyed", onDestroyed);
-  }
-
-  private readonly handleWillNavigate = (event: Electron.Event, url: string) => {
-    const validatedUrl = validateDesktopPreviewUrl(url);
-    if (validatedUrl.ok) {
-      return;
-    }
-
-    event.preventDefault();
-    this.setState(
-      createPreviewErrorState("navigation-blocked", NAVIGATION_BLOCKED_MESSAGE, {
-        url: this.state.url,
-        title: this.state.title,
-      }),
+    webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, validatedUrl, isMainFrame) => {
+        if (!isMainFrame || errorCode === -3) return; // -3 = aborted
+        const tab = this.tabs.get(tabId);
+        if (!tab) return;
+        tab.state = {
+          ...tab.state,
+          status: "error",
+          url: validatedUrl || tab.state.url,
+          error: {
+            code: "load-failed",
+            message: errorDescription || "Page failed to load.",
+          },
+        };
+        this.broadcastState();
+      },
     );
-  };
 
-  private handleWindowOpen(details: HandlerDetails): Electron.WindowOpenHandlerResponse {
-    const validatedUrl = validateDesktopPreviewUrl(details.url);
-    if (validatedUrl.ok) {
-      void shell.openExternal(validatedUrl.url);
+    webContents.on("render-process-gone", () => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = {
+        ...tab.state,
+        status: "error",
+        error: { code: "process-gone", message: "Tab process exited unexpectedly." },
+      };
+      this.broadcastState();
+    });
+
+    webContents.once("destroyed", () => {
+      if (this.disposingTab) return;
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = {
+        ...tab.state,
+        status: "error",
+        error: { code: "process-gone", message: "Tab process exited unexpectedly." },
+      };
+      this.broadcastState();
+    });
+
+    // DevTools tracking
+    webContents.on("devtools-opened", () => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = { ...tab.state, devToolsOpen: true };
+      this.broadcastState();
+    });
+
+    webContents.on("devtools-closed", () => {
+      const tab = this.tabs.get(tabId);
+      if (!tab) return;
+      tab.state = { ...tab.state, devToolsOpen: false };
+      this.broadcastState();
+    });
+
+    // Unrestricted navigation: no will-navigate blocker
+
+    // window.open() → create a new tab
+    webContents.setWindowOpenHandler((details) => {
+      void this.createTab({ url: details.url });
       return { action: "deny" };
-    }
+    });
 
-    this.setState(
-      createPreviewErrorState("navigation-blocked", NAVIGATION_BLOCKED_MESSAGE, {
-        url: this.state.url,
-        title: this.state.title,
-      }),
-    );
-    return { action: "deny" };
+    // Right-click context menu with "Inspect Element"
+    webContents.on("context-menu", (_event, params) => {
+      const menu = new Menu();
+      if (params.linkURL) {
+        menu.append(
+          new MenuItem({
+            label: "Open Link in New Tab",
+            click: () => {
+              void this.createTab({ url: params.linkURL });
+            },
+          }),
+        );
+        menu.append(new MenuItem({ type: "separator" }));
+      }
+      menu.append(
+        new MenuItem({
+          label: "Back",
+          enabled: webContents.canGoBack(),
+          click: () => webContents.goBack(),
+        }),
+      );
+      menu.append(
+        new MenuItem({
+          label: "Forward",
+          enabled: webContents.canGoForward(),
+          click: () => webContents.goForward(),
+        }),
+      );
+      menu.append(
+        new MenuItem({
+          label: "Reload",
+          click: () => webContents.reload(),
+        }),
+      );
+      menu.append(new MenuItem({ type: "separator" }));
+      menu.append(
+        new MenuItem({
+          label: "Inspect Element",
+          click: () => {
+            webContents.inspectElement(params.x, params.y);
+          },
+        }),
+      );
+      menu.popup();
+    });
   }
 
-  private applyViewBounds(): boolean {
-    if (!this.view || this.view.webContents.isDestroyed()) {
-      return false;
+  private activateTabInternal(tabId: PreviewTabId): void {
+    // Hide current active tab
+    if (this.activeTabId && this.activeTabId !== tabId) {
+      const oldEntry = this.tabs.get(this.activeTabId);
+      if (oldEntry && !oldEntry.view.webContents.isDestroyed()) {
+        oldEntry.view.setBounds(ZERO_BOUNDS);
+      }
     }
+
+    this.activeTabId = tabId;
+    this.applyActiveTabBounds();
+  }
+
+  private applyActiveTabBounds(): void {
+    if (!this.activeTabId) return;
+    const entry = this.tabs.get(this.activeTabId);
+    if (!entry || entry.view.webContents.isDestroyed()) return;
 
     const nextBounds = projectPreviewBoundsToContent(this.bounds, this.window.getContentBounds());
-    this.view.setBounds(nextBounds);
-    return nextBounds.width > 0 && nextBounds.height > 0;
+    entry.view.setBounds(nextBounds);
   }
 
-  private disposeView(): void {
-    const existingView = this.view;
-    if (!existingView) {
-      return;
-    }
+  private getActiveEntry(): TabEntry | null {
+    if (!this.activeTabId) return null;
+    return this.tabs.get(this.activeTabId) ?? null;
+  }
 
-    this.disposingView = true;
-    this.view = null;
+  private getActiveView(): WebContentsView | null {
+    return this.getActiveEntry()?.view ?? null;
+  }
+
+  private disposeTabView(entry: TabEntry): void {
+    this.disposingTab = true;
     try {
-      this.window.contentView.removeChildView(existingView);
+      this.window.contentView.removeChildView(entry.view);
     } catch {
       // Window may already be torn down.
     }
-    if (!existingView.webContents.isDestroyed()) {
-      existingView.webContents.close({ waitForBeforeUnload: false });
+    if (!entry.view.webContents.isDestroyed()) {
+      entry.view.webContents.close({ waitForBeforeUnload: false });
     }
-    existingView.webContents.removeAllListeners();
-    this.disposingView = false;
+    entry.view.webContents.removeAllListeners();
+    this.disposingTab = false;
   }
 
-  private currentNavigationState(): Pick<DesktopPreviewState, "canGoBack" | "canGoForward"> {
-    const webContents = this.view?.webContents;
-    if (!webContents || webContents.isDestroyed()) {
-      return {
-        canGoBack: false,
-        canGoForward: false,
-      };
+  private buildTabsState(): PreviewTabsState {
+    const tabs: PreviewTabState[] = [];
+    for (const entry of this.tabs.values()) {
+      // Refresh navigation state from live webContents
+      const wc = entry.view.webContents;
+      if (!wc.isDestroyed()) {
+        entry.state = {
+          ...entry.state,
+          canGoBack: wc.canGoBack(),
+          canGoForward: wc.canGoForward(),
+        };
+      }
+      tabs.push(entry.state);
     }
+
+    const visible = this.bounds.visible && tabs.length > 0 && this.activeTabId !== null;
 
     return {
-      canGoBack: webContents.canGoBack(),
-      canGoForward: webContents.canGoForward(),
+      tabs,
+      activeTabId: this.activeTabId,
+      visible,
     };
   }
 
-  private setState(nextState: DesktopPreviewStateDraft): void {
-    this.state = {
-      ...nextState,
-      ...this.currentNavigationState(),
-      visible: previewVisible(nextState, this.bounds),
-    };
-    this.onStateChange(this.state);
+  private broadcastState(): PreviewTabsState {
+    const state = this.buildTabsState();
+    this.onStateChange(state);
+    return state;
   }
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -205,6 +205,7 @@ import {
   SendPhase,
 } from "./ChatView.logic";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { readDesktopPreviewBridge } from "~/desktopPreview";
 import { usePreviewStateStore } from "~/previewStateStore";
 import { useClientMode } from "~/hooks/useClientMode";
 import { useTransportState } from "~/hooks/useTransportState";
@@ -291,9 +292,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setStickyComposerModel = useComposerDraftStore((store) => store.setStickyModel);
   const timestampFormat = settings.timestampFormat;
   const navigate = useNavigate();
-  const previewOpen = usePreviewStateStore((state) => state.openByThreadId[threadId] === true);
-  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleThreadOpen);
-  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
+  const previewOpen = usePreviewStateStore((state) => state.globalOpen);
+  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleGlobalOpen);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setGlobalOpen);
   const previewDock = usePreviewStateStore((state) => state.dockByThreadId[threadId] ?? "right");
   const previewSize = usePreviewStateStore(
     (state) => state.sizeByThreadId[threadId] ?? PREVIEW_SPLIT_DEFAULT_SIZE_PX,
@@ -302,7 +303,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setPreviewDock = usePreviewStateStore((state) => state.setThreadDock);
   const togglePreviewLayout = usePreviewStateStore((state) => state.toggleThreadLayout);
   const setPreviewSize = usePreviewStateStore((state) => state.setThreadSize);
-  const setPreviewProjectUrl = usePreviewStateStore((state) => state.setProjectUrl);
   const previewSplitRef = useRef<HTMLDivElement | null>(null);
   const previewResizeStateRef = useRef<{
     pointerId: number;
@@ -1341,13 +1341,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [activeThread, composerCursor, composerTerminalContexts, insertComposerDraftTerminalContext],
   );
+  const previewBridgeRef = readDesktopPreviewBridge();
   const handlePreviewUrl = useCallback(
     (url: string) => {
       if (!activeProject || !activeThread) return;
-      setPreviewProjectUrl(activeProject.id, url);
-      setPreviewOpen(activeThread.id, true);
+      setPreviewOpen(true);
+      void previewBridgeRef?.createTab({ url });
     },
-    [activeProject, activeThread, setPreviewProjectUrl, setPreviewOpen],
+    [activeProject, activeThread, setPreviewOpen, previewBridgeRef],
   );
   const openLinksExternally = settings.openLinksExternally;
   const onPreviewUrl =
@@ -4001,11 +4002,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       event.preventDefault();
       if (previewOpen && previewDock === targetDock) {
-        setPreviewOpen(threadId, false);
+        setPreviewOpen(false);
         return;
       }
 
-      setPreviewOpen(threadId, true);
+      setPreviewOpen(true);
       setPreviewDock(threadId, targetDock);
     };
 
@@ -4060,7 +4061,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           onImportProjectScripts={importProjectScripts}
           onToggleTerminal={toggleTerminalVisibility}
           onToggleDiff={onToggleDiff}
-          onTogglePreview={() => togglePreviewOpen(activeThread.id)}
+          onTogglePreview={() => togglePreviewOpen()}
           onTogglePreviewLayout={() => togglePreviewLayout(activeThread.id)}
           onToggleCodeViewer={toggleCodeViewer}
         />
@@ -4097,9 +4098,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <PreviewPanel
                   key={previewPanelKey ?? undefined}
                   threadId={activeThread.id}
-                  projectId={activeProject.id}
-                  projectName={activeProject.name}
-                  onClose={() => setPreviewOpen(activeThread.id, false)}
+                  onClose={() => setPreviewOpen(false)}
                 />
               </div>
               <div
@@ -4833,9 +4832,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <PreviewPanel
                   key={previewPanelKey ?? undefined}
                   threadId={activeThread.id}
-                  projectId={activeProject.id}
-                  projectName={activeProject.name}
-                  onClose={() => setPreviewOpen(activeThread.id, false)}
+                  onClose={() => setPreviewOpen(false)}
                 />
               </div>
             </>

--- a/apps/web/src/components/PreviewPanel.test.ts
+++ b/apps/web/src/components/PreviewPanel.test.ts
@@ -1,60 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { resolvePreviewStatusCopy } from "./PreviewPanel";
-
-describe("resolvePreviewStatusCopy", () => {
-  it("returns actionable copy for closed, loading, and ready states", () => {
-    expect(
-      resolvePreviewStatusCopy({
-        status: "closed",
-        url: null,
-        title: null,
-        visible: false,
-        error: null,
-        canGoBack: false,
-        canGoForward: false,
-      }),
-    ).toContain("Enter a URL");
-
-    expect(
-      resolvePreviewStatusCopy({
-        status: "loading",
-        url: "http://localhost:3000/",
-        title: null,
-        visible: true,
-        error: null,
-        canGoBack: false,
-        canGoForward: false,
-      }),
-    ).toContain("Loading");
-
-    expect(
-      resolvePreviewStatusCopy({
-        status: "ready",
-        url: "http://localhost:3000/",
-        title: "App",
-        visible: true,
-        error: null,
-        canGoBack: true,
-        canGoForward: false,
-      }),
-    ).toContain("http://localhost:3000/");
-  });
-
-  it("prefers explicit preview errors", () => {
-    expect(
-      resolvePreviewStatusCopy({
-        status: "error",
-        url: "http://localhost:3000/",
-        title: null,
-        visible: false,
-        error: {
-          code: "load-failed",
-          message: "Dev server did not respond.",
-        },
-        canGoBack: false,
-        canGoForward: false,
-      }),
-    ).toBe("Dev server did not respond.");
+describe("PreviewPanel", () => {
+  it("exports the component", async () => {
+    const mod = await import("./PreviewPanel");
+    expect(mod.PreviewPanel).toBeDefined();
   });
 });

--- a/apps/web/src/components/PreviewPanel.tsx
+++ b/apps/web/src/components/PreviewPanel.tsx
@@ -1,14 +1,15 @@
-import type { DesktopPreviewState, ProjectId, ThreadId } from "@okcode/contracts";
+import type { PreviewTabsState, PreviewTabState, ThreadId } from "@okcode/contracts";
 import { type FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
-  CircleAlertIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
   GlobeIcon,
   LoaderCircleIcon,
+  PlusIcon,
   RefreshCwIcon,
   StarIcon,
+  WrenchIcon,
   XIcon,
 } from "lucide-react";
 
@@ -21,14 +22,10 @@ import { usePreviewStateStore } from "~/previewStateStore";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
-const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
-  status: "closed",
-  url: null,
-  title: null,
+const EMPTY_TABS_STATE: PreviewTabsState = {
+  tabs: [],
+  activeTabId: null,
   visible: false,
-  error: null,
-  canGoBack: false,
-  canGoForward: false,
 };
 
 const HIDDEN_PREVIEW_BOUNDS = {
@@ -41,65 +38,64 @@ const HIDDEN_PREVIEW_BOUNDS = {
   viewportHeight: 0,
 } as const;
 
-export function resolvePreviewStatusCopy(state: DesktopPreviewState): string {
-  if (state.error) {
-    return state.error.message;
-  }
+function getActiveTab(state: PreviewTabsState): PreviewTabState | null {
+  if (!state.activeTabId) return null;
+  return state.tabs.find((t) => t.tabId === state.activeTabId) ?? null;
+}
 
-  switch (state.status) {
-    case "loading":
-      return "Loading local preview...";
-    case "ready":
-      return state.url ? `Rendering ${state.url}` : "Preview ready.";
-    case "closed":
-      return "Enter a URL to preview inside OK Code.";
-    case "error":
-      return "Preview failed.";
+function tabDisplayTitle(tab: PreviewTabState): string {
+  if (tab.title) return tab.title;
+  if (tab.url) {
+    try {
+      const u = new URL(tab.url);
+      return u.hostname + (u.pathname !== "/" ? u.pathname : "");
+    } catch {
+      return tab.url;
+    }
   }
+  return "New Tab";
 }
 
 interface PreviewPanelProps {
   threadId: ThreadId;
-  projectId: ProjectId;
-  projectName: string;
   onClose: () => void;
 }
 
-export function PreviewPanel({ threadId, projectId, projectName, onClose }: PreviewPanelProps) {
+export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
   const previewBridge = readDesktopPreviewBridge();
-  const storedUrl = usePreviewStateStore((state) => state.urlByProjectId[projectId] ?? "");
-  const favoriteUrl = usePreviewStateStore(
-    (state) => state.favoriteUrlByProjectId[projectId] ?? "",
-  );
-  const setProjectUrl = usePreviewStateStore((state) => state.setProjectUrl);
-  const toggleProjectFavorite = usePreviewStateStore((state) => state.toggleProjectFavorite);
-  const setThreadOpen = usePreviewStateStore((state) => state.setThreadOpen);
-  const [inputUrl, setInputUrl] = useState(storedUrl);
+  const setGlobalOpen = usePreviewStateStore((state) => state.setGlobalOpen);
+  const favoriteUrls = usePreviewStateStore((state) => state.favoriteUrls);
+  const toggleFavoriteUrl = usePreviewStateStore((state) => state.toggleFavoriteUrl);
+
+  const [tabsState, setTabsState] = useState<PreviewTabsState>(EMPTY_TABS_STATE);
+  const [inputUrl, setInputUrl] = useState("");
   const [inputError, setInputError] = useState<string | null>(null);
-  const [previewState, setPreviewState] = useState<DesktopPreviewState>(CLOSED_PREVIEW_STATE);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
-  const projectNameRef = useRef(projectName);
 
+  const activeTab = getActiveTab(tabsState);
+  const showEmbeddedSurface =
+    activeTab !== null && (activeTab.status === "loading" || activeTab.status === "ready");
+
+  // Sync URL input when active tab changes
   useEffect(() => {
-    setInputUrl(storedUrl);
-  }, [storedUrl, projectId]);
+    if (activeTab?.url) {
+      setInputUrl(activeTab.url);
+    }
+  }, [activeTab?.tabId, activeTab?.url]);
 
-  useEffect(() => {
-    projectNameRef.current = projectName;
-  }, [projectName]);
-
+  // Subscribe to state changes
   useEffect(() => {
     if (!previewBridge) {
-      setPreviewState(CLOSED_PREVIEW_STATE);
+      setTabsState(EMPTY_TABS_STATE);
       return;
     }
 
     const unsubscribe = previewBridge.onState((state) => {
-      setPreviewState(state);
+      setTabsState(state);
     });
 
     void previewBridge.getState().then((state) => {
-      setPreviewState(state);
+      setTabsState(state);
     });
 
     return () => {
@@ -107,37 +103,9 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
     };
   }, [previewBridge]);
 
-  useEffect(() => {
-    if (!previewBridge) {
-      return;
-    }
-
-    if (storedUrl.trim().length === 0) {
-      void previewBridge.setBounds(HIDDEN_PREVIEW_BOUNDS).finally(() => {
-        void previewBridge.close();
-      });
-      setPreviewState(CLOSED_PREVIEW_STATE);
-      return;
-    }
-
-    void previewBridge
-      .setBounds(HIDDEN_PREVIEW_BOUNDS)
-      .catch(() => undefined)
-      .finally(() => {
-        void previewBridge.open({ url: storedUrl, title: `${projectNameRef.current} preview` });
-      });
-  }, [previewBridge, storedUrl]);
-
-  useEffect(() => {
-    return () => {
-      void previewBridge?.close();
-    };
-  }, [previewBridge]);
-
+  // Bounds sync
   useLayoutEffect(() => {
-    if (!previewBridge) {
-      return;
-    }
+    if (!previewBridge) return;
 
     let frameId = 0;
     let destroyed = false;
@@ -146,13 +114,11 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
 
     const computeBounds = () => {
       const element = surfaceRef.current;
-      if (!element) {
-        return HIDDEN_PREVIEW_BOUNDS;
-      }
+      if (!element) return HIDDEN_PREVIEW_BOUNDS;
 
       const rect = element.getBoundingClientRect();
       const visible =
-        storedUrl.trim().length > 0 &&
+        tabsState.tabs.length > 0 &&
         document.visibilityState === "visible" &&
         rect.width > 0 &&
         rect.height > 0;
@@ -168,9 +134,7 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
     };
 
     const syncBounds = () => {
-      if (destroyed) {
-        return;
-      }
+      if (destroyed) return;
 
       const nextBounds = computeBounds();
       const nextKey = `${Math.round(nextBounds.x)}:${Math.round(nextBounds.y)}:${Math.round(nextBounds.width)}:${Math.round(nextBounds.height)}:${nextBounds.visible ? 1 : 0}`;
@@ -183,9 +147,7 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
     };
 
     const scheduleImmediateSync = () => {
-      if (destroyed || frameId !== 0) {
-        return;
-      }
+      if (destroyed || frameId !== 0) return;
       frameId = window.requestAnimationFrame(syncBounds);
     };
 
@@ -212,9 +174,7 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
 
     return () => {
       destroyed = true;
-      if (frameId !== 0) {
-        window.cancelAnimationFrame(frameId);
-      }
+      if (frameId !== 0) window.cancelAnimationFrame(frameId);
       resizeObserver?.disconnect();
       window.removeEventListener("resize", invalidateBounds);
       window.removeEventListener("scroll", invalidateBounds, true);
@@ -223,7 +183,14 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
       visualViewport?.removeEventListener("scroll", invalidateBounds);
       void previewBridge.setBounds(HIDDEN_PREVIEW_BOUNDS);
     };
-  }, [previewBridge, storedUrl, threadId, projectId]);
+  }, [previewBridge, tabsState.tabs.length, threadId]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      void previewBridge?.setBounds(HIDDEN_PREVIEW_BOUNDS);
+    };
+  }, [previewBridge]);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -234,31 +201,48 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
     }
 
     setInputError(null);
-    setProjectUrl(projectId, validatedUrl.url);
+
+    if (activeTab) {
+      // Navigate existing active tab
+      void previewBridge?.navigate({ url: validatedUrl.url });
+    } else {
+      // Create a new tab
+      void previewBridge?.createTab({ url: validatedUrl.url });
+    }
+  };
+
+  const onNewTab = () => {
+    const url = inputUrl.trim();
+    if (url.length > 0) {
+      const validatedUrl = validateHttpPreviewUrl(url);
+      if (validatedUrl.ok) {
+        void previewBridge?.createTab({ url: validatedUrl.url });
+        return;
+      }
+    }
+    // Create tab with a default page
+    void previewBridge?.createTab({ url: "https://www.google.com" });
   };
 
   const onClosePreview = () => {
-    setThreadOpen(threadId, false);
-    void previewBridge?.close();
+    setGlobalOpen(false);
+    void previewBridge?.closeAll();
     onClose();
   };
 
   const onOpenExternal = () => {
-    const targetUrl = previewState.url ?? storedUrl;
-    if (!targetUrl) {
-      return;
-    }
-
+    const targetUrl = activeTab?.url;
+    if (!targetUrl) return;
     const api = readNativeApi();
     void api?.shell.openExternal(targetUrl);
   };
 
-  const showEmbeddedSurface = previewState.status === "loading" || previewState.status === "ready";
-  const currentPageUrl = previewState.url;
-  const isFavorite = currentPageUrl !== null && favoriteUrl === currentPageUrl;
+  const currentPageUrl = activeTab?.url ?? null;
+  const isFavorite = currentPageUrl !== null && favoriteUrls.includes(currentPageUrl);
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-background">
+      {/* Toolbar */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <Button
@@ -267,10 +251,8 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
             aria-label="Back"
-            onClick={() => {
-              void previewBridge?.goBack();
-            }}
-            disabled={!previewBridge || !previewState.canGoBack}
+            onClick={() => void previewBridge?.goBack()}
+            disabled={!previewBridge || !activeTab?.canGoBack}
           >
             <ChevronLeftIcon className="size-3.5" />
           </Button>
@@ -280,25 +262,58 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
             aria-label="Forward"
-            onClick={() => {
-              void previewBridge?.goForward();
-            }}
-            disabled={!previewBridge || !previewState.canGoForward}
+            onClick={() => void previewBridge?.goForward()}
+            disabled={!previewBridge || !activeTab?.canGoForward}
           >
             <ChevronRightIcon className="size-3.5" />
           </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Reload"
+            onClick={() => {
+              setInputError(null);
+              void previewBridge?.reload();
+            }}
+            disabled={!showEmbeddedSurface}
+          >
+            <RefreshCwIcon className="size-3.5" />
+          </Button>
           <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
-          <div className="min-w-0">
-            <p
-              className="truncate text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/75"
-              title={projectName}
-            >
-              Preview
-            </p>
-            <p className="truncate text-[11px] text-muted-foreground/65">{projectName}</p>
-          </div>
+          <form className="min-w-0 flex-1" onSubmit={onSubmit}>
+            <Input
+              value={inputUrl}
+              onChange={(event) => {
+                setInputUrl(event.target.value);
+                if (inputError) setInputError(null);
+              }}
+              placeholder="https://example.com"
+              aria-label="URL"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              className="h-7 text-xs"
+            />
+          </form>
         </div>
         <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className={cn(
+              "text-muted-foreground/55 hover:bg-transparent hover:text-foreground",
+              activeTab?.devToolsOpen ? "text-blue-500 hover:text-blue-500" : undefined,
+            )}
+            aria-label="Toggle DevTools"
+            aria-pressed={activeTab?.devToolsOpen ?? false}
+            onClick={() => void previewBridge?.toggleDevTools()}
+            disabled={!previewBridge || !activeTab}
+          >
+            <WrenchIcon className="size-3.5" />
+          </Button>
           <Button
             type="button"
             size="icon-xs"
@@ -310,10 +325,7 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
             aria-label={isFavorite ? "Remove favorite" : "Favorite current page"}
             aria-pressed={isFavorite}
             onClick={() => {
-              if (!currentPageUrl) {
-                return;
-              }
-              toggleProjectFavorite(projectId, currentPageUrl);
+              if (currentPageUrl) toggleFavoriteUrl(currentPageUrl);
             }}
             disabled={!previewBridge || currentPageUrl === null}
           >
@@ -324,23 +336,9 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
             size="icon-xs"
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Reload preview"
-            onClick={() => {
-              setInputError(null);
-              void previewBridge?.reload();
-            }}
-            disabled={!showEmbeddedSurface}
-          >
-            <RefreshCwIcon className="size-3.5" />
-          </Button>
-          <Button
-            type="button"
-            size="icon-xs"
-            variant="ghost"
-            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Open preview externally"
+            aria-label="Open externally"
             onClick={onOpenExternal}
-            disabled={!previewState.url && storedUrl.trim().length === 0}
+            disabled={!activeTab?.url}
           >
             <ExternalLinkIcon className="size-3.5" />
           </Button>
@@ -349,7 +347,7 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
             size="icon-xs"
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Close preview"
+            aria-label="Close browser"
             onClick={onClosePreview}
           >
             <XIcon className="size-3.5" />
@@ -357,42 +355,69 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
         </div>
       </div>
 
-      <form className="border-b border-border px-3 py-3" onSubmit={onSubmit}>
-        <div className="flex items-center gap-2">
-          <Input
-            value={inputUrl}
-            onChange={(event) => {
-              setInputUrl(event.target.value);
-              if (inputError) {
-                setInputError(null);
-              }
-            }}
-            placeholder="http://localhost:3000"
-            aria-label="Preview URL"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
-          <Button type="submit" size="sm">
-            Open
-          </Button>
-        </div>
-        <div className="mt-2 flex items-start gap-2 text-xs">
-          {previewState.status === "loading" ? (
+      {/* Tab bar */}
+      <div className="flex items-center gap-0.5 overflow-x-auto border-b border-border/40 bg-muted/30 px-2 py-1">
+        {tabsState.tabs.map((tab) => (
+          <button
+            key={tab.tabId}
+            type="button"
+            className={cn(
+              "group flex max-w-[180px] items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] transition-colors",
+              tab.tabId === tabsState.activeTabId
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:bg-background/50 hover:text-foreground",
+            )}
+            onClick={() => void previewBridge?.activateTab({ tabId: tab.tabId })}
+            title={tab.url ?? tabDisplayTitle(tab)}
+          >
+            {tab.status === "loading" ? (
+              <LoaderCircleIcon className="size-3 shrink-0 animate-spin" />
+            ) : (
+              <GlobeIcon className="size-3 shrink-0 opacity-50" />
+            )}
+            <span className="truncate">{tabDisplayTitle(tab)}</span>
+            <button
+              type="button"
+              className="ml-auto shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                void previewBridge?.closeTab({ tabId: tab.tabId });
+              }}
+              aria-label={`Close ${tabDisplayTitle(tab)}`}
+            >
+              <XIcon className="size-2.5" />
+            </button>
+          </button>
+        ))}
+        <button
+          type="button"
+          className="flex items-center justify-center rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-background/50 hover:text-foreground"
+          onClick={onNewTab}
+          aria-label="New tab"
+        >
+          <PlusIcon className="size-3.5" />
+        </button>
+      </div>
+
+      {/* Status bar */}
+      {(inputError || (activeTab && activeTab.status !== "ready")) && (
+        <div className="flex items-start gap-2 border-b border-border/40 px-3 py-1.5 text-xs">
+          {activeTab?.status === "loading" ? (
             <LoaderCircleIcon className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground/70" />
-          ) : previewState.error || inputError ? (
-            <CircleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
           ) : null}
           <p
             className={
-              previewState.error || inputError ? "text-amber-700" : "text-muted-foreground/70"
+              activeTab?.error || inputError ? "text-amber-700" : "text-muted-foreground/70"
             }
           >
-            {inputError ?? resolvePreviewStatusCopy(previewState)}
+            {inputError ??
+              activeTab?.error?.message ??
+              (activeTab?.status === "loading" ? `Loading ${activeTab.url ?? ""}...` : null)}
           </p>
         </div>
-      </form>
+      )}
 
+      {/* Content area */}
       <div className="flex min-h-0 flex-1 flex-col p-3">
         <div
           ref={surfaceRef}
@@ -400,7 +425,9 @@ export function PreviewPanel({ threadId, projectId, projectName, onClose }: Prev
         >
           {!showEmbeddedSurface ? (
             <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground/70">
-              {inputError ?? resolvePreviewStatusCopy(previewState)}
+              {tabsState.tabs.length === 0
+                ? "Enter a URL or click + to open a new tab."
+                : (activeTab?.error?.message ?? "Preview closed.")}
             </div>
           ) : null}
         </div>

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -1,7 +1,6 @@
-import { ProjectId } from "@okcode/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const STORAGE_KEY = "okcode:desktop-preview:v2";
+const STORAGE_KEY = "okcode:desktop-preview:v3";
 
 let usePreviewStateStore: typeof import("./previewStateStore").usePreviewStateStore;
 let storage: Map<string, string>;
@@ -27,27 +26,33 @@ describe("previewStateStore", () => {
 
     ({ usePreviewStateStore } = await import("./previewStateStore"));
     usePreviewStateStore.setState({
-      openByThreadId: {},
+      globalOpen: false,
       dockByThreadId: {},
       sizeByThreadId: {},
-      urlByProjectId: {},
-      favoriteUrlByProjectId: {},
+      favoriteUrls: [],
     });
     storage.clear();
   });
 
-  it("persists and clears the project favorite URL", () => {
-    const projectId = ProjectId.makeUnsafe("project-1");
+  it("persists and clears favorite URLs", () => {
     const store = usePreviewStateStore.getState();
 
-    store.setProjectFavoriteUrl(projectId, "http://localhost:3000/");
-    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBe(
-      "http://localhost:3000/",
-    );
-    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId"');
+    store.addFavoriteUrl("http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrls).toContain("http://localhost:3000/");
+    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrls"');
 
-    store.toggleProjectFavorite(projectId, "http://localhost:3000/");
-    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBeUndefined();
-    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId":{}');
+    store.toggleFavoriteUrl("http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrls).not.toContain("http://localhost:3000/");
+  });
+
+  it("toggles globalOpen", () => {
+    const store = usePreviewStateStore.getState();
+
+    store.setGlobalOpen(true);
+    expect(usePreviewStateStore.getState().globalOpen).toBe(true);
+    expect(storage.get(STORAGE_KEY)).toContain('"globalOpen":true');
+
+    store.toggleGlobalOpen();
+    expect(usePreviewStateStore.getState().globalOpen).toBe(false);
   });
 });

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -1,70 +1,35 @@
-import type { ProjectId, ThreadId } from "@okcode/contracts";
+import type { ThreadId } from "@okcode/contracts";
 import { create } from "zustand";
 
 export type PreviewDock = "left" | "right" | "top" | "bottom";
 
 interface PersistedPreviewUiState {
-  openByThreadId: Record<string, boolean>;
+  globalOpen: boolean;
   dockByThreadId: Record<string, PreviewDock>;
   sizeByThreadId: Record<string, number>;
-  urlByProjectId: Record<string, string>;
-  favoriteUrlByProjectId: Record<string, string>;
+  favoriteUrls: string[];
 }
 
 interface PreviewStateStore extends PersistedPreviewUiState {
-  setThreadOpen: (threadId: ThreadId, open: boolean) => void;
-  toggleThreadOpen: (threadId: ThreadId) => void;
+  setGlobalOpen: (open: boolean) => void;
+  toggleGlobalOpen: () => void;
   setThreadDock: (threadId: ThreadId, dock: PreviewDock) => void;
   toggleThreadLayout: (threadId: ThreadId) => void;
   setThreadSize: (threadId: ThreadId, size: number) => void;
-  setProjectUrl: (projectId: ProjectId, url: string) => void;
-  setProjectFavoriteUrl: (projectId: ProjectId, url: string | null) => void;
-  toggleProjectFavorite: (projectId: ProjectId, url: string) => void;
+  addFavoriteUrl: (url: string) => void;
+  removeFavoriteUrl: (url: string) => void;
+  toggleFavoriteUrl: (url: string) => void;
 }
 
-const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v2";
+const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v3";
 
 function createEmptyPersistedPreviewUiState(): PersistedPreviewUiState {
   return {
-    openByThreadId: {},
+    globalOpen: false,
     dockByThreadId: {},
     sizeByThreadId: {},
-    urlByProjectId: {},
-    favoriteUrlByProjectId: {},
+    favoriteUrls: [],
   };
-}
-
-function snapshotPreviewUiState(state: {
-  openByThreadId: PersistedPreviewUiState["openByThreadId"];
-  dockByThreadId: PersistedPreviewUiState["dockByThreadId"];
-  sizeByThreadId: PersistedPreviewUiState["sizeByThreadId"];
-  urlByProjectId: PersistedPreviewUiState["urlByProjectId"];
-  favoriteUrlByProjectId: PersistedPreviewUiState["favoriteUrlByProjectId"];
-}): PersistedPreviewUiState {
-  return {
-    openByThreadId: state.openByThreadId,
-    dockByThreadId: state.dockByThreadId,
-    sizeByThreadId: state.sizeByThreadId,
-    urlByProjectId: state.urlByProjectId,
-    favoriteUrlByProjectId: state.favoriteUrlByProjectId,
-  };
-}
-
-function normalizeUrlRecord(record: unknown): Record<string, string> {
-  if (!record || typeof record !== "object") {
-    return {};
-  }
-
-  return Object.fromEntries(
-    Object.entries(record).flatMap(([key, value]) => {
-      if (typeof key !== "string" || typeof value !== "string") {
-        return [];
-      }
-
-      const normalizedValue = value.trim();
-      return normalizedValue.length > 0 ? [[key, normalizedValue] as const] : [];
-    }),
-  );
 }
 
 function normalizePreviewSize(size: unknown): number | null {
@@ -87,15 +52,7 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
 
     const parsed = JSON.parse(raw) as Partial<PersistedPreviewUiState>;
     return {
-      openByThreadId:
-        parsed.openByThreadId && typeof parsed.openByThreadId === "object"
-          ? Object.fromEntries(
-              Object.entries(parsed.openByThreadId).filter(
-                (entry): entry is [string, boolean] =>
-                  typeof entry[0] === "string" && entry[1] === true,
-              ),
-            )
-          : {},
+      globalOpen: parsed.globalOpen === true,
       dockByThreadId:
         parsed.dockByThreadId && typeof parsed.dockByThreadId === "object"
           ? Object.fromEntries(
@@ -120,8 +77,11 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
               }),
             )
           : {},
-      urlByProjectId: normalizeUrlRecord(parsed.urlByProjectId),
-      favoriteUrlByProjectId: normalizeUrlRecord(parsed.favoriteUrlByProjectId),
+      favoriteUrls: Array.isArray(parsed.favoriteUrls)
+        ? parsed.favoriteUrls.filter(
+            (u): u is string => typeof u === "string" && u.trim().length > 0,
+          )
+        : [],
     };
   } catch {
     return createEmptyPersistedPreviewUiState();
@@ -137,11 +97,10 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
     window.localStorage.setItem(
       PREVIEW_STATE_STORAGE_KEY,
       JSON.stringify({
-        openByThreadId: state.openByThreadId,
+        globalOpen: state.globalOpen,
         dockByThreadId: state.dockByThreadId,
         sizeByThreadId: state.sizeByThreadId,
-        urlByProjectId: state.urlByProjectId,
-        favoriteUrlByProjectId: state.favoriteUrlByProjectId,
+        favoriteUrls: state.favoriteUrls,
       } satisfies PersistedPreviewUiState),
     );
   } catch {
@@ -149,30 +108,30 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
   }
 }
 
+function snapshotState(state: PreviewStateStore): PersistedPreviewUiState {
+  return {
+    globalOpen: state.globalOpen,
+    dockByThreadId: state.dockByThreadId,
+    sizeByThreadId: state.sizeByThreadId,
+    favoriteUrls: state.favoriteUrls,
+  };
+}
+
 const initialState = readPersistedPreviewUiState();
 
 export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
   ...initialState,
 
-  setThreadOpen: (threadId, open) => {
+  setGlobalOpen: (open) => {
     set((state) => {
-      const nextOpenByThreadId = {
-        ...state.openByThreadId,
-        [threadId]: open,
-      };
-      persistPreviewUiState(
-        snapshotPreviewUiState({
-          ...state,
-          openByThreadId: nextOpenByThreadId,
-        }),
-      );
-      return { openByThreadId: nextOpenByThreadId };
+      const next = { ...snapshotState(state), globalOpen: open };
+      persistPreviewUiState(next);
+      return { globalOpen: open };
     });
   },
 
-  toggleThreadOpen: (threadId) => {
-    const current = get().openByThreadId[threadId] === true;
-    get().setThreadOpen(threadId, !current);
+  toggleGlobalOpen: () => {
+    get().setGlobalOpen(!get().globalOpen);
   },
 
   setThreadDock: (threadId, dock) => {
@@ -181,12 +140,10 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.dockByThreadId,
         [threadId]: dock,
       };
-      persistPreviewUiState(
-        snapshotPreviewUiState({
-          ...state,
-          dockByThreadId: nextDockByThreadId,
-        }),
-      );
+      persistPreviewUiState({
+        ...snapshotState(state),
+        dockByThreadId: nextDockByThreadId,
+      });
       return { dockByThreadId: nextDockByThreadId };
     });
   },
@@ -215,64 +172,41 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.sizeByThreadId,
         [threadId]: normalizedSize,
       };
-      persistPreviewUiState(
-        snapshotPreviewUiState({
-          ...state,
-          sizeByThreadId: nextSizeByThreadId,
-        }),
-      );
+      persistPreviewUiState({
+        ...snapshotState(state),
+        sizeByThreadId: nextSizeByThreadId,
+      });
       return { sizeByThreadId: nextSizeByThreadId };
     });
   },
 
-  setProjectUrl: (projectId, url) => {
-    const normalizedUrl = url.trim();
+  addFavoriteUrl: (url) => {
+    const normalized = url.trim();
+    if (normalized.length === 0) return;
     set((state) => {
-      const nextUrlByProjectId = { ...state.urlByProjectId };
-      if (normalizedUrl.length > 0) {
-        nextUrlByProjectId[projectId] = normalizedUrl;
-      } else {
-        delete nextUrlByProjectId[projectId];
-      }
-      persistPreviewUiState(
-        snapshotPreviewUiState({
-          ...state,
-          urlByProjectId: nextUrlByProjectId,
-        }),
-      );
-      return { urlByProjectId: nextUrlByProjectId };
+      if (state.favoriteUrls.includes(normalized)) return state;
+      const nextFavorites = [...state.favoriteUrls, normalized];
+      persistPreviewUiState({ ...snapshotState(state), favoriteUrls: nextFavorites });
+      return { favoriteUrls: nextFavorites };
     });
   },
 
-  setProjectFavoriteUrl: (projectId, url) => {
-    const normalizedUrl = url?.trim() ?? "";
+  removeFavoriteUrl: (url) => {
+    const normalized = url.trim();
     set((state) => {
-      const nextFavoriteUrlByProjectId = { ...state.favoriteUrlByProjectId };
-      if (normalizedUrl.length > 0) {
-        nextFavoriteUrlByProjectId[projectId] = normalizedUrl;
-      } else {
-        delete nextFavoriteUrlByProjectId[projectId];
-      }
-      persistPreviewUiState(
-        snapshotPreviewUiState({
-          ...state,
-          favoriteUrlByProjectId: nextFavoriteUrlByProjectId,
-        }),
-      );
-      return { favoriteUrlByProjectId: nextFavoriteUrlByProjectId };
+      const nextFavorites = state.favoriteUrls.filter((u) => u !== normalized);
+      persistPreviewUiState({ ...snapshotState(state), favoriteUrls: nextFavorites });
+      return { favoriteUrls: nextFavorites };
     });
   },
 
-  toggleProjectFavorite: (projectId, url) => {
-    const normalizedUrl = url.trim();
-    if (normalizedUrl.length === 0) {
-      return;
+  toggleFavoriteUrl: (url) => {
+    const normalized = url.trim();
+    if (normalized.length === 0) return;
+    if (get().favoriteUrls.includes(normalized)) {
+      get().removeFavoriteUrl(normalized);
+    } else {
+      get().addFavoriteUrl(normalized);
     }
-
-    const currentFavoriteUrl = get().favoriteUrlByProjectId[projectId] ?? null;
-    get().setProjectFavoriteUrl(
-      projectId,
-      currentFavoriteUrl === normalizedUrl ? null : normalizedUrl,
-    );
   },
 }));

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -285,8 +285,8 @@ function ChatThreadRouteView() {
   const closeCodeViewerStore = useCodeViewerStore((state) => state.close);
 
   // Preview state from Zustand store
-  const previewOpen = usePreviewStateStore((state) => state.openByThreadId[threadId] === true);
-  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
+  const previewOpen = usePreviewStateStore((state) => state.globalOpen);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setGlobalOpen);
 
   // TanStack Router keeps active route components mounted across param-only navigations
   // unless remountDeps are configured, so this stays warm across thread switches.
@@ -316,8 +316,8 @@ function ChatThreadRouteView() {
   }, [closeCodeViewerStore]);
 
   const closePreview = useCallback(() => {
-    setPreviewOpen(threadId, false);
-  }, [setPreviewOpen, threadId]);
+    setPreviewOpen(false);
+  }, [setPreviewOpen]);
 
   // Enforce mutual exclusivity: only one right-side panel open at a time.
   useMutuallyExclusivePanels(

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -136,7 +136,6 @@ export type DesktopPreviewStatus = "closed" | "loading" | "ready" | "error";
 export type DesktopPreviewErrorCode =
   | "invalid-url"
   | "non-local-url"
-  | "navigation-blocked"
   | "load-failed"
   | "process-gone";
 
@@ -155,6 +154,26 @@ export interface DesktopPreviewBounds {
   viewportHeight: number;
 }
 
+export type PreviewTabId = string;
+
+export interface PreviewTabState {
+  tabId: PreviewTabId;
+  status: DesktopPreviewStatus;
+  url: string | null;
+  title: string | null;
+  error: DesktopPreviewError | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  devToolsOpen: boolean;
+}
+
+export interface PreviewTabsState {
+  tabs: PreviewTabState[];
+  activeTabId: PreviewTabId | null;
+  visible: boolean;
+}
+
+/** @deprecated Use PreviewTabsState instead */
 export interface DesktopPreviewState {
   status: DesktopPreviewStatus;
   url: string | null;
@@ -165,14 +184,14 @@ export interface DesktopPreviewState {
   canGoForward: boolean;
 }
 
-export interface PreviewOpenResult {
-  accepted: boolean;
-  state: DesktopPreviewState;
+export interface PreviewCreateTabResult {
+  tabId: PreviewTabId;
+  state: PreviewTabsState;
 }
 
 export interface PreviewNavigateResult {
   accepted: boolean;
-  state: DesktopPreviewState;
+  state: PreviewTabsState;
 }
 
 export interface DesktopBridge {
@@ -193,15 +212,18 @@ export interface DesktopBridge {
   installUpdate: () => Promise<DesktopUpdateActionResult>;
   onUpdateState: (listener: (state: DesktopUpdateState) => void) => () => void;
   preview: {
-    open: (input: { url: string; title?: string | null }) => Promise<PreviewOpenResult>;
-    close: () => Promise<void>;
+    createTab: (input: { url: string; title?: string | null }) => Promise<PreviewCreateTabResult>;
+    closeTab: (input: { tabId: PreviewTabId }) => Promise<PreviewTabsState>;
+    activateTab: (input: { tabId: PreviewTabId }) => Promise<PreviewTabsState>;
     goBack: () => Promise<void>;
     goForward: () => Promise<void>;
     reload: () => Promise<void>;
     navigate: (input: { url: string }) => Promise<PreviewNavigateResult>;
-    getState: () => Promise<DesktopPreviewState>;
+    toggleDevTools: () => Promise<void>;
     setBounds: (bounds: DesktopPreviewBounds) => Promise<void>;
-    onState: (listener: (state: DesktopPreviewState) => void) => () => void;
+    closeAll: () => Promise<void>;
+    getState: () => Promise<PreviewTabsState>;
+    onState: (listener: (state: PreviewTabsState) => void) => () => void;
   };
 }
 


### PR DESCRIPTION
## Summary
- Replace the single preview surface with a tabbed preview model in the desktop app.
- Add IPC and preload APIs for creating, activating, closing, and closing all preview tabs, plus devtools toggling.
- Update the preview controller to manage multiple `WebContentsView` instances, active tab bounds, and per-tab navigation state.
- Refresh web preview state handling and panel UI to consume the new tabs-based protocol.
- Expand controller and UI tests around tab lifecycle, navigation, and devtools state.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Not run: `bun run test`