### PR TITLE
Handle terminal cwd errors with fallback warning UI

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -536,7 +537,12 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
   async open(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
     const input = decodeTerminalOpenInput(raw);
     return this.runWithThreadLock(input.threadId, async () => {
-      await this.assertValidCwd(input.cwd);
+      let cwd = input.cwd;
+      try {
+        await this.assertValidCwd(cwd);
+      } catch {
+        cwd = os.homedir();
+      }
 
       const sessionKey = toSessionKey(input.threadId, input.terminalId);
       const existing = this.sessions.get(sessionKey);
@@ -548,7 +554,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         const session: TerminalSessionState = {
           threadId: input.threadId,
           terminalId: input.terminalId,
-          cwd: input.cwd,
+          cwd,
           status: "starting",
           pid: null,
           history,
@@ -566,7 +572,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         };
         this.sessions.set(sessionKey, session);
         this.evictInactiveSessionsIfNeeded();
-        await this.startSession(session, { ...input, cols, rows }, "started");
+        await this.startSession(session, { ...input, cwd, cols, rows }, "started");
         return this.snapshot(session);
       }
 
@@ -577,9 +583,9 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       const runtimeEnvChanged =
         JSON.stringify(currentRuntimeEnv) !== JSON.stringify(nextRuntimeEnv);
 
-      if (existing.cwd !== input.cwd || runtimeEnvChanged) {
+      if (existing.cwd !== cwd || runtimeEnvChanged) {
         this.stopProcess(existing);
-        existing.cwd = input.cwd;
+        existing.cwd = cwd;
         existing.runtimeEnv = nextRuntimeEnv;
         existing.history = "";
         existing.pendingHistoryControlSequence = "";
@@ -596,7 +602,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       if (!existing.process) {
         await this.startSession(
           existing,
-          { ...input, cols: targetCols, rows: targetRows },
+          { ...input, cwd, cols: targetCols, rows: targetRows },
           "started",
         );
         return this.snapshot(existing);
@@ -661,7 +667,12 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
   async restart(raw: TerminalRestartInput): Promise<TerminalSessionSnapshot> {
     const input = decodeTerminalRestartInput(raw);
     return this.runWithThreadLock(input.threadId, async () => {
-      await this.assertValidCwd(input.cwd);
+      let cwd = input.cwd;
+      try {
+        await this.assertValidCwd(cwd);
+      } catch {
+        cwd = os.homedir();
+      }
 
       const sessionKey = toSessionKey(input.threadId, input.terminalId);
       let session = this.sessions.get(sessionKey);
@@ -671,7 +682,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         session = {
           threadId: input.threadId,
           terminalId: input.terminalId,
-          cwd: input.cwd,
+          cwd,
           status: "starting",
           pid: null,
           history: "",
@@ -691,7 +702,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
         this.evictInactiveSessionsIfNeeded();
       } else {
         this.stopProcess(session);
-        session.cwd = input.cwd;
+        session.cwd = cwd;
         session.runtimeEnv = normalizedRuntimeEnv(input.env);
       }
 
@@ -701,7 +712,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
       session.history = "";
       session.pendingHistoryControlSequence = "";
       await this.persistHistory(input.threadId, input.terminalId, session.history);
-      await this.startSession(session, { ...input, cols, rows }, "restarted");
+      await this.startSession(session, { ...input, cwd, cols, rows }, "restarted");
       return this.snapshot(session);
     });
   }

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -1202,6 +1202,10 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
       };
     }
 
+    if (squashed instanceof Error) {
+      return { message: squashed.message };
+    }
+
     return { message: Cause.pretty(cause) };
   };
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -49,7 +49,7 @@ function clampDrawerHeight(height: number): number {
 }
 
 function writeSystemMessage(terminal: Terminal, message: string): void {
-  terminal.write(`\r\n[terminal] ${message}\r\n`);
+  terminal.write(`\r\n\x1b[33m⚠ ${message}\x1b[0m\r\n`);
 }
 
 function terminalThemeFromApp(): ITheme {


### PR DESCRIPTION
## Summary
- Fall back to the user home directory when a terminal `cwd` is invalid during open/restart, instead of failing the session.
- Preserve the resolved fallback `cwd` across session startup and restart paths so the terminal launches consistently.
- Surface plain error messages from the server and render terminal warnings with a highlighted warning style in the drawer.

## Testing
- Not run (per request).
- Verified the diff updates the terminal manager open/restart flows to retry with `os.homedir()` on `cwd` validation failure.
- Verified WebSocket error serialization now returns `Error.message` when available, which feeds the warning UI path.
- Verified the terminal drawer system message styling now renders warning text with a distinct color/icon treatment.