### PR TITLE
Add Claude update command for rebasing the current branch

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,9 @@
+Run the following command:
+
+```
+git fetch origin && git rebase origin/${branch}
+```
+
+Where `${branch}` is the current git branch (run `git branch --show-current` to determine it).
+
+Report the result to the user.


### PR DESCRIPTION
## Summary
- Add a new Claude command at `.claude/commands/update.md`.
- The command fetches `origin` and rebases the current branch onto `origin/${branch}`.
- The command instructs Claude to detect the active branch with `git branch --show-current` and report the result back to the user.

## Testing
- Not run (documentation-only change).
- Verified the new command file contents in the diff.