### PR TITLE
feat(preview): Add element selection context

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -19,11 +19,11 @@ import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type {
   DesktopPreviewBounds,
+  PreviewPickElementResult,
+  DesktopPreviewState,
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
-  PreviewTabId,
-  PreviewTabsState,
 } from "@okcode/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -31,7 +31,7 @@ import type { ContextMenuItem } from "@okcode/contracts";
 import { NetService } from "@okcode/shared/Net";
 import { RotatingFileSink } from "@okcode/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
-import { createEmptyTabsState } from "./preview";
+import { createClosedPreviewState } from "./preview";
 import { DesktopPreviewController } from "./previewController";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
@@ -63,18 +63,17 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
-const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
-const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
-const PREVIEW_ACTIVATE_TAB_CHANNEL = "desktop:preview-activate-tab";
+const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
+const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
 const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
 const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
-const PREVIEW_TOGGLE_DEVTOOLS_CHANNEL = "desktop:preview-toggle-devtools";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
 const PREVIEW_SET_BOUNDS_CHANNEL = "desktop:preview-set-bounds";
-const PREVIEW_CLOSE_ALL_CHANNEL = "desktop:preview-close-all";
-const PREVIEW_TABS_STATE_CHANNEL = "desktop:preview-tabs-state";
+const PREVIEW_PICK_ELEMENT_CHANNEL = "desktop:preview-pick-element";
+const PREVIEW_CANCEL_PICK_ELEMENT_CHANNEL = "desktop:preview-cancel-pick-element";
+const PREVIEW_STATE_CHANNEL = "desktop:preview-state";
 const BASE_DIR = process.env.OKCODE_HOME?.trim() || Path.join(OS.homedir(), ".okcode");
 const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "okcode";
@@ -753,11 +752,11 @@ function emitUpdateState(): void {
   }
 }
 
-function emitPreviewState(window: BrowserWindow, state: PreviewTabsState): void {
+function emitPreviewState(window: BrowserWindow, state: DesktopPreviewState): void {
   if (window.isDestroyed()) {
     return;
   }
-  window.webContents.send(PREVIEW_TABS_STATE_CHANNEL, state);
+  window.webContents.send(PREVIEW_STATE_CHANNEL, state);
 }
 
 function getPreviewController(window: BrowserWindow): DesktopPreviewController {
@@ -1283,33 +1282,27 @@ function registerIpcHandlers(): void {
     } satisfies DesktopUpdateActionResult;
   });
 
-  ipcMain.removeHandler(PREVIEW_CREATE_TAB_CHANNEL);
-  ipcMain.handle(
-    PREVIEW_CREATE_TAB_CHANNEL,
-    async (event, input: { url?: unknown; title?: unknown }) => {
-      const window = resolvePreviewWindow(event.sender);
-      if (!window) {
-        return { tabId: "", state: createEmptyTabsState() };
-      }
-      return getPreviewController(window).createTab({
-        url: input?.url,
-        title: input?.title,
-      });
-    },
-  );
-
-  ipcMain.removeHandler(PREVIEW_CLOSE_TAB_CHANNEL);
-  ipcMain.handle(PREVIEW_CLOSE_TAB_CHANNEL, async (event, input: { tabId?: PreviewTabId }) => {
+  ipcMain.removeHandler(PREVIEW_OPEN_CHANNEL);
+  ipcMain.handle(PREVIEW_OPEN_CHANNEL, async (event, input: { url?: unknown; title?: unknown }) => {
     const window = resolvePreviewWindow(event.sender);
-    if (!window || !input?.tabId) return createEmptyTabsState();
-    return getPreviewController(window).closeTab(input.tabId);
+    if (!window) {
+      return {
+        accepted: false,
+        state: getPreviewController(mainWindow ?? createWindow()).getState(),
+      };
+    }
+    const controller = getPreviewController(window);
+    return controller.open({
+      url: input?.url,
+      title: input?.title,
+    });
   });
 
-  ipcMain.removeHandler(PREVIEW_ACTIVATE_TAB_CHANNEL);
-  ipcMain.handle(PREVIEW_ACTIVATE_TAB_CHANNEL, async (event, input: { tabId?: PreviewTabId }) => {
+  ipcMain.removeHandler(PREVIEW_CLOSE_CHANNEL);
+  ipcMain.handle(PREVIEW_CLOSE_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
-    if (!window || !input?.tabId) return createEmptyTabsState();
-    return getPreviewController(window).activateTab(input.tabId);
+    if (!window) return;
+    getPreviewController(window).close();
   });
 
   ipcMain.removeHandler(PREVIEW_GO_BACK_CHANNEL);
@@ -1337,23 +1330,21 @@ function registerIpcHandlers(): void {
   ipcMain.handle(PREVIEW_NAVIGATE_CHANNEL, async (event, input: { url?: unknown }) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) {
-      return { accepted: false, state: createEmptyTabsState() };
+      return {
+        accepted: false,
+        state: getPreviewController(mainWindow ?? createWindow()).getState(),
+      };
     }
-    return getPreviewController(window).navigate({ url: input?.url });
-  });
-
-  ipcMain.removeHandler(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL);
-  ipcMain.handle(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL, async (event) => {
-    const window = resolvePreviewWindow(event.sender);
-    if (!window) return;
-    getPreviewController(window).toggleDevTools();
+    return getPreviewController(window).navigate({
+      url: input?.url,
+    });
   });
 
   ipcMain.removeHandler(PREVIEW_GET_STATE_CHANNEL);
   ipcMain.handle(PREVIEW_GET_STATE_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) {
-      return createEmptyTabsState();
+      return createClosedPreviewState();
     }
     return getPreviewController(window).getState();
   });
@@ -1365,11 +1356,25 @@ function registerIpcHandlers(): void {
     getPreviewController(window).setBounds(bounds);
   });
 
-  ipcMain.removeHandler(PREVIEW_CLOSE_ALL_CHANNEL);
-  ipcMain.handle(PREVIEW_CLOSE_ALL_CHANNEL, async (event) => {
+  ipcMain.removeHandler(PREVIEW_PICK_ELEMENT_CHANNEL);
+  ipcMain.handle(PREVIEW_PICK_ELEMENT_CHANNEL, async (event) => {
+    const window = resolvePreviewWindow(event.sender);
+    if (!window) {
+      return {
+        accepted: false,
+        selection: null,
+        reason: "preview-unavailable",
+        state: createClosedPreviewState(),
+      } satisfies PreviewPickElementResult;
+    }
+    return getPreviewController(window).pickElement();
+  });
+
+  ipcMain.removeHandler(PREVIEW_CANCEL_PICK_ELEMENT_CHANNEL);
+  ipcMain.handle(PREVIEW_CANCEL_PICK_ELEMENT_CHANNEL, async (event) => {
     const window = resolvePreviewWindow(event.sender);
     if (!window) return;
-    getPreviewController(window).closeAll();
+    await getPreviewController(window).cancelPickElement();
   });
 }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -13,18 +13,17 @@ const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
-const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
-const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
-const PREVIEW_ACTIVATE_TAB_CHANNEL = "desktop:preview-activate-tab";
+const PREVIEW_OPEN_CHANNEL = "desktop:preview-open";
+const PREVIEW_CLOSE_CHANNEL = "desktop:preview-close";
 const PREVIEW_GO_BACK_CHANNEL = "desktop:preview-go-back";
 const PREVIEW_GO_FORWARD_CHANNEL = "desktop:preview-go-forward";
 const PREVIEW_RELOAD_CHANNEL = "desktop:preview-reload";
 const PREVIEW_NAVIGATE_CHANNEL = "desktop:preview-navigate";
-const PREVIEW_TOGGLE_DEVTOOLS_CHANNEL = "desktop:preview-toggle-devtools";
 const PREVIEW_GET_STATE_CHANNEL = "desktop:preview-get-state";
 const PREVIEW_SET_BOUNDS_CHANNEL = "desktop:preview-set-bounds";
-const PREVIEW_CLOSE_ALL_CHANNEL = "desktop:preview-close-all";
-const PREVIEW_TABS_STATE_CHANNEL = "desktop:preview-tabs-state";
+const PREVIEW_PICK_ELEMENT_CHANNEL = "desktop:preview-pick-element";
+const PREVIEW_CANCEL_PICK_ELEMENT_CHANNEL = "desktop:preview-cancel-pick-element";
+const PREVIEW_STATE_CHANNEL = "desktop:preview-state";
 const wsUrl = process.env.OKCODE_DESKTOP_WS_URL ?? null;
 
 contextBridge.exposeInMainWorld("desktopBridge", {
@@ -62,26 +61,25 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     };
   },
   preview: {
-    createTab: (input) => ipcRenderer.invoke(PREVIEW_CREATE_TAB_CHANNEL, input),
-    closeTab: (input) => ipcRenderer.invoke(PREVIEW_CLOSE_TAB_CHANNEL, input),
-    activateTab: (input) => ipcRenderer.invoke(PREVIEW_ACTIVATE_TAB_CHANNEL, input),
+    open: (input) => ipcRenderer.invoke(PREVIEW_OPEN_CHANNEL, input),
+    close: () => ipcRenderer.invoke(PREVIEW_CLOSE_CHANNEL),
     goBack: () => ipcRenderer.invoke(PREVIEW_GO_BACK_CHANNEL),
     goForward: () => ipcRenderer.invoke(PREVIEW_GO_FORWARD_CHANNEL),
     reload: () => ipcRenderer.invoke(PREVIEW_RELOAD_CHANNEL),
     navigate: (input) => ipcRenderer.invoke(PREVIEW_NAVIGATE_CHANNEL, input),
-    toggleDevTools: () => ipcRenderer.invoke(PREVIEW_TOGGLE_DEVTOOLS_CHANNEL),
-    setBounds: (bounds) => ipcRenderer.invoke(PREVIEW_SET_BOUNDS_CHANNEL, bounds),
-    closeAll: () => ipcRenderer.invoke(PREVIEW_CLOSE_ALL_CHANNEL),
+    pickElement: () => ipcRenderer.invoke(PREVIEW_PICK_ELEMENT_CHANNEL),
+    cancelPickElement: () => ipcRenderer.invoke(PREVIEW_CANCEL_PICK_ELEMENT_CHANNEL),
     getState: () => ipcRenderer.invoke(PREVIEW_GET_STATE_CHANNEL),
+    setBounds: (bounds) => ipcRenderer.invoke(PREVIEW_SET_BOUNDS_CHANNEL, bounds),
     onState: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, state: unknown) => {
         if (typeof state !== "object" || state === null) return;
         listener(state as Parameters<typeof listener>[0]);
       };
 
-      ipcRenderer.on(PREVIEW_TABS_STATE_CHANNEL, wrappedListener);
+      ipcRenderer.on(PREVIEW_STATE_CHANNEL, wrappedListener);
       return () => {
-        ipcRenderer.removeListener(PREVIEW_TABS_STATE_CHANNEL, wrappedListener);
+        ipcRenderer.removeListener(PREVIEW_STATE_CHANNEL, wrappedListener);
       };
     },
   },

--- a/apps/desktop/src/preview.test.ts
+++ b/apps/desktop/src/preview.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  createEmptyTabsState,
+  createClosedPreviewState,
+  createPreviewErrorState,
   sanitizeDesktopPreviewBounds,
   validateDesktopPreviewUrl,
 } from "./preview";
@@ -103,11 +104,34 @@ describe("sanitizeDesktopPreviewBounds", () => {
 });
 
 describe("preview state helpers", () => {
-  it("creates empty tabs state", () => {
-    expect(createEmptyTabsState()).toEqual({
-      tabs: [],
-      activeTabId: null,
+  it("creates closed and error states with predictable defaults", () => {
+    expect(createClosedPreviewState()).toEqual({
+      status: "closed",
+      url: null,
+      title: null,
       visible: false,
+      error: null,
+      canGoBack: false,
+      canGoForward: false,
+      pickingElement: false,
+    });
+
+    expect(
+      createPreviewErrorState("load-failed", "Dev server did not respond.", {
+        url: "http://localhost:3000/",
+      }),
+    ).toEqual({
+      status: "error",
+      url: "http://localhost:3000/",
+      title: null,
+      visible: false,
+      error: {
+        code: "load-failed",
+        message: "Dev server did not respond.",
+      },
+      canGoBack: false,
+      canGoForward: false,
+      pickingElement: false,
     });
   });
 });

--- a/apps/desktop/src/preview.ts
+++ b/apps/desktop/src/preview.ts
@@ -1,24 +1,65 @@
 import type {
   DesktopPreviewBounds,
   DesktopPreviewError,
-  PreviewTabsState,
+  DesktopPreviewErrorCode,
+  DesktopPreviewState,
 } from "@okcode/contracts";
-import { sanitizeLocalPreviewBounds, validateHttpPreviewUrl } from "@okcode/shared/preview";
+import {
+  sanitizeLocalPreviewBounds,
+  validateHttpPreviewUrl,
+  validateLocalPreviewUrl,
+} from "@okcode/shared/preview";
 
-const EMPTY_TABS_STATE: PreviewTabsState = {
-  tabs: [],
-  activeTabId: null,
+const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
+  status: "closed",
+  url: null,
+  title: null,
   visible: false,
+  error: null,
+  canGoBack: false,
+  canGoForward: false,
+  pickingElement: false,
 };
 
-export function createEmptyTabsState(): PreviewTabsState {
-  return { ...EMPTY_TABS_STATE };
+function makePreviewError(code: DesktopPreviewErrorCode, message: string): DesktopPreviewError {
+  return { code, message };
+}
+
+export function createClosedPreviewState(): DesktopPreviewState {
+  return { ...CLOSED_PREVIEW_STATE };
+}
+
+export function createPreviewErrorState(
+  code: DesktopPreviewErrorCode,
+  message: string,
+  partial?: Partial<DesktopPreviewState>,
+): DesktopPreviewState {
+  return {
+    status: "error",
+    url: partial?.url ?? null,
+    title: partial?.title ?? null,
+    visible: false,
+    error: makePreviewError(code, message),
+    canGoBack: false,
+    canGoForward: false,
+    pickingElement: false,
+  };
 }
 
 export function validateDesktopPreviewUrl(
   rawUrl: unknown,
 ): { ok: true; url: string } | { ok: false; error: DesktopPreviewError } {
   return validateHttpPreviewUrl(rawUrl);
+}
+
+/**
+ * Stricter validation that only allows localhost URLs.
+ * Kept for contexts where only local dev servers should be previewed.
+ */
+export function validateDesktopLocalPreviewUrl(
+  rawUrl: unknown,
+): { ok: true; url: string } | { ok: false; error: DesktopPreviewError } {
+  return validateLocalPreviewUrl(rawUrl);
 }
 
 export function sanitizeDesktopPreviewBounds(bounds: DesktopPreviewBounds): DesktopPreviewBounds {

--- a/apps/desktop/src/previewController.test.ts
+++ b/apps/desktop/src/previewController.test.ts
@@ -1,199 +1,182 @@
 import type { BrowserWindow } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { openExternalMock, viewInstances, FakeWebContentsView, FakeMenu, FakeMenuItem } = vi.hoisted(
-  () => {
-    const openExternalMock = vi.fn();
-    const viewInstances: Array<{ webContents: unknown }> = [];
+const {
+  beginPreviewElementPickMock,
+  cancelPreviewElementPickMock,
+  openExternalMock,
+  viewInstances,
+  FakeWebContentsView,
+} = vi.hoisted(() => {
+  const beginPreviewElementPickMock = vi.fn();
+  const cancelPreviewElementPickMock = vi.fn(async () => undefined);
+  const openExternalMock = vi.fn();
+  const viewInstances: Array<{ webContents: unknown }> = [];
 
-    class FakeWebContents {
-      private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-      private history: string[] = [];
-      private historyIndex = -1;
-      private destroyed = false;
-      private _devToolsOpen = false;
+  class FakeWebContents {
+    private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    private history: string[] = [];
+    private historyIndex = -1;
+    private destroyed = false;
+    private windowOpenHandler: ((details: { url: string }) => { action: "allow" | "deny" }) | null =
+      null;
 
-      private addListener(event: string, listener: (...args: unknown[]) => void): void {
-        const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
-        listeners.add(listener);
-        this.listeners.set(event, listeners);
+    private addListener(event: string, listener: (...args: unknown[]) => void): void {
+      const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+      listeners.add(listener);
+      this.listeners.set(event, listeners);
+    }
+
+    on = (event: string, listener: (...args: unknown[]) => void) => {
+      this.addListener(event, listener);
+      return this;
+    };
+
+    once = (event: string, listener: (...args: unknown[]) => void) => {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        listener(...args);
+      };
+      this.addListener(event, wrapped);
+      return this;
+    };
+
+    off = (event: string, listener: (...args: unknown[]) => void) => {
+      const listeners = this.listeners.get(event);
+      listeners?.delete(listener);
+      if (listeners && listeners.size === 0) {
+        this.listeners.delete(event);
+      }
+      return this;
+    };
+
+    removeAllListeners = (event?: string) => {
+      if (typeof event === "string") {
+        this.listeners.delete(event);
+      } else {
+        this.listeners.clear();
+      }
+      return this;
+    };
+
+    emit = (event: string, ...args: unknown[]) => {
+      const listeners = [...(this.listeners.get(event) ?? [])];
+      for (const listener of listeners) {
+        listener(...args);
+      }
+      return listeners.length > 0;
+    };
+
+    loadURL = vi.fn(async (url: string) => {
+      if (this.destroyed) {
+        throw new Error("webContents destroyed");
       }
 
-      on = (event: string, listener: (...args: unknown[]) => void) => {
-        this.addListener(event, listener);
-        return this;
-      };
-
-      once = (event: string, listener: (...args: unknown[]) => void) => {
-        const wrapped = (...args: unknown[]) => {
-          this.off(event, wrapped);
-          listener(...args);
-        };
-        this.addListener(event, wrapped);
-        return this;
-      };
-
-      off = (event: string, listener: (...args: unknown[]) => void) => {
-        const listeners = this.listeners.get(event);
-        listeners?.delete(listener);
-        if (listeners && listeners.size === 0) {
-          this.listeners.delete(event);
-        }
-        return this;
-      };
-
-      removeAllListeners = (event?: string) => {
-        if (typeof event === "string") {
-          this.listeners.delete(event);
-        } else {
-          this.listeners.clear();
-        }
-        return this;
-      };
-
-      emit = (event: string, ...args: unknown[]) => {
-        const listeners = [...(this.listeners.get(event) ?? [])];
-        for (const listener of listeners) {
-          listener(...args);
-        }
-        return listeners.length > 0;
-      };
-
-      loadURL = vi.fn(async (url: string) => {
-        if (this.destroyed) {
-          throw new Error("webContents destroyed");
-        }
-
-        const nextUrl = new URL(url).toString();
-        if (this.historyIndex < this.history.length - 1) {
-          this.history = this.history.slice(0, this.historyIndex + 1);
-        }
-        this.history.push(nextUrl);
-        this.historyIndex = this.history.length - 1;
-        this.emit("did-start-loading");
-        this.emit("did-navigate", {}, nextUrl);
-        this.emit(
-          "page-title-updated",
-          { preventDefault: () => undefined },
-          `Page ${this.historyIndex + 1}`,
-        );
-        this.emit("did-stop-loading");
-      });
-
-      reload = vi.fn(() => {
-        if (this.destroyed || this.historyIndex < 0) {
-          return;
-        }
-        this.emit("did-start-loading");
-        this.emit("did-stop-loading");
-      });
-
-      goBack = vi.fn(() => {
-        if (!this.canGoBack()) {
-          return;
-        }
-        this.historyIndex -= 1;
-        this.emit("did-start-loading");
-        this.emit("did-navigate", {}, this.getURL());
-        this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
-        this.emit("did-stop-loading");
-      });
-
-      goForward = vi.fn(() => {
-        if (!this.canGoForward()) {
-          return;
-        }
-        this.historyIndex += 1;
-        this.emit("did-start-loading");
-        this.emit("did-navigate", {}, this.getURL());
-        this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
-        this.emit("did-stop-loading");
-      });
-
-      setWindowOpenHandler = vi.fn();
-
-      inspectElement = vi.fn();
-
-      toggleDevTools = vi.fn(() => {
-        this._devToolsOpen = !this._devToolsOpen;
-        if (this._devToolsOpen) {
-          this.emit("devtools-opened");
-        } else {
-          this.emit("devtools-closed");
-        }
-      });
-
-      isDestroyed = vi.fn(() => this.destroyed);
-
-      getURL = vi.fn(() => this.history[this.historyIndex] ?? "");
-
-      getTitle = vi.fn(() => (this.historyIndex >= 0 ? `Page ${this.historyIndex + 1}` : ""));
-
-      canGoBack = vi.fn(() => this.historyIndex > 0);
-
-      canGoForward = vi.fn(
-        () => this.historyIndex >= 0 && this.historyIndex < this.history.length - 1,
+      const nextUrl = new URL(url).toString();
+      if (this.historyIndex < this.history.length - 1) {
+        this.history = this.history.slice(0, this.historyIndex + 1);
+      }
+      this.history.push(nextUrl);
+      this.historyIndex = this.history.length - 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, nextUrl);
+      this.emit(
+        "page-title-updated",
+        { preventDefault: () => undefined },
+        `Page ${this.historyIndex + 1}`,
       );
+      this.emit("did-stop-loading");
+    });
 
-      close = vi.fn(() => {
-        if (this.destroyed) {
-          return;
-        }
-        this.destroyed = true;
-        this.emit("destroyed");
-      });
-    }
-
-    class FakeWebContentsView {
-      webContents = new FakeWebContents();
-      setBorderRadius = vi.fn();
-      setBounds = vi.fn();
-
-      constructor(_options: unknown) {
-        viewInstances.push(this);
+    reload = vi.fn(() => {
+      if (this.destroyed || this.historyIndex < 0) {
+        return;
       }
-    }
+      this.emit("did-start-loading");
+      this.emit("did-stop-loading");
+    });
 
-    class FakeMenu {
-      items: Array<{ label: string; click?: () => void }> = [];
-      append(item: { label: string; click?: () => void }) {
-        this.items.push(item);
+    goBack = vi.fn(() => {
+      if (!this.canGoBack()) {
+        return;
       }
-      popup = vi.fn();
-    }
+      this.historyIndex -= 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, this.getURL());
+      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+      this.emit("did-stop-loading");
+    });
 
-    class FakeMenuItem {
-      label: string;
-      click: (() => void) | undefined;
-      enabled: boolean;
-      type: string;
-      constructor(options: {
-        label?: string;
-        click?: () => void;
-        enabled?: boolean;
-        type?: string;
-      }) {
-        this.label = options.label ?? "";
-        this.click = options.click ?? undefined;
-        this.enabled = options.enabled ?? true;
-        this.type = options.type ?? "normal";
+    goForward = vi.fn(() => {
+      if (!this.canGoForward()) {
+        return;
       }
-    }
+      this.historyIndex += 1;
+      this.emit("did-start-loading");
+      this.emit("did-navigate", {}, this.getURL());
+      this.emit("page-title-updated", { preventDefault: () => undefined }, this.getTitle());
+      this.emit("did-stop-loading");
+    });
 
-    return { openExternalMock, viewInstances, FakeWebContentsView, FakeMenu, FakeMenuItem };
-  },
-);
+    setWindowOpenHandler = vi.fn(
+      (handler: ((details: { url: string }) => { action: "allow" | "deny" }) | null) => {
+        this.windowOpenHandler = handler;
+        return { action: "deny" as const };
+      },
+    );
+
+    isDestroyed = vi.fn(() => this.destroyed);
+
+    getURL = vi.fn(() => this.history[this.historyIndex] ?? "");
+
+    getTitle = vi.fn(() => (this.historyIndex >= 0 ? `Page ${this.historyIndex + 1}` : ""));
+
+    canGoBack = vi.fn(() => this.historyIndex > 0);
+
+    canGoForward = vi.fn(
+      () => this.historyIndex >= 0 && this.historyIndex < this.history.length - 1,
+    );
+
+    close = vi.fn(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.destroyed = true;
+      this.emit("destroyed");
+    });
+  }
+
+  class FakeWebContentsView {
+    webContents = new FakeWebContents();
+    setBorderRadius = vi.fn();
+    setBounds = vi.fn();
+
+    constructor(_options: unknown) {
+      viewInstances.push(this);
+    }
+  }
+
+  return {
+    beginPreviewElementPickMock,
+    cancelPreviewElementPickMock,
+    openExternalMock,
+    viewInstances,
+    FakeWebContentsView,
+  };
+});
 
 vi.mock("electron", () => ({
   shell: {
     openExternal: openExternalMock,
   },
   WebContentsView: FakeWebContentsView,
-  Menu: FakeMenu,
-  MenuItem: FakeMenuItem,
 }));
 
-import type { PreviewTabsState } from "@okcode/contracts";
+vi.mock("./previewPicker", () => ({
+  beginPreviewElementPick: beginPreviewElementPickMock,
+  cancelPreviewElementPick: cancelPreviewElementPickMock,
+}));
+
 import { DesktopPreviewController } from "./previewController";
 
 function createWindow() {
@@ -211,18 +194,17 @@ function createWindow() {
   } as unknown as BrowserWindow;
 }
 
-function findTab(state: PreviewTabsState, tabId: string) {
-  return state.tabs.find((t) => t.tabId === tabId);
-}
-
 describe("DesktopPreviewController", () => {
   beforeEach(() => {
+    beginPreviewElementPickMock.mockReset();
+    cancelPreviewElementPickMock.mockReset();
+    cancelPreviewElementPickMock.mockResolvedValue(undefined);
     openExternalMock.mockReset();
     viewInstances.length = 0;
   });
 
-  it("creates tabs, navigates, and supports back/forward", async () => {
-    let latestState = null as PreviewTabsState | null;
+  it("keeps browser history across open calls and exposes back/forward state", async () => {
+    let latestState = null as ReturnType<DesktopPreviewController["getState"]> | null;
     const window = createWindow();
     const controller = new DesktopPreviewController(window, (state) => {
       latestState = state;
@@ -238,50 +220,57 @@ describe("DesktopPreviewController", () => {
       viewportHeight: 768,
     });
 
-    const { tabId: tab1Id } = await controller.createTab({
-      url: "http://localhost:3000/",
-      title: "Tab 1",
-    });
+    await controller.open({ url: "http://localhost:3000/", title: "Project preview" });
     expect(viewInstances).toHaveLength(1);
-    expect(latestState).toBeTruthy();
-    expect(latestState!.activeTabId).toBe(tab1Id);
-    expect(latestState!.tabs).toHaveLength(1);
-
-    const tab1 = findTab(latestState!, tab1Id);
-    expect(tab1).toMatchObject({
+    expect(latestState).toMatchObject({
       status: "ready",
       url: "http://localhost:3000/",
       canGoBack: false,
       canGoForward: false,
     });
 
-    // Navigate within the same tab
-    await controller.navigate({ url: "http://localhost:3000/docs" });
+    await controller.open({ url: "http://localhost:3000/docs", title: "Project preview" });
     expect(viewInstances).toHaveLength(1);
-    const tab1After = findTab(latestState!, tab1Id);
-    expect(tab1After).toMatchObject({
+    expect(latestState).toMatchObject({
+      status: "ready",
       url: "http://localhost:3000/docs",
       canGoBack: true,
       canGoForward: false,
     });
 
     controller.goBack();
-    expect(findTab(latestState!, tab1Id)).toMatchObject({
+    expect(latestState).toMatchObject({
+      status: "ready",
       url: "http://localhost:3000/",
       canGoBack: false,
       canGoForward: true,
     });
 
     controller.goForward();
-    expect(findTab(latestState!, tab1Id)).toMatchObject({
+    expect(latestState).toMatchObject({
+      status: "ready",
       url: "http://localhost:3000/docs",
       canGoBack: true,
       canGoForward: false,
     });
+
+    controller.close();
+    expect(latestState).toMatchObject({
+      status: "closed",
+      url: null,
+      canGoBack: false,
+      canGoForward: false,
+    });
+    expect(controller.getState()).toMatchObject({
+      status: "closed",
+      canGoBack: false,
+      canGoForward: false,
+    });
+    expect(window.contentView.removeChildView).toHaveBeenCalledTimes(1);
   });
 
-  it("supports multiple tabs and switching between them", async () => {
-    let latestState = null as PreviewTabsState | null;
+  it("tracks preview element picking state and returns the selected element", async () => {
+    let latestState = null as ReturnType<DesktopPreviewController["getState"]> | null;
     const window = createWindow();
     const controller = new DesktopPreviewController(window, (state) => {
       latestState = state;
@@ -297,34 +286,39 @@ describe("DesktopPreviewController", () => {
       viewportHeight: 768,
     });
 
-    const { tabId: tab1Id } = await controller.createTab({
-      url: "http://localhost:3000/",
+    await controller.open({ url: "http://localhost:3000/", title: "Project preview" });
+    beginPreviewElementPickMock.mockResolvedValueOnce({
+      pageUrl: "http://localhost:3000/",
+      pageTitle: "Homepage",
+      selector: 'button[data-testid="save"]',
+      tagName: "button",
+      role: "button",
+      ariaLabel: "Save changes",
+      text: "Save changes",
+      href: null,
+      name: null,
+      placeholder: null,
     });
-    const { tabId: tab2Id } = await controller.createTab({
-      url: "http://localhost:4000/",
+
+    const result = await controller.pickElement();
+
+    expect(beginPreviewElementPickMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      accepted: true,
+      reason: null,
+      selection: {
+        selector: 'button[data-testid="save"]',
+        role: "button",
+      },
     });
-
-    expect(viewInstances).toHaveLength(2);
-    expect(latestState!.tabs).toHaveLength(2);
-    expect(latestState!.activeTabId).toBe(tab2Id);
-
-    // Switch to tab 1
-    controller.activateTab(tab1Id);
-    expect(latestState!.activeTabId).toBe(tab1Id);
-
-    // Close tab 1 — should activate tab 2
-    controller.closeTab(tab1Id);
-    expect(latestState!.tabs).toHaveLength(1);
-    expect(latestState!.activeTabId).toBe(tab2Id);
-
-    // Close all
-    controller.closeAll();
-    expect(latestState!.tabs).toHaveLength(0);
-    expect(latestState!.activeTabId).toBeNull();
+    expect(latestState).toMatchObject({
+      status: "ready",
+      pickingElement: false,
+    });
   });
 
-  it("toggles devtools on the active tab", async () => {
-    let latestState = null as PreviewTabsState | null;
+  it("cancels active preview element picking when requested", async () => {
+    let latestState = null as ReturnType<DesktopPreviewController["getState"]> | null;
     const window = createWindow();
     const controller = new DesktopPreviewController(window, (state) => {
       latestState = state;
@@ -340,13 +334,34 @@ describe("DesktopPreviewController", () => {
       viewportHeight: 768,
     });
 
-    const { tabId } = await controller.createTab({ url: "http://localhost:3000/" });
-    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(false);
+    await controller.open({ url: "http://localhost:3000/", title: "Project preview" });
 
-    controller.toggleDevTools();
-    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(true);
+    let resolvePick: ((value: null) => void) | null = null;
+    beginPreviewElementPickMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePick = resolve;
+        }),
+    );
+    cancelPreviewElementPickMock.mockImplementationOnce(async () => {
+      resolvePick?.(null);
+    });
 
-    controller.toggleDevTools();
-    expect(findTab(latestState!, tabId)?.devToolsOpen).toBe(false);
+    const pickResultPromise = controller.pickElement();
+    expect(controller.getState().pickingElement).toBe(true);
+
+    await controller.cancelPickElement();
+    const result = await pickResultPromise;
+
+    expect(cancelPreviewElementPickMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      accepted: true,
+      selection: null,
+      reason: "cancelled",
+    });
+    expect(latestState).toMatchObject({
+      status: "ready",
+      pickingElement: false,
+    });
   });
 });

--- a/apps/desktop/src/previewController.ts
+++ b/apps/desktop/src/previewController.ts
@@ -1,15 +1,20 @@
-import { type BrowserWindow, Menu, MenuItem, WebContentsView } from "electron";
+import { type BrowserWindow, type HandlerDetails, shell, WebContentsView } from "electron";
 import type {
   DesktopPreviewBounds,
-  PreviewCreateTabResult,
+  DesktopPreviewElementSelection,
+  DesktopPreviewState,
   PreviewNavigateResult,
-  PreviewTabId,
-  PreviewTabState,
-  PreviewTabsState,
+  PreviewOpenResult,
+  PreviewPickElementResult,
 } from "@okcode/contracts";
-import { randomUUID } from "node:crypto";
 
-import { sanitizeDesktopPreviewBounds, validateDesktopPreviewUrl } from "./preview";
+import {
+  createClosedPreviewState,
+  createPreviewErrorState,
+  sanitizeDesktopPreviewBounds,
+  validateDesktopPreviewUrl,
+} from "./preview";
+import { beginPreviewElementPick, cancelPreviewElementPick } from "./previewPicker";
 import { projectPreviewBoundsToContent } from "./previewBounds";
 
 const PREVIEW_WEB_PREFERENCES = {
@@ -18,30 +23,26 @@ const PREVIEW_WEB_PREFERENCES = {
   sandbox: true,
 } as const;
 
-const ZERO_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
+const ABORTED_LOAD_ERROR_CODE = -3;
+const NAVIGATION_BLOCKED_MESSAGE = "Blocked navigation outside the local preview policy.";
+const PROCESS_GONE_MESSAGE = "Preview process exited unexpectedly.";
 
-interface TabEntry {
-  id: PreviewTabId;
-  view: WebContentsView;
-  state: PreviewTabState;
-}
+type DesktopPreviewStateDraft = Omit<
+  DesktopPreviewState,
+  "visible" | "canGoBack" | "canGoForward"
+> &
+  Partial<Pick<DesktopPreviewState, "visible" | "canGoBack" | "canGoForward">>;
 
-function createClosedTabState(tabId: PreviewTabId): PreviewTabState {
-  return {
-    tabId,
-    status: "closed",
-    url: null,
-    title: null,
-    error: null,
-    canGoBack: false,
-    canGoForward: false,
-    devToolsOpen: false,
-  };
+function previewVisible(
+  state: Pick<DesktopPreviewState, "status">,
+  bounds: DesktopPreviewBounds,
+): boolean {
+  return bounds.visible && state.status !== "closed";
 }
 
 export class DesktopPreviewController {
-  private tabs: Map<PreviewTabId, TabEntry> = new Map();
-  private activeTabId: PreviewTabId | null = null;
+  private view: WebContentsView | null = null;
+  private state: DesktopPreviewState = createClosedPreviewState();
   private bounds: DesktopPreviewBounds = {
     x: 0,
     y: 0,
@@ -51,443 +52,398 @@ export class DesktopPreviewController {
     viewportWidth: 0,
     viewportHeight: 0,
   };
-  private disposingTab = false;
+  private unsubscribers: Array<() => void> = [];
+  private disposingView = false;
+  private activePickPromise: Promise<DesktopPreviewElementSelection | null> | null = null;
 
   constructor(
     private readonly window: BrowserWindow,
-    private readonly onStateChange: (state: PreviewTabsState) => void,
+    private readonly onStateChange: (state: DesktopPreviewState) => void,
   ) {}
 
-  getState(): PreviewTabsState {
-    return this.buildTabsState();
+  getState(): DesktopPreviewState {
+    return this.state;
   }
 
-  async createTab(input: { url: unknown; title?: unknown }): Promise<PreviewCreateTabResult> {
+  async open(input: { url: unknown; title?: unknown }): Promise<PreviewOpenResult> {
     const validatedUrl = validateDesktopPreviewUrl(input.url);
     if (!validatedUrl.ok) {
-      // Still create the tab but in error state
-      const tabId = randomUUID();
-      const tabState: PreviewTabState = {
-        tabId,
-        status: "error",
-        url: null,
-        title: null,
-        error: validatedUrl.error,
-        canGoBack: false,
-        canGoForward: false,
-        devToolsOpen: false,
-      };
-      // Don't actually create a view for invalid URLs
-      return { tabId, state: this.buildTabsState() };
+      this.setState(
+        createPreviewErrorState(validatedUrl.error.code, validatedUrl.error.message, {
+          url: this.state.url,
+          title: this.state.title,
+        }),
+      );
+      return { accepted: false, state: this.state };
     }
 
-    const tabId = randomUUID();
     const nextTitle =
       typeof input.title === "string" && input.title.trim().length > 0 ? input.title : null;
-
-    const view = this.createView(tabId);
-    const tabState: PreviewTabState = {
-      tabId,
+    const view = this.ensureView();
+    this.setState({
       status: "loading",
       url: validatedUrl.url,
-      title: nextTitle,
+      title: nextTitle ?? this.state.title,
+      visible: previewVisible({ status: "loading" }, this.bounds),
       error: null,
-      canGoBack: false,
-      canGoForward: false,
-      devToolsOpen: false,
-    };
-
-    const entry: TabEntry = { id: tabId, view, state: tabState };
-    this.tabs.set(tabId, entry);
-
-    // Switch to this tab
-    this.activateTabInternal(tabId);
-
-    // Load URL
-    void view.webContents.loadURL(validatedUrl.url).catch((error: unknown) => {
-      const tab = this.tabs.get(tabId);
-      if (!tab || tab.view !== view) return;
-      tab.state = {
-        ...tab.state,
-        status: "error",
-        error: {
-          code: "load-failed",
-          message: error instanceof Error ? error.message : String(error),
-        },
-      };
-      this.broadcastState();
+      pickingElement: false,
     });
 
-    const state = this.buildTabsState();
-    return { tabId, state };
+    void view.webContents.loadURL(validatedUrl.url).catch((error: unknown) => {
+      if (this.view !== view) {
+        return;
+      }
+      this.setState(
+        createPreviewErrorState(
+          "load-failed",
+          error instanceof Error ? error.message : String(error),
+          {
+            url: validatedUrl.url,
+            title: this.state.title,
+          },
+        ),
+      );
+    });
+
+    return { accepted: true, state: this.state };
   }
 
-  closeTab(tabId: PreviewTabId): PreviewTabsState {
-    const entry = this.tabs.get(tabId);
-    if (!entry) return this.buildTabsState();
-
-    this.disposeTabView(entry);
-    this.tabs.delete(tabId);
-
-    // If this was the active tab, activate an adjacent one
-    if (this.activeTabId === tabId) {
-      const remaining = Array.from(this.tabs.keys());
-      this.activeTabId = remaining.length > 0 ? remaining[remaining.length - 1]! : null;
-      if (this.activeTabId) {
-        this.applyActiveTabBounds();
-      }
+  async navigate(input: { url: unknown }): Promise<PreviewNavigateResult> {
+    if (!this.view) {
+      return {
+        accepted: false,
+        state: createClosedPreviewState(),
+      };
     }
 
-    return this.broadcastState();
-  }
-
-  activateTab(tabId: PreviewTabId): PreviewTabsState {
-    if (!this.tabs.has(tabId)) return this.buildTabsState();
-    this.activateTabInternal(tabId);
-    return this.broadcastState();
+    const result = await this.open({ url: input.url, title: this.state.title });
+    return {
+      accepted: result.accepted,
+      state: result.state,
+    };
   }
 
   goBack(): void {
-    const view = this.getActiveView();
-    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoBack()) return;
+    const view = this.view;
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoBack()) {
+      return;
+    }
+
     view.webContents.goBack();
   }
 
   goForward(): void {
-    const view = this.getActiveView();
-    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoForward()) return;
+    const view = this.view;
+    if (!view || view.webContents.isDestroyed() || !view.webContents.canGoForward()) {
+      return;
+    }
+
     view.webContents.goForward();
   }
 
   reload(): void {
-    this.getActiveView()?.webContents.reload();
+    void this.cancelElementPick();
+    this.view?.webContents.reload();
   }
 
-  async navigate(input: { url: unknown }): Promise<PreviewNavigateResult> {
-    const activeEntry = this.getActiveEntry();
-    if (!activeEntry) {
-      return { accepted: false, state: this.buildTabsState() };
+  close(): void {
+    void this.cancelElementPick();
+    this.disposeView();
+    this.setState(createClosedPreviewState());
+  }
+
+  async pickElement(): Promise<PreviewPickElementResult> {
+    const view = this.view;
+    if (
+      !view ||
+      view.webContents.isDestroyed() ||
+      (this.state.status !== "ready" && this.state.status !== "loading")
+    ) {
+      return {
+        accepted: false,
+        selection: null,
+        reason: "preview-unavailable",
+        state: this.state,
+      };
     }
 
-    const validatedUrl = validateDesktopPreviewUrl(input.url);
-    if (!validatedUrl.ok) {
-      activeEntry.state = {
-        ...activeEntry.state,
-        status: "error",
-        error: validatedUrl.error,
+    if (this.activePickPromise) {
+      return {
+        accepted: false,
+        selection: null,
+        reason: "already-picking",
+        state: this.state,
       };
-      return { accepted: false, state: this.broadcastState() };
     }
 
-    activeEntry.state = {
-      ...activeEntry.state,
-      status: "loading",
-      url: validatedUrl.url,
-      error: null,
-    };
-    this.broadcastState();
-
-    void activeEntry.view.webContents.loadURL(validatedUrl.url).catch((error: unknown) => {
-      const tab = this.tabs.get(activeEntry.id);
-      if (!tab || tab.view !== activeEntry.view) return;
-      tab.state = {
-        ...tab.state,
-        status: "error",
-        error: {
-          code: "load-failed",
-          message: error instanceof Error ? error.message : String(error),
-        },
-      };
-      this.broadcastState();
+    this.setState({
+      ...this.state,
+      pickingElement: true,
     });
 
-    return { accepted: true, state: this.buildTabsState() };
-  }
+    const pickPromise = beginPreviewElementPick(view.webContents);
+    this.activePickPromise = pickPromise;
 
-  toggleDevTools(): void {
-    const view = this.getActiveView();
-    if (!view || view.webContents.isDestroyed()) return;
-    view.webContents.toggleDevTools();
-  }
-
-  closeAll(): void {
-    for (const entry of this.tabs.values()) {
-      this.disposeTabView(entry);
+    let result: Omit<PreviewPickElementResult, "state"> | null = null;
+    try {
+      const selection = await pickPromise;
+      result = {
+        accepted: true,
+        selection,
+        reason: selection ? null : "cancelled",
+      };
+    } catch {
+      result = {
+        accepted: false,
+        selection: null,
+        reason: "selection-failed",
+      };
+    } finally {
+      if (this.activePickPromise === pickPromise) {
+        this.activePickPromise = null;
+        this.setState({
+          ...this.state,
+          pickingElement: false,
+        });
+      }
     }
-    this.tabs.clear();
-    this.activeTabId = null;
-    this.broadcastState();
+
+    return {
+      ...(result ?? {
+        accepted: false,
+        selection: null,
+        reason: "selection-failed",
+      }),
+      state: this.state,
+    };
+  }
+
+  async cancelPickElement(): Promise<void> {
+    await this.cancelElementPick();
   }
 
   setBounds(bounds: DesktopPreviewBounds): void {
     this.bounds = sanitizeDesktopPreviewBounds(bounds);
-    this.applyActiveTabBounds();
-    this.broadcastState();
+    const appliedVisible = this.applyViewBounds();
+    if (this.state.status !== "closed") {
+      this.setState({
+        ...this.state,
+        visible: previewVisible(this.state, this.bounds) && appliedVisible,
+      });
+    }
   }
 
   destroy(): void {
-    this.closeAll();
+    void this.cancelElementPick();
+    this.disposeView();
+    this.unsubscribers.forEach((unsubscribe) => unsubscribe());
+    this.unsubscribers = [];
   }
 
-  // --- Private helpers ---
+  private ensureView(): WebContentsView {
+    if (this.view && !this.view.webContents.isDestroyed()) {
+      this.applyViewBounds();
+      return this.view;
+    }
 
-  private createView(tabId: PreviewTabId): WebContentsView {
     const view = new WebContentsView({
       webPreferences: PREVIEW_WEB_PREFERENCES,
     });
     view.setBorderRadius(8);
+    this.view = view;
     this.window.contentView.addChildView(view);
-    // Start hidden
-    view.setBounds(ZERO_BOUNDS);
-    this.bindView(tabId, view);
+    this.bindView(view);
+    this.applyViewBounds();
     return view;
   }
 
-  private bindView(tabId: PreviewTabId, view: WebContentsView): void {
+  private bindView(view: WebContentsView): void {
     const { webContents } = view;
 
-    webContents.on("did-start-loading", () => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = {
-        ...tab.state,
+    const onDidStartLoading = () => {
+      void this.cancelElementPick();
+      this.setState({
         status: "loading",
-        url: webContents.getURL() || tab.state.url,
+        url: webContents.getURL() || this.state.url,
+        title: this.state.title,
+        visible: previewVisible(this.state, this.bounds),
         error: null,
-      };
-      this.broadcastState();
-    });
-
-    webContents.on("did-stop-loading", () => {
-      const tab = this.tabs.get(tabId);
-      if (!tab || tab.state.status === "error") return;
-      tab.state = {
-        ...tab.state,
-        status: "ready",
-        url: webContents.getURL() || tab.state.url,
-        title: webContents.getTitle() || tab.state.title,
-        canGoBack: webContents.canGoBack(),
-        canGoForward: webContents.canGoForward(),
-      };
-      this.broadcastState();
-    });
-
-    webContents.on("did-navigate", (_event, url) => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = {
-        ...tab.state,
-        url,
-        canGoBack: webContents.canGoBack(),
-        canGoForward: webContents.canGoForward(),
-      };
-      this.broadcastState();
-    });
-
-    webContents.on("did-navigate-in-page", (_event, url) => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = {
-        ...tab.state,
-        url,
-        canGoBack: webContents.canGoBack(),
-        canGoForward: webContents.canGoForward(),
-      };
-      this.broadcastState();
-    });
-
-    webContents.on("page-title-updated", (event, title) => {
-      event.preventDefault();
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = { ...tab.state, title: title || null };
-      this.broadcastState();
-    });
-
-    webContents.on(
-      "did-fail-load",
-      (_event, errorCode, errorDescription, validatedUrl, isMainFrame) => {
-        if (!isMainFrame || errorCode === -3) return; // -3 = aborted
-        const tab = this.tabs.get(tabId);
-        if (!tab) return;
-        tab.state = {
-          ...tab.state,
-          status: "error",
-          url: validatedUrl || tab.state.url,
-          error: {
-            code: "load-failed",
-            message: errorDescription || "Page failed to load.",
-          },
-        };
-        this.broadcastState();
-      },
-    );
-
-    webContents.on("render-process-gone", () => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = {
-        ...tab.state,
-        status: "error",
-        error: { code: "process-gone", message: "Tab process exited unexpectedly." },
-      };
-      this.broadcastState();
-    });
-
-    webContents.once("destroyed", () => {
-      if (this.disposingTab) return;
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = {
-        ...tab.state,
-        status: "error",
-        error: { code: "process-gone", message: "Tab process exited unexpectedly." },
-      };
-      this.broadcastState();
-    });
-
-    // DevTools tracking
-    webContents.on("devtools-opened", () => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = { ...tab.state, devToolsOpen: true };
-      this.broadcastState();
-    });
-
-    webContents.on("devtools-closed", () => {
-      const tab = this.tabs.get(tabId);
-      if (!tab) return;
-      tab.state = { ...tab.state, devToolsOpen: false };
-      this.broadcastState();
-    });
-
-    // Unrestricted navigation: no will-navigate blocker
-
-    // window.open() → create a new tab
-    webContents.setWindowOpenHandler((details) => {
-      void this.createTab({ url: details.url });
-      return { action: "deny" };
-    });
-
-    // Right-click context menu with "Inspect Element"
-    webContents.on("context-menu", (_event, params) => {
-      const menu = new Menu();
-      if (params.linkURL) {
-        menu.append(
-          new MenuItem({
-            label: "Open Link in New Tab",
-            click: () => {
-              void this.createTab({ url: params.linkURL });
-            },
-          }),
-        );
-        menu.append(new MenuItem({ type: "separator" }));
+        pickingElement: false,
+      });
+    };
+    const onDidStopLoading = () => {
+      if (this.state.status === "error" || this.state.status === "closed") {
+        return;
       }
-      menu.append(
-        new MenuItem({
-          label: "Back",
-          enabled: webContents.canGoBack(),
-          click: () => webContents.goBack(),
+      this.setState({
+        status: "ready",
+        url: webContents.getURL() || this.state.url,
+        title: webContents.getTitle() || this.state.title,
+        visible: previewVisible(this.state, this.bounds),
+        error: null,
+        pickingElement: false,
+      });
+    };
+    const onDidNavigate = (url: string) => {
+      this.setState({
+        ...this.state,
+        url,
+      });
+    };
+    const onPageTitleUpdated = (event: Electron.Event, title: string) => {
+      event.preventDefault();
+      this.setState({
+        ...this.state,
+        title: title || null,
+      });
+    };
+    const onDidFailLoad = (
+      _event: Electron.Event,
+      errorCode: number,
+      errorDescription: string,
+      validatedUrl: string,
+      isMainFrame: boolean,
+    ) => {
+      if (!isMainFrame || errorCode === ABORTED_LOAD_ERROR_CODE) {
+        return;
+      }
+      this.setState(
+        createPreviewErrorState("load-failed", errorDescription || "Preview failed to load.", {
+          url: validatedUrl || this.state.url,
+          title: this.state.title,
         }),
       );
-      menu.append(
-        new MenuItem({
-          label: "Forward",
-          enabled: webContents.canGoForward(),
-          click: () => webContents.goForward(),
+    };
+    const onRenderProcessGone = () => {
+      this.setState(
+        createPreviewErrorState("process-gone", PROCESS_GONE_MESSAGE, {
+          url: this.state.url,
+          title: this.state.title,
         }),
       );
-      menu.append(
-        new MenuItem({
-          label: "Reload",
-          click: () => webContents.reload(),
+    };
+    const onDestroyed = () => {
+      void this.cancelElementPick();
+      if (this.disposingView) {
+        return;
+      }
+      this.view = null;
+      this.setState(
+        createPreviewErrorState("process-gone", PROCESS_GONE_MESSAGE, {
+          url: this.state.url,
+          title: this.state.title,
         }),
       );
-      menu.append(new MenuItem({ type: "separator" }));
-      menu.append(
-        new MenuItem({
-          label: "Inspect Element",
-          click: () => {
-            webContents.inspectElement(params.x, params.y);
-          },
-        }),
-      );
-      menu.popup();
-    });
+    };
+
+    webContents.setWindowOpenHandler((details) => this.handleWindowOpen(details));
+    webContents.on("will-navigate", this.handleWillNavigate);
+    webContents.on("did-start-loading", onDidStartLoading);
+    webContents.on("did-stop-loading", onDidStopLoading);
+    webContents.on("did-navigate", (_event, url) => onDidNavigate(url));
+    webContents.on("did-navigate-in-page", (_event, url) => onDidNavigate(url));
+    webContents.on("page-title-updated", onPageTitleUpdated);
+    webContents.on("did-fail-load", onDidFailLoad);
+    webContents.on("render-process-gone", onRenderProcessGone);
+    webContents.once("destroyed", onDestroyed);
   }
 
-  private activateTabInternal(tabId: PreviewTabId): void {
-    // Hide current active tab
-    if (this.activeTabId && this.activeTabId !== tabId) {
-      const oldEntry = this.tabs.get(this.activeTabId);
-      if (oldEntry && !oldEntry.view.webContents.isDestroyed()) {
-        oldEntry.view.setBounds(ZERO_BOUNDS);
-      }
+  private readonly handleWillNavigate = (event: Electron.Event, url: string) => {
+    const validatedUrl = validateDesktopPreviewUrl(url);
+    if (validatedUrl.ok) {
+      return;
     }
 
-    this.activeTabId = tabId;
-    this.applyActiveTabBounds();
+    event.preventDefault();
+    this.setState(
+      createPreviewErrorState("navigation-blocked", NAVIGATION_BLOCKED_MESSAGE, {
+        url: this.state.url,
+        title: this.state.title,
+      }),
+    );
+  };
+
+  private handleWindowOpen(details: HandlerDetails): Electron.WindowOpenHandlerResponse {
+    const validatedUrl = validateDesktopPreviewUrl(details.url);
+    if (validatedUrl.ok) {
+      void shell.openExternal(validatedUrl.url);
+      return { action: "deny" };
+    }
+
+    this.setState(
+      createPreviewErrorState("navigation-blocked", NAVIGATION_BLOCKED_MESSAGE, {
+        url: this.state.url,
+        title: this.state.title,
+      }),
+    );
+    return { action: "deny" };
   }
 
-  private applyActiveTabBounds(): void {
-    if (!this.activeTabId) return;
-    const entry = this.tabs.get(this.activeTabId);
-    if (!entry || entry.view.webContents.isDestroyed()) return;
+  private applyViewBounds(): boolean {
+    if (!this.view || this.view.webContents.isDestroyed()) {
+      return false;
+    }
 
     const nextBounds = projectPreviewBoundsToContent(this.bounds, this.window.getContentBounds());
-    entry.view.setBounds(nextBounds);
+    this.view.setBounds(nextBounds);
+    return nextBounds.width > 0 && nextBounds.height > 0;
   }
 
-  private getActiveEntry(): TabEntry | null {
-    if (!this.activeTabId) return null;
-    return this.tabs.get(this.activeTabId) ?? null;
-  }
+  private disposeView(): void {
+    const existingView = this.view;
+    if (!existingView) {
+      return;
+    }
 
-  private getActiveView(): WebContentsView | null {
-    return this.getActiveEntry()?.view ?? null;
-  }
-
-  private disposeTabView(entry: TabEntry): void {
-    this.disposingTab = true;
+    this.disposingView = true;
+    this.view = null;
     try {
-      this.window.contentView.removeChildView(entry.view);
+      this.window.contentView.removeChildView(existingView);
     } catch {
       // Window may already be torn down.
     }
-    if (!entry.view.webContents.isDestroyed()) {
-      entry.view.webContents.close({ waitForBeforeUnload: false });
+    if (!existingView.webContents.isDestroyed()) {
+      existingView.webContents.close({ waitForBeforeUnload: false });
     }
-    entry.view.webContents.removeAllListeners();
-    this.disposingTab = false;
+    existingView.webContents.removeAllListeners();
+    this.disposingView = false;
   }
 
-  private buildTabsState(): PreviewTabsState {
-    const tabs: PreviewTabState[] = [];
-    for (const entry of this.tabs.values()) {
-      // Refresh navigation state from live webContents
-      const wc = entry.view.webContents;
-      if (!wc.isDestroyed()) {
-        entry.state = {
-          ...entry.state,
-          canGoBack: wc.canGoBack(),
-          canGoForward: wc.canGoForward(),
-        };
-      }
-      tabs.push(entry.state);
+  private currentNavigationState(): Pick<DesktopPreviewState, "canGoBack" | "canGoForward"> {
+    const webContents = this.view?.webContents;
+    if (!webContents || webContents.isDestroyed()) {
+      return {
+        canGoBack: false,
+        canGoForward: false,
+      };
     }
 
-    const visible = this.bounds.visible && tabs.length > 0 && this.activeTabId !== null;
-
     return {
-      tabs,
-      activeTabId: this.activeTabId,
-      visible,
+      canGoBack: webContents.canGoBack(),
+      canGoForward: webContents.canGoForward(),
     };
   }
 
-  private broadcastState(): PreviewTabsState {
-    const state = this.buildTabsState();
-    this.onStateChange(state);
-    return state;
+  private setState(nextState: DesktopPreviewStateDraft): void {
+    this.state = {
+      ...nextState,
+      ...this.currentNavigationState(),
+      visible: previewVisible(nextState, this.bounds),
+    };
+    this.onStateChange(this.state);
+  }
+
+  private async cancelElementPick(): Promise<void> {
+    const pickPromise = this.activePickPromise;
+    const webContents = this.view?.webContents;
+    if (!pickPromise || !webContents || webContents.isDestroyed()) {
+      return;
+    }
+
+    try {
+      await cancelPreviewElementPick(webContents);
+    } catch {
+      // The picker is best-effort cleanup; navigation and view disposal can race it.
+    }
   }
 }

--- a/apps/desktop/src/previewPicker.ts
+++ b/apps/desktop/src/previewPicker.ts
@@ -1,0 +1,303 @@
+import type { DesktopPreviewElementSelection } from "@okcode/contracts";
+
+const PREVIEW_PICKER_CHANNEL = "__okcodePreviewPicker";
+
+function buildPreviewPickerScript(): string {
+  return `
+(() => {
+  const CHANNEL_KEY = ${JSON.stringify(PREVIEW_PICKER_CHANNEL)};
+  const globalState = window;
+  const existingPicker = globalState[CHANNEL_KEY];
+  if (existingPicker && typeof existingPicker.cancel === "function") {
+    existingPicker.cancel();
+  }
+
+  const escapeSelector = (value) => {
+    if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+      return CSS.escape(value);
+    }
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\\\$&");
+  };
+
+  const normalizeText = (value, maxLength = 180) => {
+    const normalized = typeof value === "string" ? value.replace(/\\s+/g, " ").trim() : "";
+    if (normalized.length <= maxLength) {
+      return normalized;
+    }
+    return normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd() + "...";
+  };
+
+  const describeElement = (element) => {
+    const tagName = (element.tagName || "element").toLowerCase();
+    const role = normalizeText(element.getAttribute("role"), 80) || null;
+    const ariaLabel = normalizeText(element.getAttribute("aria-label"), 120) || null;
+    const text =
+      normalizeText(
+        "innerText" in element && typeof element.innerText === "string"
+          ? element.innerText
+          : element.textContent,
+      ) || "";
+    const href =
+      "href" in element && typeof element.href === "string" && element.href.length > 0
+        ? element.href
+        : null;
+    const name = normalizeText(element.getAttribute("name"), 120) || null;
+    const placeholder = normalizeText(element.getAttribute("placeholder"), 120) || null;
+    const pageTitle = normalizeText(document.title, 160) || null;
+    const pageUrl = window.location.href;
+    const selector = buildSelector(element);
+
+    return {
+      pageUrl,
+      pageTitle,
+      selector,
+      tagName,
+      role,
+      ariaLabel,
+      text,
+      href,
+      name,
+      placeholder,
+    };
+  };
+
+  const describeLabel = (selection) => {
+    const kind = selection.role || selection.tagName || "element";
+    const primary =
+      selection.ariaLabel ||
+      selection.text ||
+      selection.placeholder ||
+      selection.name ||
+      selection.selector;
+    if (primary && primary !== selection.selector) {
+      return kind + ' "' + primary + '"';
+    }
+    return kind + " " + selection.selector;
+  };
+
+  const buildSelector = (element) => {
+    const segments = [];
+    let current = element;
+    let depth = 0;
+
+    while (current && current.nodeType === Node.ELEMENT_NODE && depth < 5) {
+      const tagName = current.tagName.toLowerCase();
+      if (current.id) {
+        segments.unshift(tagName + "#" + escapeSelector(current.id));
+        break;
+      }
+
+      let segment = tagName;
+      const prioritizedAttributes = [
+        "data-testid",
+        "data-test",
+        "data-qa",
+        "aria-label",
+        "name",
+      ];
+      for (const attributeName of prioritizedAttributes) {
+        const attributeValue = current.getAttribute(attributeName);
+        if (!attributeValue) {
+          continue;
+        }
+        segment +=
+          "[" +
+          attributeName +
+          '="' +
+          String(attributeValue).replace(/"/g, '\\\\"') +
+          '"]';
+        segments.unshift(segment);
+        return segments.join(" > ");
+      }
+
+      const classNames = Array.from(current.classList)
+        .filter(Boolean)
+        .slice(0, 2);
+      if (classNames.length > 0) {
+        segment += classNames.map((className) => "." + escapeSelector(className)).join("");
+      } else if (current.parentElement) {
+        const siblings = Array.from(current.parentElement.children).filter(
+          (child) => child.tagName === current.tagName,
+        );
+        if (siblings.length > 1) {
+          const siblingIndex = siblings.indexOf(current);
+          segment += ":nth-of-type(" + String(siblingIndex + 1) + ")";
+        }
+      }
+
+      segments.unshift(segment);
+      current = current.parentElement;
+      depth += 1;
+    }
+
+    return segments.join(" > ");
+  };
+
+  const overlay = document.createElement("div");
+  overlay.style.position = "fixed";
+  overlay.style.left = "0";
+  overlay.style.top = "0";
+  overlay.style.width = "0";
+  overlay.style.height = "0";
+  overlay.style.pointerEvents = "none";
+  overlay.style.zIndex = "2147483646";
+  overlay.style.borderRadius = "8px";
+  overlay.style.border = "2px solid rgba(59, 130, 246, 0.92)";
+  overlay.style.background = "rgba(59, 130, 246, 0.12)";
+  overlay.style.boxShadow = "0 0 0 1px rgba(15, 23, 42, 0.3), 0 10px 30px rgba(15, 23, 42, 0.18)";
+
+  const badge = document.createElement("div");
+  badge.style.position = "fixed";
+  badge.style.left = "0";
+  badge.style.top = "0";
+  badge.style.maxWidth = "min(360px, calc(100vw - 24px))";
+  badge.style.pointerEvents = "none";
+  badge.style.zIndex = "2147483647";
+  badge.style.borderRadius = "999px";
+  badge.style.padding = "6px 10px";
+  badge.style.font = "600 12px/1.3 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  badge.style.color = "white";
+  badge.style.background = "rgba(15, 23, 42, 0.88)";
+  badge.style.boxShadow = "0 10px 24px rgba(15, 23, 42, 0.28)";
+  badge.style.transform = "translate(-9999px, -9999px)";
+  badge.textContent = "Select an element";
+
+  document.documentElement.appendChild(overlay);
+  document.documentElement.appendChild(badge);
+
+  let activeTarget = null;
+  let resolved = false;
+
+  const moveOverlayToTarget = (target) => {
+    if (!target) {
+      overlay.style.width = "0";
+      overlay.style.height = "0";
+      badge.style.transform = "translate(-9999px, -9999px)";
+      return;
+    }
+
+    const rect = target.getBoundingClientRect();
+    overlay.style.left = rect.left + "px";
+    overlay.style.top = rect.top + "px";
+    overlay.style.width = rect.width + "px";
+    overlay.style.height = rect.height + "px";
+
+    const selection = describeElement(target);
+    badge.textContent = describeLabel(selection);
+    const nextLeft = Math.max(12, Math.min(rect.left, window.innerWidth - 372));
+    const nextTop = rect.top > 40 ? rect.top - 36 : rect.bottom + 12;
+    badge.style.transform = "translate(" + nextLeft + "px, " + nextTop + "px)";
+  };
+
+  const cleanup = (result) => {
+    if (resolved) {
+      return result;
+    }
+    resolved = true;
+    document.removeEventListener("mousemove", onMouseMove, true);
+    document.removeEventListener("click", onClick, true);
+    document.removeEventListener("keydown", onKeyDown, true);
+    window.removeEventListener("scroll", onViewportChange, true);
+    window.removeEventListener("resize", onViewportChange, true);
+    overlay.remove();
+    badge.remove();
+    if (globalState[CHANNEL_KEY] && globalState[CHANNEL_KEY].cleanup === cleanup) {
+      delete globalState[CHANNEL_KEY];
+    }
+    return result;
+  };
+
+  const cancel = () => cleanup(null);
+
+  const updateTarget = (target) => {
+    if (!(target instanceof Element)) {
+      activeTarget = null;
+      moveOverlayToTarget(null);
+      return;
+    }
+    activeTarget = target;
+    moveOverlayToTarget(target);
+  };
+
+  const onMouseMove = (event) => {
+    updateTarget(document.elementFromPoint(event.clientX, event.clientY));
+  };
+
+  const onViewportChange = () => {
+    moveOverlayToTarget(activeTarget);
+  };
+
+  const onClick = (event) => {
+    const target = document.elementFromPoint(event.clientX, event.clientY);
+    if (!(target instanceof Element)) {
+      event.preventDefault();
+      event.stopPropagation();
+      resolvePromise(cancel());
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+    resolvePromise(cleanup(describeElement(target)));
+  };
+
+  const onKeyDown = (event) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+    resolvePromise(cancel());
+  };
+
+  globalState[CHANNEL_KEY] = {
+    cancel: () => resolvePromise(cancel()),
+    cleanup,
+  };
+
+  let resolvePromise;
+  const promise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  document.addEventListener("mousemove", onMouseMove, true);
+  document.addEventListener("click", onClick, true);
+  document.addEventListener("keydown", onKeyDown, true);
+  window.addEventListener("scroll", onViewportChange, true);
+  window.addEventListener("resize", onViewportChange, true);
+
+  updateTarget(document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2));
+  return promise;
+})()
+`;
+}
+
+const PREVIEW_PICKER_SCRIPT = buildPreviewPickerScript();
+
+const PREVIEW_PICKER_CANCEL_SCRIPT = `
+(() => {
+  const picker = window[${JSON.stringify(PREVIEW_PICKER_CHANNEL)}];
+  if (picker && typeof picker.cancel === "function") {
+    picker.cancel();
+  }
+})()
+`;
+
+interface PreviewPickerWebContents {
+  executeJavaScript<T>(code: string): Promise<T>;
+}
+
+export async function beginPreviewElementPick(
+  webContents: PreviewPickerWebContents,
+): Promise<DesktopPreviewElementSelection | null> {
+  return webContents.executeJavaScript<DesktopPreviewElementSelection | null>(
+    PREVIEW_PICKER_SCRIPT,
+  );
+}
+
+export async function cancelPreviewElementPick(
+  webContents: PreviewPickerWebContents,
+): Promise<void> {
+  await webContents.executeJavaScript(PREVIEW_PICKER_CANCEL_SCRIPT);
+}

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -20,6 +20,7 @@ describe("deriveComposerSendState", () => {
           createdAt: "2026-03-17T12:52:29.000Z",
         },
       ],
+      previewContexts: [],
     });
 
     expect(state.trimmedPrompt).toBe("");
@@ -44,10 +45,39 @@ describe("deriveComposerSendState", () => {
           createdAt: "2026-03-17T12:52:29.000Z",
         },
       ],
+      previewContexts: [],
     });
 
     expect(state.trimmedPrompt).toBe("yoo  waddup");
     expect(state.expiredTerminalContextCount).toBe(1);
+    expect(state.hasSendableContent).toBe(true);
+  });
+
+  it("treats preview element references as sendable content even without text", () => {
+    const state = deriveComposerSendState({
+      prompt: "",
+      imageCount: 0,
+      terminalContexts: [],
+      previewContexts: [
+        {
+          id: "preview-1",
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          createdAt: "2026-03-28T12:00:00.000Z",
+          pageUrl: "http://localhost:3000/",
+          pageTitle: "Homepage",
+          selector: 'button[data-testid="submit"]',
+          tagName: "button",
+          role: "button",
+          ariaLabel: null,
+          text: "Submit",
+          href: null,
+          name: null,
+          placeholder: null,
+        },
+      ],
+    });
+
+    expect(state.sendablePreviewContexts).toHaveLength(1);
     expect(state.hasSendableContent).toBe(true);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -8,6 +8,7 @@ import {
   stripInlineTerminalContextPlaceholders,
   type TerminalContextDraft,
 } from "../lib/terminalContext";
+import { type PreviewContextDraft } from "../lib/previewContext";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "okcode:last-invoked-script-by-project";
 const WORKTREE_BRANCH_PREFIX = "okcode";
@@ -82,6 +83,7 @@ export interface QueuedMessage {
   text: string;
   images: ComposerImageAttachment[];
   terminalContexts: TerminalContextDraft[];
+  previewContexts: PreviewContextDraft[];
   createdAt: string;
 }
 
@@ -133,22 +135,29 @@ export function deriveComposerSendState(options: {
   prompt: string;
   imageCount: number;
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
+  previewContexts: ReadonlyArray<PreviewContextDraft>;
 }): {
   trimmedPrompt: string;
   sendableTerminalContexts: TerminalContextDraft[];
+  sendablePreviewContexts: PreviewContextDraft[];
   expiredTerminalContextCount: number;
   hasSendableContent: boolean;
 } {
   const trimmedPrompt = stripInlineTerminalContextPlaceholders(options.prompt).trim();
   const sendableTerminalContexts = filterTerminalContextsWithText(options.terminalContexts);
+  const sendablePreviewContexts = [...options.previewContexts];
   const expiredTerminalContextCount =
     options.terminalContexts.length - sendableTerminalContexts.length;
   return {
     trimmedPrompt,
     sendableTerminalContexts,
+    sendablePreviewContexts,
     expiredTerminalContextCount,
     hasSendableContent:
-      trimmedPrompt.length > 0 || options.imageCount > 0 || sendableTerminalContexts.length > 0,
+      trimmedPrompt.length > 0 ||
+      options.imageCount > 0 ||
+      sendableTerminalContexts.length > 0 ||
+      sendablePreviewContexts.length > 0,
   };
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -153,13 +153,18 @@ import {
   useComposerThreadDraft,
 } from "../composerDraftStore";
 import {
-  appendTerminalContextsToPrompt,
   formatTerminalContextLabel,
   insertInlineTerminalContextPlaceholder,
   removeInlineTerminalContextPlaceholder,
   type TerminalContextDraft,
   type TerminalContextSelection,
 } from "../lib/terminalContext";
+import {
+  type PreviewContextDraft,
+  buildPreviewContextDedupKey,
+  formatPreviewContextLabel,
+} from "../lib/previewContext";
+import { appendUserMessageContextsToPrompt } from "../lib/userMessageContext";
 import { deriveLatestContextWindowSnapshot } from "../lib/contextWindow";
 import { shouldUseCompactComposerFooter } from "./composerFooterLayout";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
@@ -188,6 +193,7 @@ import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
 import { CompanionConnectionBanner } from "./chat/CompanionConnectionBanner";
 import { MobileThreadAttentionBar } from "./chat/MobileThreadAttentionBar";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
+import { ComposerPendingPreviewContexts } from "./chat/ComposerPendingPreviewContexts";
 import {
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
@@ -205,7 +211,6 @@ import {
   SendPhase,
 } from "./ChatView.logic";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
-import { readDesktopPreviewBridge } from "~/desktopPreview";
 import { usePreviewStateStore } from "~/previewStateStore";
 import { useClientMode } from "~/hooks/useClientMode";
 import { useTransportState } from "~/hooks/useTransportState";
@@ -292,9 +297,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setStickyComposerModel = useComposerDraftStore((store) => store.setStickyModel);
   const timestampFormat = settings.timestampFormat;
   const navigate = useNavigate();
-  const previewOpen = usePreviewStateStore((state) => state.globalOpen);
-  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleGlobalOpen);
-  const setPreviewOpen = usePreviewStateStore((state) => state.setGlobalOpen);
+  const previewOpen = usePreviewStateStore((state) => state.openByThreadId[threadId] === true);
+  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleThreadOpen);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
   const previewDock = usePreviewStateStore((state) => state.dockByThreadId[threadId] ?? "right");
   const previewSize = usePreviewStateStore(
     (state) => state.sizeByThreadId[threadId] ?? PREVIEW_SPLIT_DEFAULT_SIZE_PX,
@@ -303,6 +308,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setPreviewDock = usePreviewStateStore((state) => state.setThreadDock);
   const togglePreviewLayout = usePreviewStateStore((state) => state.toggleThreadLayout);
   const setPreviewSize = usePreviewStateStore((state) => state.setThreadSize);
+  const setPreviewProjectUrl = usePreviewStateStore((state) => state.setProjectUrl);
   const previewSplitRef = useRef<HTMLDivElement | null>(null);
   const previewResizeStateRef = useRef<{
     pointerId: number;
@@ -321,14 +327,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const prompt = composerDraft.prompt;
   const composerImages = composerDraft.images;
   const composerTerminalContexts = composerDraft.terminalContexts;
+  const composerPreviewContexts = composerDraft.previewContexts;
   const composerSendState = useMemo(
     () =>
       deriveComposerSendState({
         prompt,
         imageCount: composerImages.length,
         terminalContexts: composerTerminalContexts,
+        previewContexts: composerPreviewContexts,
       }),
-    [composerImages.length, composerTerminalContexts, prompt],
+    [composerImages.length, composerPreviewContexts, composerTerminalContexts, prompt],
   );
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
@@ -347,8 +355,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const addComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.addTerminalContexts,
   );
+  const addComposerDraftPreviewContexts = useComposerDraftStore(
+    (store) => store.addPreviewContexts,
+  );
   const removeComposerDraftTerminalContext = useComposerDraftStore(
     (store) => store.removeTerminalContext,
+  );
+  const removeComposerDraftPreviewContext = useComposerDraftStore(
+    (store) => store.removePreviewContext,
   );
   const setComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.setTerminalContexts,
@@ -384,6 +398,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const queuedMessagesRef = useRef(queuedMessages);
   queuedMessagesRef.current = queuedMessages;
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>(composerTerminalContexts);
+  const composerPreviewContextsRef = useRef<PreviewContextDraft[]>(composerPreviewContexts);
   const [localDraftErrorsByThreadId, setLocalDraftErrorsByThreadId] = useState<
     Record<ThreadId, string | null>
   >({});
@@ -500,6 +515,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [addComposerDraftTerminalContexts, threadId],
   );
+  const addComposerPreviewContextsToDraft = useCallback(
+    (contexts: PreviewContextDraft[]) => {
+      addComposerDraftPreviewContexts(threadId, contexts);
+    },
+    [addComposerDraftPreviewContexts, threadId],
+  );
   const removeComposerImageFromDraft = useCallback(
     (imageId: string) => {
       removeComposerDraftImage(threadId, imageId);
@@ -527,6 +548,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
       );
     },
     [composerTerminalContexts, removeComposerDraftTerminalContext, setPrompt, threadId],
+  );
+  const removeComposerPreviewContextFromDraft = useCallback(
+    (contextId: string) => {
+      removeComposerDraftPreviewContext(threadId, contextId);
+    },
+    [removeComposerDraftPreviewContext, threadId],
   );
 
   const serverThread = threads.find((t) => t.id === threadId);
@@ -1299,6 +1326,31 @@ export default function ChatView({ threadId }: ChatViewProps) {
       focusComposer();
     });
   }, [focusComposer]);
+  const handlePreviewElementSelected = useCallback(
+    (selection: PreviewContextDraft) => {
+      const dedupKey = buildPreviewContextDedupKey(selection);
+      const alreadyAttached = composerPreviewContexts.some(
+        (context) => buildPreviewContextDedupKey(context) === dedupKey,
+      );
+      if (alreadyAttached) {
+        toastManager.add({
+          type: "info",
+          title: "Element already referenced",
+          description: `${formatPreviewContextLabel(selection)} is already attached to this draft.`,
+        });
+        return;
+      }
+
+      addComposerPreviewContextsToDraft([selection]);
+      focusComposer();
+      toastManager.add({
+        type: "success",
+        title: "Element referenced",
+        description: `${formatPreviewContextLabel(selection)} will be included with your next message.`,
+      });
+    },
+    [addComposerPreviewContextsToDraft, composerPreviewContexts, focusComposer],
+  );
   const addTerminalContextToDraft = useCallback(
     (selection: TerminalContextSelection) => {
       if (!activeThread) {
@@ -1341,14 +1393,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [activeThread, composerCursor, composerTerminalContexts, insertComposerDraftTerminalContext],
   );
-  const previewBridgeRef = readDesktopPreviewBridge();
   const handlePreviewUrl = useCallback(
     (url: string) => {
       if (!activeProject || !activeThread) return;
-      setPreviewOpen(true);
-      void previewBridgeRef?.createTab({ url });
+      setPreviewProjectUrl(activeProject.id, url);
+      setPreviewOpen(activeThread.id, true);
     },
-    [activeProject, activeThread, setPreviewOpen, previewBridgeRef],
+    [activeProject, activeThread, setPreviewProjectUrl, setPreviewOpen],
   );
   const openLinksExternally = settings.openLinksExternally;
   const onPreviewUrl =
@@ -2104,6 +2155,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [composerTerminalContexts]);
 
   useEffect(() => {
+    composerPreviewContextsRef.current = composerPreviewContexts;
+  }, [composerPreviewContexts]);
+
+  useEffect(() => {
     if (!activeThread?.id) return;
     if (activeThread.messages.length === 0) {
       return;
@@ -2340,10 +2395,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const messageIdForSend = nextQueued.id;
     const messageCreatedAt = new Date().toISOString();
     const composerTerminalContextsSnapshot = nextQueued.terminalContexts;
-    const messageTextForSend = appendTerminalContextsToPrompt(
-      nextQueued.text,
-      composerTerminalContextsSnapshot,
-    );
+    const composerPreviewContextsSnapshot = nextQueued.previewContexts;
+    const messageTextForSend = appendUserMessageContextsToPrompt(nextQueued.text, {
+      terminalContexts: composerTerminalContextsSnapshot,
+      previewContexts: composerPreviewContextsSnapshot,
+    });
     const outgoingMessageText = formatOutgoingPrompt({
       provider: selectedProvider,
       effort: selectedPromptEffort,
@@ -2705,13 +2761,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const nextImages = latestDraft?.images ?? composerImagesRef.current;
     const nextTerminalContexts =
       latestDraft?.terminalContexts ?? composerTerminalContextsRef.current;
+    const nextPreviewContexts = latestDraft?.previewContexts ?? composerPreviewContextsRef.current;
     promptRef.current = nextPrompt;
     composerImagesRef.current = nextImages;
     composerTerminalContextsRef.current = nextTerminalContexts;
+    composerPreviewContextsRef.current = nextPreviewContexts;
     return {
       prompt: nextPrompt,
       images: nextImages,
       terminalContexts: nextTerminalContexts,
+      previewContexts: nextPreviewContexts,
     };
   }, [activeThread]);
 
@@ -2727,15 +2786,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const promptForSend = liveComposerDraft.prompt;
     const composerImagesForSend = liveComposerDraft.images;
     const composerTerminalContextsForSend = liveComposerDraft.terminalContexts;
+    const composerPreviewContextsForSend = liveComposerDraft.previewContexts;
     const {
       trimmedPrompt: trimmed,
       sendableTerminalContexts: sendableComposerTerminalContexts,
+      sendablePreviewContexts: sendableComposerPreviewContexts,
       expiredTerminalContextCount,
       hasSendableContent,
     } = deriveComposerSendState({
       prompt: promptForSend,
       imageCount: composerImagesForSend.length,
       terminalContexts: composerTerminalContextsForSend,
+      previewContexts: composerPreviewContextsForSend,
     });
     if (showPlanFollowUpPrompt && activeProposedPlan) {
       const followUp = resolvePlanFollowUpSubmission({
@@ -2754,7 +2816,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
       return;
     }
     const standaloneSlashCommand =
-      composerImagesForSend.length === 0 && sendableComposerTerminalContexts.length === 0
+      composerImagesForSend.length === 0 &&
+      sendableComposerTerminalContexts.length === 0 &&
+      sendableComposerPreviewContexts.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -2784,10 +2848,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     // ── Queue message if a turn is already running ────────────────────
     if (phase === "running") {
       const composerImagesSnapshot = [...composerImagesForSend];
-      const messageTextForSend = appendTerminalContextsToPrompt(
-        promptForSend,
-        sendableComposerTerminalContexts,
-      );
+      const messageTextForSend = appendUserMessageContextsToPrompt(promptForSend, {
+        terminalContexts: sendableComposerTerminalContexts,
+        previewContexts: sendableComposerPreviewContexts,
+      });
       const messageCreatedAt = new Date().toISOString();
       const outgoingMessageText = formatOutgoingPrompt({
         provider: selectedProvider,
@@ -2810,6 +2874,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           text: promptForSend,
           images: composerImagesSnapshot,
           terminalContexts: [...sendableComposerTerminalContexts],
+          previewContexts: [...sendableComposerPreviewContexts],
           createdAt: messageCreatedAt,
         },
       ]);
@@ -2871,10 +2936,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
     const composerImagesSnapshot = [...composerImagesForSend];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
-    const messageTextForSend = appendTerminalContextsToPrompt(
-      promptForSend,
-      composerTerminalContextsSnapshot,
-    );
+    const composerPreviewContextsSnapshot = [...sendableComposerPreviewContexts];
+    const messageTextForSend = appendUserMessageContextsToPrompt(promptForSend, {
+      terminalContexts: composerTerminalContextsSnapshot,
+      previewContexts: composerPreviewContextsSnapshot,
+    });
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
     const outgoingMessageText = formatOutgoingPrompt({
@@ -3083,7 +3149,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         !turnStartSucceeded &&
         promptRef.current.length === 0 &&
         composerImagesRef.current.length === 0 &&
-        composerTerminalContextsRef.current.length === 0
+        composerTerminalContextsRef.current.length === 0 &&
+        composerPreviewContextsRef.current.length === 0
       ) {
         setOptimisticUserMessages((existing) => {
           const removed = existing.filter((message) => message.id === messageIdForSend);
@@ -3098,6 +3165,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
         addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
         addComposerTerminalContextsToDraft(composerTerminalContextsSnapshot);
+        addComposerPreviewContextsToDraft(composerPreviewContextsSnapshot);
         setComposerTrigger(detectComposerTrigger(promptForSend, promptForSend.length));
       }
       setThreadError(
@@ -4002,11 +4070,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       event.preventDefault();
       if (previewOpen && previewDock === targetDock) {
-        setPreviewOpen(false);
+        setPreviewOpen(threadId, false);
         return;
       }
 
-      setPreviewOpen(true);
+      setPreviewOpen(threadId, true);
       setPreviewDock(threadId, targetDock);
     };
 
@@ -4061,7 +4129,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           onImportProjectScripts={importProjectScripts}
           onToggleTerminal={toggleTerminalVisibility}
           onToggleDiff={onToggleDiff}
-          onTogglePreview={() => togglePreviewOpen()}
+          onTogglePreview={() => togglePreviewOpen(activeThread.id)}
           onTogglePreviewLayout={() => togglePreviewLayout(activeThread.id)}
           onToggleCodeViewer={toggleCodeViewer}
         />
@@ -4098,7 +4166,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <PreviewPanel
                   key={previewPanelKey ?? undefined}
                   threadId={activeThread.id}
-                  onClose={() => setPreviewOpen(false)}
+                  projectId={activeProject.id}
+                  projectName={activeProject.name}
+                  onElementSelected={(selection) => {
+                    handlePreviewElementSelected({
+                      ...selection,
+                      id: randomUUID(),
+                      threadId: activeThread.id,
+                      createdAt: new Date().toISOString(),
+                    });
+                  }}
+                  onClose={() => setPreviewOpen(activeThread.id, false)}
                 />
               </div>
               <div
@@ -4357,6 +4435,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             ))}
                           </div>
                         )}
+                      {!isComposerApprovalState &&
+                      pendingUserInputs.length === 0 &&
+                      composerPreviewContexts.length > 0 ? (
+                        <ComposerPendingPreviewContexts
+                          contexts={composerPreviewContexts}
+                          onRemoveContext={removeComposerPreviewContextFromDraft}
+                          className="mb-3"
+                        />
+                      ) : null}
                       <ComposerPromptEditor
                         ref={composerEditorRef}
                         value={
@@ -4832,7 +4919,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <PreviewPanel
                   key={previewPanelKey ?? undefined}
                   threadId={activeThread.id}
-                  onClose={() => setPreviewOpen(false)}
+                  projectId={activeProject.id}
+                  projectName={activeProject.name}
+                  onElementSelected={(selection) => {
+                    handlePreviewElementSelected({
+                      ...selection,
+                      id: randomUUID(),
+                      threadId: activeThread.id,
+                      createdAt: new Date().toISOString(),
+                    });
+                  }}
+                  onClose={() => setPreviewOpen(activeThread.id, false)}
                 />
               </div>
             </>

--- a/apps/web/src/components/PreviewPanel.test.ts
+++ b/apps/web/src/components/PreviewPanel.test.ts
@@ -1,8 +1,79 @@
 import { describe, expect, it } from "vitest";
 
-describe("PreviewPanel", () => {
-  it("exports the component", async () => {
-    const mod = await import("./PreviewPanel");
-    expect(mod.PreviewPanel).toBeDefined();
+import { resolvePreviewStatusCopy } from "./PreviewPanel";
+
+describe("resolvePreviewStatusCopy", () => {
+  it("returns actionable copy for closed, loading, and ready states", () => {
+    expect(
+      resolvePreviewStatusCopy({
+        status: "closed",
+        url: null,
+        title: null,
+        visible: false,
+        error: null,
+        canGoBack: false,
+        canGoForward: false,
+        pickingElement: false,
+      }),
+    ).toContain("Enter a URL");
+
+    expect(
+      resolvePreviewStatusCopy({
+        status: "loading",
+        url: "http://localhost:3000/",
+        title: null,
+        visible: true,
+        error: null,
+        canGoBack: false,
+        canGoForward: false,
+        pickingElement: false,
+      }),
+    ).toContain("Loading");
+
+    expect(
+      resolvePreviewStatusCopy({
+        status: "ready",
+        url: "http://localhost:3000/",
+        title: "App",
+        visible: true,
+        error: null,
+        canGoBack: true,
+        canGoForward: false,
+        pickingElement: false,
+      }),
+    ).toContain("http://localhost:3000/");
+  });
+
+  it("shows picker guidance while the preview element picker is active", () => {
+    expect(
+      resolvePreviewStatusCopy({
+        status: "ready",
+        url: "http://localhost:3000/",
+        title: "App",
+        visible: true,
+        error: null,
+        canGoBack: true,
+        canGoForward: false,
+        pickingElement: true,
+      }),
+    ).toContain("Click an element");
+  });
+
+  it("prefers explicit preview errors", () => {
+    expect(
+      resolvePreviewStatusCopy({
+        status: "error",
+        url: "http://localhost:3000/",
+        title: null,
+        visible: false,
+        error: {
+          code: "load-failed",
+          message: "Dev server did not respond.",
+        },
+        canGoBack: false,
+        canGoForward: false,
+        pickingElement: false,
+      }),
+    ).toBe("Dev server did not respond.");
   });
 });

--- a/apps/web/src/components/PreviewPanel.tsx
+++ b/apps/web/src/components/PreviewPanel.tsx
@@ -1,15 +1,20 @@
-import type { PreviewTabsState, PreviewTabState, ThreadId } from "@okcode/contracts";
+import type {
+  DesktopPreviewElementSelection,
+  DesktopPreviewState,
+  ProjectId,
+  ThreadId,
+} from "@okcode/contracts";
 import { type FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
+  CircleAlertIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
   GlobeIcon,
   LoaderCircleIcon,
-  PlusIcon,
+  MousePointerClickIcon,
   RefreshCwIcon,
   StarIcon,
-  WrenchIcon,
   XIcon,
 } from "lucide-react";
 
@@ -22,10 +27,15 @@ import { usePreviewStateStore } from "~/previewStateStore";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
-const EMPTY_TABS_STATE: PreviewTabsState = {
-  tabs: [],
-  activeTabId: null,
+const CLOSED_PREVIEW_STATE: DesktopPreviewState = {
+  status: "closed",
+  url: null,
+  title: null,
   visible: false,
+  error: null,
+  canGoBack: false,
+  canGoForward: false,
+  pickingElement: false,
 };
 
 const HIDDEN_PREVIEW_BOUNDS = {
@@ -38,64 +48,76 @@ const HIDDEN_PREVIEW_BOUNDS = {
   viewportHeight: 0,
 } as const;
 
-function getActiveTab(state: PreviewTabsState): PreviewTabState | null {
-  if (!state.activeTabId) return null;
-  return state.tabs.find((t) => t.tabId === state.activeTabId) ?? null;
-}
-
-function tabDisplayTitle(tab: PreviewTabState): string {
-  if (tab.title) return tab.title;
-  if (tab.url) {
-    try {
-      const u = new URL(tab.url);
-      return u.hostname + (u.pathname !== "/" ? u.pathname : "");
-    } catch {
-      return tab.url;
-    }
+export function resolvePreviewStatusCopy(state: DesktopPreviewState): string {
+  if (state.pickingElement) {
+    return "Click an element in the preview to reference it in chat. Press Escape to cancel.";
   }
-  return "New Tab";
+
+  if (state.error) {
+    return state.error.message;
+  }
+
+  switch (state.status) {
+    case "loading":
+      return "Loading local preview...";
+    case "ready":
+      return state.url ? `Rendering ${state.url}` : "Preview ready.";
+    case "closed":
+      return "Enter a URL to preview inside OK Code.";
+    case "error":
+      return "Preview failed.";
+  }
 }
 
 interface PreviewPanelProps {
   threadId: ThreadId;
+  projectId: ProjectId;
+  projectName: string;
+  onElementSelected: (selection: DesktopPreviewElementSelection) => void;
   onClose: () => void;
 }
 
-export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
+export function PreviewPanel({
+  threadId,
+  projectId,
+  projectName,
+  onElementSelected,
+  onClose,
+}: PreviewPanelProps) {
   const previewBridge = readDesktopPreviewBridge();
-  const setGlobalOpen = usePreviewStateStore((state) => state.setGlobalOpen);
-  const favoriteUrls = usePreviewStateStore((state) => state.favoriteUrls);
-  const toggleFavoriteUrl = usePreviewStateStore((state) => state.toggleFavoriteUrl);
-
-  const [tabsState, setTabsState] = useState<PreviewTabsState>(EMPTY_TABS_STATE);
-  const [inputUrl, setInputUrl] = useState("");
+  const storedUrl = usePreviewStateStore((state) => state.urlByProjectId[projectId] ?? "");
+  const favoriteUrl = usePreviewStateStore(
+    (state) => state.favoriteUrlByProjectId[projectId] ?? "",
+  );
+  const setProjectUrl = usePreviewStateStore((state) => state.setProjectUrl);
+  const toggleProjectFavorite = usePreviewStateStore((state) => state.toggleProjectFavorite);
+  const setThreadOpen = usePreviewStateStore((state) => state.setThreadOpen);
+  const [inputUrl, setInputUrl] = useState(storedUrl);
   const [inputError, setInputError] = useState<string | null>(null);
+  const [previewState, setPreviewState] = useState<DesktopPreviewState>(CLOSED_PREVIEW_STATE);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const projectNameRef = useRef(projectName);
 
-  const activeTab = getActiveTab(tabsState);
-  const showEmbeddedSurface =
-    activeTab !== null && (activeTab.status === "loading" || activeTab.status === "ready");
-
-  // Sync URL input when active tab changes
   useEffect(() => {
-    if (activeTab?.url) {
-      setInputUrl(activeTab.url);
-    }
-  }, [activeTab?.tabId, activeTab?.url]);
+    setInputUrl(storedUrl);
+  }, [storedUrl, projectId]);
 
-  // Subscribe to state changes
+  useEffect(() => {
+    projectNameRef.current = projectName;
+  }, [projectName]);
+
   useEffect(() => {
     if (!previewBridge) {
-      setTabsState(EMPTY_TABS_STATE);
+      setPreviewState(CLOSED_PREVIEW_STATE);
       return;
     }
 
     const unsubscribe = previewBridge.onState((state) => {
-      setTabsState(state);
+      setPreviewState(state);
     });
 
     void previewBridge.getState().then((state) => {
-      setTabsState(state);
+      setPreviewState(state);
     });
 
     return () => {
@@ -103,9 +125,37 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
     };
   }, [previewBridge]);
 
-  // Bounds sync
+  useEffect(() => {
+    if (!previewBridge) {
+      return;
+    }
+
+    if (storedUrl.trim().length === 0) {
+      void previewBridge.setBounds(HIDDEN_PREVIEW_BOUNDS).finally(() => {
+        void previewBridge.close();
+      });
+      setPreviewState(CLOSED_PREVIEW_STATE);
+      return;
+    }
+
+    void previewBridge
+      .setBounds(HIDDEN_PREVIEW_BOUNDS)
+      .catch(() => undefined)
+      .finally(() => {
+        void previewBridge.open({ url: storedUrl, title: `${projectNameRef.current} preview` });
+      });
+  }, [previewBridge, storedUrl]);
+
+  useEffect(() => {
+    return () => {
+      void previewBridge?.close();
+    };
+  }, [previewBridge]);
+
   useLayoutEffect(() => {
-    if (!previewBridge) return;
+    if (!previewBridge) {
+      return;
+    }
 
     let frameId = 0;
     let destroyed = false;
@@ -114,11 +164,13 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
 
     const computeBounds = () => {
       const element = surfaceRef.current;
-      if (!element) return HIDDEN_PREVIEW_BOUNDS;
+      if (!element) {
+        return HIDDEN_PREVIEW_BOUNDS;
+      }
 
       const rect = element.getBoundingClientRect();
       const visible =
-        tabsState.tabs.length > 0 &&
+        storedUrl.trim().length > 0 &&
         document.visibilityState === "visible" &&
         rect.width > 0 &&
         rect.height > 0;
@@ -134,7 +186,9 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
     };
 
     const syncBounds = () => {
-      if (destroyed) return;
+      if (destroyed) {
+        return;
+      }
 
       const nextBounds = computeBounds();
       const nextKey = `${Math.round(nextBounds.x)}:${Math.round(nextBounds.y)}:${Math.round(nextBounds.width)}:${Math.round(nextBounds.height)}:${nextBounds.visible ? 1 : 0}`;
@@ -147,7 +201,9 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
     };
 
     const scheduleImmediateSync = () => {
-      if (destroyed || frameId !== 0) return;
+      if (destroyed || frameId !== 0) {
+        return;
+      }
       frameId = window.requestAnimationFrame(syncBounds);
     };
 
@@ -174,7 +230,9 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
 
     return () => {
       destroyed = true;
-      if (frameId !== 0) window.cancelAnimationFrame(frameId);
+      if (frameId !== 0) {
+        window.cancelAnimationFrame(frameId);
+      }
       resizeObserver?.disconnect();
       window.removeEventListener("resize", invalidateBounds);
       window.removeEventListener("scroll", invalidateBounds, true);
@@ -183,14 +241,7 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
       visualViewport?.removeEventListener("scroll", invalidateBounds);
       void previewBridge.setBounds(HIDDEN_PREVIEW_BOUNDS);
     };
-  }, [previewBridge, tabsState.tabs.length, threadId]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      void previewBridge?.setBounds(HIDDEN_PREVIEW_BOUNDS);
-    };
-  }, [previewBridge]);
+  }, [previewBridge, storedUrl, threadId, projectId]);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -201,48 +252,51 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
     }
 
     setInputError(null);
-
-    if (activeTab) {
-      // Navigate existing active tab
-      void previewBridge?.navigate({ url: validatedUrl.url });
-    } else {
-      // Create a new tab
-      void previewBridge?.createTab({ url: validatedUrl.url });
-    }
-  };
-
-  const onNewTab = () => {
-    const url = inputUrl.trim();
-    if (url.length > 0) {
-      const validatedUrl = validateHttpPreviewUrl(url);
-      if (validatedUrl.ok) {
-        void previewBridge?.createTab({ url: validatedUrl.url });
-        return;
-      }
-    }
-    // Create tab with a default page
-    void previewBridge?.createTab({ url: "https://www.google.com" });
+    setProjectUrl(projectId, validatedUrl.url);
   };
 
   const onClosePreview = () => {
-    setGlobalOpen(false);
-    void previewBridge?.closeAll();
+    setThreadOpen(threadId, false);
+    void previewBridge?.close();
     onClose();
   };
 
   const onOpenExternal = () => {
-    const targetUrl = activeTab?.url;
-    if (!targetUrl) return;
+    const targetUrl = previewState.url ?? storedUrl;
+    if (!targetUrl) {
+      return;
+    }
+
     const api = readNativeApi();
     void api?.shell.openExternal(targetUrl);
   };
 
-  const currentPageUrl = activeTab?.url ?? null;
-  const isFavorite = currentPageUrl !== null && favoriteUrls.includes(currentPageUrl);
+  const onToggleElementPicker = () => {
+    if (!previewBridge) {
+      return;
+    }
+
+    if (previewState.pickingElement) {
+      void previewBridge.cancelPickElement();
+      return;
+    }
+
+    void previewBridge
+      .pickElement()
+      .then((result) => {
+        if (result.selection) {
+          onElementSelected(result.selection);
+        }
+      })
+      .catch(() => undefined);
+  };
+
+  const showEmbeddedSurface = previewState.status === "loading" || previewState.status === "ready";
+  const currentPageUrl = previewState.url;
+  const isFavorite = currentPageUrl !== null && favoriteUrl === currentPageUrl;
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-background">
-      {/* Toolbar */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <Button
@@ -251,8 +305,10 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
             aria-label="Back"
-            onClick={() => void previewBridge?.goBack()}
-            disabled={!previewBridge || !activeTab?.canGoBack}
+            onClick={() => {
+              void previewBridge?.goBack();
+            }}
+            disabled={!previewBridge || !previewState.canGoBack}
           >
             <ChevronLeftIcon className="size-3.5" />
           </Button>
@@ -262,41 +318,23 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
             aria-label="Forward"
-            onClick={() => void previewBridge?.goForward()}
-            disabled={!previewBridge || !activeTab?.canGoForward}
+            onClick={() => {
+              void previewBridge?.goForward();
+            }}
+            disabled={!previewBridge || !previewState.canGoForward}
           >
             <ChevronRightIcon className="size-3.5" />
           </Button>
-          <Button
-            type="button"
-            size="icon-xs"
-            variant="ghost"
-            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Reload"
-            onClick={() => {
-              setInputError(null);
-              void previewBridge?.reload();
-            }}
-            disabled={!showEmbeddedSurface}
-          >
-            <RefreshCwIcon className="size-3.5" />
-          </Button>
           <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground/65" />
-          <form className="min-w-0 flex-1" onSubmit={onSubmit}>
-            <Input
-              value={inputUrl}
-              onChange={(event) => {
-                setInputUrl(event.target.value);
-                if (inputError) setInputError(null);
-              }}
-              placeholder="https://example.com"
-              aria-label="URL"
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              className="h-7 text-xs"
-            />
-          </form>
+          <div className="min-w-0">
+            <p
+              className="truncate text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/75"
+              title={projectName}
+            >
+              Preview
+            </p>
+            <p className="truncate text-[11px] text-muted-foreground/65">{projectName}</p>
+          </div>
         </div>
         <div className="flex items-center gap-1">
           <Button
@@ -305,14 +343,16 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             variant="ghost"
             className={cn(
               "text-muted-foreground/55 hover:bg-transparent hover:text-foreground",
-              activeTab?.devToolsOpen ? "text-blue-500 hover:text-blue-500" : undefined,
+              previewState.pickingElement ? "text-foreground" : undefined,
             )}
-            aria-label="Toggle DevTools"
-            aria-pressed={activeTab?.devToolsOpen ?? false}
-            onClick={() => void previewBridge?.toggleDevTools()}
-            disabled={!previewBridge || !activeTab}
+            aria-label={
+              previewState.pickingElement ? "Cancel element picker" : "Select an element in preview"
+            }
+            aria-pressed={previewState.pickingElement}
+            onClick={onToggleElementPicker}
+            disabled={!previewBridge || previewState.status !== "ready"}
           >
-            <WrenchIcon className="size-3.5" />
+            <MousePointerClickIcon className="size-3.5" />
           </Button>
           <Button
             type="button"
@@ -325,7 +365,10 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             aria-label={isFavorite ? "Remove favorite" : "Favorite current page"}
             aria-pressed={isFavorite}
             onClick={() => {
-              if (currentPageUrl) toggleFavoriteUrl(currentPageUrl);
+              if (!currentPageUrl) {
+                return;
+              }
+              toggleProjectFavorite(projectId, currentPageUrl);
             }}
             disabled={!previewBridge || currentPageUrl === null}
           >
@@ -336,9 +379,23 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             size="icon-xs"
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Open externally"
+            aria-label="Reload preview"
+            onClick={() => {
+              setInputError(null);
+              void previewBridge?.reload();
+            }}
+            disabled={!showEmbeddedSurface}
+          >
+            <RefreshCwIcon className="size-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
+            aria-label="Open preview externally"
             onClick={onOpenExternal}
-            disabled={!activeTab?.url}
+            disabled={!previewState.url && storedUrl.trim().length === 0}
           >
             <ExternalLinkIcon className="size-3.5" />
           </Button>
@@ -347,7 +404,7 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
             size="icon-xs"
             variant="ghost"
             className="text-muted-foreground/55 hover:bg-transparent hover:text-foreground"
-            aria-label="Close browser"
+            aria-label="Close preview"
             onClick={onClosePreview}
           >
             <XIcon className="size-3.5" />
@@ -355,69 +412,42 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
         </div>
       </div>
 
-      {/* Tab bar */}
-      <div className="flex items-center gap-0.5 overflow-x-auto border-b border-border/40 bg-muted/30 px-2 py-1">
-        {tabsState.tabs.map((tab) => (
-          <button
-            key={tab.tabId}
-            type="button"
-            className={cn(
-              "group flex max-w-[180px] items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] transition-colors",
-              tab.tabId === tabsState.activeTabId
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:bg-background/50 hover:text-foreground",
-            )}
-            onClick={() => void previewBridge?.activateTab({ tabId: tab.tabId })}
-            title={tab.url ?? tabDisplayTitle(tab)}
-          >
-            {tab.status === "loading" ? (
-              <LoaderCircleIcon className="size-3 shrink-0 animate-spin" />
-            ) : (
-              <GlobeIcon className="size-3 shrink-0 opacity-50" />
-            )}
-            <span className="truncate">{tabDisplayTitle(tab)}</span>
-            <button
-              type="button"
-              className="ml-auto shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                void previewBridge?.closeTab({ tabId: tab.tabId });
-              }}
-              aria-label={`Close ${tabDisplayTitle(tab)}`}
-            >
-              <XIcon className="size-2.5" />
-            </button>
-          </button>
-        ))}
-        <button
-          type="button"
-          className="flex items-center justify-center rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-background/50 hover:text-foreground"
-          onClick={onNewTab}
-          aria-label="New tab"
-        >
-          <PlusIcon className="size-3.5" />
-        </button>
-      </div>
-
-      {/* Status bar */}
-      {(inputError || (activeTab && activeTab.status !== "ready")) && (
-        <div className="flex items-start gap-2 border-b border-border/40 px-3 py-1.5 text-xs">
-          {activeTab?.status === "loading" ? (
+      <form className="border-b border-border px-3 py-3" onSubmit={onSubmit}>
+        <div className="flex items-center gap-2">
+          <Input
+            value={inputUrl}
+            onChange={(event) => {
+              setInputUrl(event.target.value);
+              if (inputError) {
+                setInputError(null);
+              }
+            }}
+            placeholder="http://localhost:3000"
+            aria-label="Preview URL"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+          />
+          <Button type="submit" size="sm">
+            Open
+          </Button>
+        </div>
+        <div className="mt-2 flex items-start gap-2 text-xs">
+          {previewState.status === "loading" ? (
             <LoaderCircleIcon className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground/70" />
+          ) : previewState.error || inputError ? (
+            <CircleAlertIcon className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
           ) : null}
           <p
             className={
-              activeTab?.error || inputError ? "text-amber-700" : "text-muted-foreground/70"
+              previewState.error || inputError ? "text-amber-700" : "text-muted-foreground/70"
             }
           >
-            {inputError ??
-              activeTab?.error?.message ??
-              (activeTab?.status === "loading" ? `Loading ${activeTab.url ?? ""}...` : null)}
+            {inputError ?? resolvePreviewStatusCopy(previewState)}
           </p>
         </div>
-      )}
+      </form>
 
-      {/* Content area */}
       <div className="flex min-h-0 flex-1 flex-col p-3">
         <div
           ref={surfaceRef}
@@ -425,9 +455,7 @@ export function PreviewPanel({ threadId, onClose }: PreviewPanelProps) {
         >
           {!showEmbeddedSurface ? (
             <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground/70">
-              {tabsState.tabs.length === 0
-                ? "Enter a URL or click + to open a new tab."
-                : (activeTab?.error?.message ?? "Preview closed.")}
+              {inputError ?? resolvePreviewStatusCopy(previewState)}
             </div>
           ) : null}
         </div>

--- a/apps/web/src/components/chat/ClaudeTraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/ClaudeTraitsPicker.browser.tsx
@@ -25,6 +25,7 @@ async function mountPicker(props?: {
     nonPersistedImageIds: [],
     persistedAttachments: [],
     terminalContexts: [],
+    previewContexts: [],
     provider: "claudeAgent",
     model: props?.model ?? "claude-opus-4-6",
     modelOptions: {

--- a/apps/web/src/components/chat/CodexTraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/CodexTraitsPicker.browser.tsx
@@ -22,6 +22,7 @@ async function mountPicker(props: {
     nonPersistedImageIds: [],
     persistedAttachments: [],
     terminalContexts: [],
+    previewContexts: [],
     provider: "codex",
     model: null,
     modelOptions: {

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -27,6 +27,7 @@ async function mountMenu(props?: {
     nonPersistedImageIds: [],
     persistedAttachments: [],
     terminalContexts: [],
+    previewContexts: [],
     provider,
     model: props?.model ?? "claude-opus-4-6",
     modelOptions: props?.modelOptions ?? null,

--- a/apps/web/src/components/chat/ComposerPendingPreviewContexts.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingPreviewContexts.test.tsx
@@ -1,0 +1,34 @@
+import { ThreadId } from "@okcode/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ComposerPendingPreviewContextChip } from "./ComposerPendingPreviewContexts";
+
+describe("ComposerPendingPreviewContextChip", () => {
+  it("renders a removable preview reference chip", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerPendingPreviewContextChip
+        context={{
+          id: "preview-1",
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          createdAt: "2026-03-28T12:00:00.000Z",
+          pageUrl: "http://localhost:3000/",
+          pageTitle: "Homepage",
+          selector: 'button[data-testid="submit"]',
+          tagName: "button",
+          role: "button",
+          ariaLabel: null,
+          text: "Submit",
+          href: null,
+          name: null,
+          placeholder: null,
+        }}
+        onRemove={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("button &quot;Submit&quot;");
+    expect(markup).toContain("Remove button");
+    expect(markup).toContain("lucide-mouse-pointer-click");
+  });
+});

--- a/apps/web/src/components/chat/ComposerPendingPreviewContexts.tsx
+++ b/apps/web/src/components/chat/ComposerPendingPreviewContexts.tsx
@@ -1,0 +1,52 @@
+import { cn } from "~/lib/utils";
+import { type PreviewContextDraft, formatPreviewContextLabel } from "~/lib/previewContext";
+import { PreviewContextInlineChip } from "./PreviewContextInlineChip";
+
+interface ComposerPendingPreviewContextsProps {
+  contexts: ReadonlyArray<PreviewContextDraft>;
+  onRemoveContext: (contextId: string) => void;
+  className?: string;
+}
+
+interface ComposerPendingPreviewContextChipProps {
+  context: PreviewContextDraft;
+  onRemove: () => void;
+}
+
+export function ComposerPendingPreviewContextChip({
+  context,
+  onRemove,
+}: ComposerPendingPreviewContextChipProps) {
+  const label = formatPreviewContextLabel(context);
+  const tooltipText = [
+    label,
+    context.pageTitle ? `page: ${context.pageTitle}` : null,
+    `url: ${context.pageUrl}`,
+    `selector: ${context.selector}`,
+    context.text.length > 0 ? `text: ${context.text}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  return <PreviewContextInlineChip label={label} tooltipText={tooltipText} onRemove={onRemove} />;
+}
+
+export function ComposerPendingPreviewContexts(props: ComposerPendingPreviewContextsProps) {
+  const { contexts, onRemoveContext, className } = props;
+
+  if (contexts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
+      {contexts.map((context) => (
+        <ComposerPendingPreviewContextChip
+          key={context.id}
+          context={context}
+          onRemove={() => onRemoveContext(context.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -44,10 +44,9 @@ import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { computeMessageDurationStart, normalizeCompactToolLabel } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
-import {
-  deriveDisplayedUserMessageState,
-  type ParsedTerminalContextEntry,
-} from "~/lib/terminalContext";
+import { type ParsedPreviewContextEntry } from "~/lib/previewContext";
+import { deriveDisplayedUserMessageState } from "~/lib/userMessageContext";
+import { type ParsedTerminalContextEntry } from "~/lib/terminalContext";
 import { cn } from "~/lib/utils";
 import { type TimestampFormat } from "../../appSettings";
 import { formatTimestamp } from "../../timestampFormat";
@@ -56,6 +55,7 @@ import {
   formatInlineTerminalContextLabel,
   textContainsInlineTerminalContextLabels,
 } from "./userMessageTerminalContexts";
+import { PreviewContextInlineChip } from "./PreviewContextInlineChip";
 
 const MAX_VISIBLE_WORK_LOG_ENTRIES = 6;
 const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
@@ -368,7 +368,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         (() => {
           const userImages = row.message.attachments ?? [];
           const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
-          const terminalContexts = displayedUserMessage.contexts;
+          const terminalContexts = displayedUserMessage.terminalContexts;
+          const previewContexts = displayedUserMessage.previewContexts;
           const canRevertAgentWork = revertTurnCountByUserMessageId.has(row.message.id);
           const isQueued = row.message.queued === true;
           return (
@@ -419,10 +420,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   </div>
                 )}
                 {(displayedUserMessage.visibleText.trim().length > 0 ||
-                  terminalContexts.length > 0) && (
+                  terminalContexts.length > 0 ||
+                  previewContexts.length > 0) && (
                   <UserMessageBody
                     text={displayedUserMessage.visibleText}
                     terminalContexts={terminalContexts}
+                    previewContexts={previewContexts}
                   />
                 )}
                 <div className="mt-1.5 flex items-center justify-end gap-2">
@@ -717,17 +720,44 @@ const UserMessageTerminalContextInlineLabel = memo(
   },
 );
 
+const UserMessagePreviewContextInlineLabel = memo(
+  function UserMessagePreviewContextInlineLabel(props: { context: ParsedPreviewContextEntry }) {
+    const tooltipText =
+      props.context.body.length > 0
+        ? `${props.context.header}\n${props.context.body}`
+        : props.context.header;
+
+    return <PreviewContextInlineChip label={props.context.header} tooltipText={tooltipText} />;
+  },
+);
+
 const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
   terminalContexts: ParsedTerminalContextEntry[];
+  previewContexts: ParsedPreviewContextEntry[];
 }) {
+  const prefixNodes: ReactNode[] = [];
+  for (const context of props.previewContexts) {
+    prefixNodes.push(
+      <UserMessagePreviewContextInlineLabel
+        key={`user-preview-context-inline:${context.header}`}
+        context={context}
+      />,
+    );
+    prefixNodes.push(
+      <span key={`user-preview-context-inline-space:${context.header}`} aria-hidden="true">
+        {" "}
+      </span>,
+    );
+  }
+
   if (props.terminalContexts.length > 0) {
     const hasEmbeddedInlineLabels = textContainsInlineTerminalContextLabels(
       props.text,
       props.terminalContexts,
     );
     const inlinePrefix = buildInlineTerminalContextText(props.terminalContexts);
-    const inlineNodes: ReactNode[] = [];
+    const inlineNodes: ReactNode[] = [...prefixNodes];
 
     if (hasEmbeddedInlineLabels) {
       let cursor = 0;
@@ -788,13 +818,25 @@ const UserMessageBody = memo(function UserMessageBody(props: {
 
     if (props.text.length > 0) {
       inlineNodes.push(<span key="user-message-terminal-context-inline-text">{props.text}</span>);
-    } else if (inlinePrefix.length === 0) {
+    } else if (inlinePrefix.length === 0 && props.previewContexts.length === 0) {
       return null;
     }
 
     return (
       <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground">
         {inlineNodes}
+      </div>
+    );
+  }
+
+  if (props.previewContexts.length > 0) {
+    if (props.text.length > 0) {
+      prefixNodes.push(<span key="user-message-preview-context-inline-text">{props.text}</span>);
+    }
+
+    return (
+      <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground">
+        {prefixNodes}
       </div>
     );
   }

--- a/apps/web/src/components/chat/PreviewContextInlineChip.tsx
+++ b/apps/web/src/components/chat/PreviewContextInlineChip.tsx
@@ -1,0 +1,50 @@
+import { MousePointerClickIcon, XIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import {
+  COMPOSER_INLINE_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
+} from "../composerInlineChip";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+interface PreviewContextInlineChipProps {
+  label: string;
+  tooltipText: string;
+  onRemove?: () => void;
+}
+
+export function PreviewContextInlineChip(props: PreviewContextInlineChipProps) {
+  const { label, tooltipText, onRemove } = props;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className={COMPOSER_INLINE_CHIP_CLASS_NAME}>
+            <MousePointerClickIcon className={cn(COMPOSER_INLINE_CHIP_ICON_CLASS_NAME, "size-3")} />
+            <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>{label}</span>
+            {onRemove ? (
+              <button
+                type="button"
+                className={COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME}
+                aria-label={`Remove ${label}`}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onRemove();
+                }}
+              >
+                <XIcon className="size-3" />
+              </button>
+            ) : null}
+          </span>
+        }
+      />
+      <TooltipPopup side="top" className="max-w-80 whitespace-pre-wrap leading-tight">
+        {tooltipText}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/timelineHeight.test.ts
+++ b/apps/web/src/components/timelineHeight.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { appendTerminalContextsToPrompt } from "../lib/terminalContext";
+import { appendPreviewContextsToPrompt } from "../lib/previewContext";
 import { buildInlineTerminalContextText } from "./chat/userMessageTerminalContexts";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
 
@@ -102,6 +103,35 @@ describe("estimateTimelineMessageHeight", () => {
       estimateTimelineMessageHeight({
         role: "user",
         text: `${buildInlineTerminalContextText([{ header: "Terminal 1 lines 40-43" }])} Investigate this`,
+      }),
+    );
+  });
+
+  it("adds preview context chrome without counting the hidden block as message text", () => {
+    const prompt = appendPreviewContextsToPrompt("Inspect this", [
+      {
+        pageUrl: "http://localhost:3000/",
+        pageTitle: "Homepage",
+        selector: 'button[data-testid="submit"]',
+        tagName: "button",
+        role: "button",
+        ariaLabel: null,
+        text: "Submit",
+        href: null,
+        name: null,
+        placeholder: null,
+      },
+    ]);
+
+    expect(
+      estimateTimelineMessageHeight({
+        role: "user",
+        text: prompt,
+      }),
+    ).toBe(
+      estimateTimelineMessageHeight({
+        role: "user",
+        text: 'button "Submit" Inspect this',
       }),
     );
   });

--- a/apps/web/src/components/timelineHeight.ts
+++ b/apps/web/src/components/timelineHeight.ts
@@ -1,4 +1,5 @@
-import { deriveDisplayedUserMessageState } from "../lib/terminalContext";
+import { buildInlinePreviewContextText } from "../lib/previewContext";
+import { deriveDisplayedUserMessageState } from "../lib/userMessageContext";
 import { buildInlineTerminalContextText } from "./chat/userMessageTerminalContexts";
 
 const ASSISTANT_CHARS_PER_LINE_FALLBACK = 72;
@@ -80,9 +81,11 @@ export function estimateTimelineMessageHeight(
     const charsPerLine = estimateCharsPerLineForUser(layout.timelineWidthPx);
     const displayedUserMessage = deriveDisplayedUserMessageState(message.text);
     const renderedText =
-      displayedUserMessage.contexts.length > 0
+      displayedUserMessage.terminalContexts.length > 0 ||
+      displayedUserMessage.previewContexts.length > 0
         ? [
-            buildInlineTerminalContextText(displayedUserMessage.contexts),
+            buildInlineTerminalContextText(displayedUserMessage.terminalContexts),
+            buildInlinePreviewContextText(displayedUserMessage.previewContexts),
             displayedUserMessage.visibleText,
           ]
             .filter((part) => part.length > 0)

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -13,6 +13,7 @@ import {
   insertInlineTerminalContextPlaceholder,
   type TerminalContextDraft,
 } from "./lib/terminalContext";
+import { type PreviewContextDraft } from "./lib/previewContext";
 import { createDebouncedStorage } from "./lib/storage";
 
 function makeImage(input: {
@@ -59,6 +60,32 @@ function makeTerminalContext(input: {
     lineEnd: input.lineEnd ?? 5,
     text: input.text ?? "git status\nOn branch main",
     createdAt: "2026-03-13T12:00:00.000Z",
+  };
+}
+
+function makePreviewContext(input: {
+  id: string;
+  selector?: string;
+  pageUrl?: string;
+  pageTitle?: string | null;
+  role?: string | null;
+  tagName?: string;
+  text?: string;
+}): PreviewContextDraft {
+  return {
+    id: input.id,
+    threadId: ThreadId.makeUnsafe("thread-dedupe"),
+    createdAt: "2026-03-28T12:00:00.000Z",
+    pageUrl: input.pageUrl ?? "http://localhost:3000/settings",
+    pageTitle: input.pageTitle ?? "Settings",
+    selector: input.selector ?? 'button[data-testid="save"]',
+    tagName: input.tagName ?? "button",
+    role: input.role ?? "button",
+    ariaLabel: null,
+    text: input.text ?? "Save changes",
+    href: null,
+    name: null,
+    placeholder: null,
   };
 }
 
@@ -415,6 +442,97 @@ describe("composerDraftStore terminal contexts", () => {
     expect(mergedState.draftsByThreadId[threadId]).toBeUndefined();
     expect(mergedState.draftThreadsByThreadId).toEqual({});
     expect(mergedState.projectDraftThreadIdByProjectId).toEqual({});
+  });
+});
+
+describe("composerDraftStore preview contexts", () => {
+  const threadId = ThreadId.makeUnsafe("thread-preview-contexts");
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("deduplicates identical preview contexts by page and selector", () => {
+    useComposerDraftStore
+      .getState()
+      .addPreviewContexts(threadId, [
+        makePreviewContext({ id: "preview-1" }),
+        makePreviewContext({ id: "preview-2" }),
+      ]);
+
+    const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
+    expect(draft?.previewContexts.map((context) => context.id)).toEqual(["preview-1"]);
+  });
+
+  it("persists preview contexts with their selection metadata", () => {
+    useComposerDraftStore
+      .getState()
+      .addPreviewContext(threadId, makePreviewContext({ id: "preview-persist" }));
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadId?: Record<string, { previewContexts?: Array<Record<string, unknown>> }>;
+    };
+
+    expect(persistedState.draftsByThreadId?.[threadId]?.previewContexts?.[0]).toMatchObject({
+      id: "preview-persist",
+      pageUrl: "http://localhost:3000/settings",
+      selector: 'button[data-testid="save"]',
+      role: "button",
+    });
+  });
+
+  it("hydrates persisted preview contexts into the draft store", () => {
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const mergedState = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "",
+            attachments: [],
+            previewContexts: [
+              {
+                id: "preview-hydrated",
+                threadId,
+                createdAt: "2026-03-28T12:00:00.000Z",
+                pageUrl: "http://localhost:3000/settings",
+                pageTitle: "Settings",
+                selector: 'button[data-testid="save"]',
+                tagName: "button",
+                role: "button",
+                ariaLabel: null,
+                text: "Save changes",
+                href: null,
+                name: null,
+                placeholder: null,
+              },
+            ],
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectId: {},
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+
+    expect(mergedState.draftsByThreadId[threadId]?.previewContexts).toMatchObject([
+      {
+        id: "preview-hydrated",
+        selector: 'button[data-testid="save"]',
+        pageTitle: "Settings",
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -21,6 +21,11 @@ import {
   ensureInlineTerminalContextPlaceholders,
   normalizeTerminalContextText,
 } from "./lib/terminalContext";
+import {
+  type PreviewContextDraft,
+  buildPreviewContextDedupKey,
+  normalizePreviewContextSelection,
+} from "./lib/previewContext";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { createDebouncedStorage, createMemoryStorage } from "./lib/storage";
@@ -79,10 +84,28 @@ const PersistedTerminalContextDraft = Schema.Struct({
 });
 type PersistedTerminalContextDraft = typeof PersistedTerminalContextDraft.Type;
 
+const PersistedPreviewContextDraft = Schema.Struct({
+  id: Schema.String,
+  threadId: ThreadId,
+  createdAt: Schema.String,
+  pageUrl: Schema.String,
+  pageTitle: Schema.NullOr(Schema.String),
+  selector: Schema.String,
+  tagName: Schema.String,
+  role: Schema.NullOr(Schema.String),
+  ariaLabel: Schema.NullOr(Schema.String),
+  text: Schema.String,
+  href: Schema.NullOr(Schema.String),
+  name: Schema.NullOr(Schema.String),
+  placeholder: Schema.NullOr(Schema.String),
+});
+type PersistedPreviewContextDraft = typeof PersistedPreviewContextDraft.Type;
+
 const PersistedComposerThreadDraftState = Schema.Struct({
   prompt: Schema.String,
   attachments: Schema.Array(PersistedComposerImageAttachment),
   terminalContexts: Schema.optionalKey(Schema.Array(PersistedTerminalContextDraft)),
+  previewContexts: Schema.optionalKey(Schema.Array(PersistedPreviewContextDraft)),
   provider: Schema.optionalKey(ProviderKind),
   model: Schema.optionalKey(Schema.String),
   modelOptions: Schema.optionalKey(ProviderModelOptions),
@@ -131,6 +154,7 @@ interface ComposerThreadDraftState {
   nonPersistedImageIds: string[];
   persistedAttachments: PersistedComposerImageAttachment[];
   terminalContexts: TerminalContextDraft[];
+  previewContexts: PreviewContextDraft[];
   provider: ProviderKind | null;
   model: string | null;
   modelOptions: ProviderModelOptions | null;
@@ -191,6 +215,7 @@ interface ComposerDraftStoreState {
   setStickyModelOptions: (modelOptions: ProviderModelOptions | null | undefined) => void;
   setPrompt: (threadId: ThreadId, prompt: string) => void;
   setTerminalContexts: (threadId: ThreadId, contexts: TerminalContextDraft[]) => void;
+  setPreviewContexts: (threadId: ThreadId, contexts: PreviewContextDraft[]) => void;
   setProvider: (threadId: ThreadId, provider: ProviderKind | null | undefined) => void;
   setModel: (threadId: ThreadId, model: string | null | undefined) => void;
   setModelOptions: (
@@ -223,6 +248,10 @@ interface ComposerDraftStoreState {
   addTerminalContexts: (threadId: ThreadId, contexts: TerminalContextDraft[]) => void;
   removeTerminalContext: (threadId: ThreadId, contextId: string) => void;
   clearTerminalContexts: (threadId: ThreadId) => void;
+  addPreviewContext: (threadId: ThreadId, context: PreviewContextDraft) => void;
+  addPreviewContexts: (threadId: ThreadId, contexts: PreviewContextDraft[]) => void;
+  removePreviewContext: (threadId: ThreadId, contextId: string) => void;
+  clearPreviewContexts: (threadId: ThreadId) => void;
   clearPersistedAttachments: (threadId: ThreadId) => void;
   syncPersistedAttachments: (
     threadId: ThreadId,
@@ -245,15 +274,18 @@ const EMPTY_IMAGES: ComposerImageAttachment[] = [];
 const EMPTY_IDS: string[] = [];
 const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerImageAttachment[] = [];
 const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
+const EMPTY_PREVIEW_CONTEXTS: PreviewContextDraft[] = [];
 Object.freeze(EMPTY_IMAGES);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
+Object.freeze(EMPTY_PREVIEW_CONTEXTS);
 const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   prompt: "",
   images: EMPTY_IMAGES,
   nonPersistedImageIds: EMPTY_IDS,
   persistedAttachments: EMPTY_PERSISTED_ATTACHMENTS,
   terminalContexts: EMPTY_TERMINAL_CONTEXTS,
+  previewContexts: EMPTY_PREVIEW_CONTEXTS,
   provider: null,
   model: null,
   modelOptions: null,
@@ -268,6 +300,7 @@ function createEmptyThreadDraft(): ComposerThreadDraftState {
     nonPersistedImageIds: [],
     persistedAttachments: [],
     terminalContexts: [],
+    previewContexts: [],
     provider: null,
     model: null,
     modelOptions: null,
@@ -333,12 +366,53 @@ function normalizeTerminalContextsForThread(
   return normalizedContexts;
 }
 
+function normalizePreviewContextForThread(
+  threadId: ThreadId,
+  context: PreviewContextDraft,
+): PreviewContextDraft | null {
+  const normalizedContext = normalizePreviewContextSelection(context);
+  if (!normalizedContext) {
+    return null;
+  }
+  return {
+    ...context,
+    ...normalizedContext,
+    threadId,
+  };
+}
+
+function normalizePreviewContextsForThread(
+  threadId: ThreadId,
+  contexts: ReadonlyArray<PreviewContextDraft>,
+): PreviewContextDraft[] {
+  const existingIds = new Set<string>();
+  const existingDedupKeys = new Set<string>();
+  const normalizedContexts: PreviewContextDraft[] = [];
+
+  for (const context of contexts) {
+    const normalizedContext = normalizePreviewContextForThread(threadId, context);
+    if (!normalizedContext) {
+      continue;
+    }
+    const dedupKey = buildPreviewContextDedupKey(normalizedContext);
+    if (existingIds.has(normalizedContext.id) || existingDedupKeys.has(dedupKey)) {
+      continue;
+    }
+    normalizedContexts.push(normalizedContext);
+    existingIds.add(normalizedContext.id);
+    existingDedupKeys.add(dedupKey);
+  }
+
+  return normalizedContexts;
+}
+
 function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
   return (
     draft.prompt.length === 0 &&
     draft.images.length === 0 &&
     draft.persistedAttachments.length === 0 &&
     draft.terminalContexts.length === 0 &&
+    draft.previewContexts.length === 0 &&
     draft.provider === null &&
     draft.model === null &&
     draft.modelOptions === null &&
@@ -529,6 +603,52 @@ function normalizePersistedTerminalContextDraft(
   };
 }
 
+function normalizePersistedPreviewContextDraft(
+  value: unknown,
+): PersistedPreviewContextDraft | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const id = candidate.id;
+  const threadId = candidate.threadId;
+  const createdAt = candidate.createdAt;
+  const pageUrl = candidate.pageUrl;
+  const selector = candidate.selector;
+  const tagName = candidate.tagName;
+  if (
+    typeof id !== "string" ||
+    id.length === 0 ||
+    typeof threadId !== "string" ||
+    threadId.length === 0 ||
+    typeof createdAt !== "string" ||
+    createdAt.length === 0 ||
+    typeof pageUrl !== "string" ||
+    pageUrl.length === 0 ||
+    typeof selector !== "string" ||
+    selector.length === 0 ||
+    typeof tagName !== "string" ||
+    tagName.length === 0
+  ) {
+    return null;
+  }
+  return {
+    id,
+    threadId: threadId as ThreadId,
+    createdAt,
+    pageUrl,
+    pageTitle: typeof candidate.pageTitle === "string" ? candidate.pageTitle : null,
+    selector,
+    tagName,
+    role: typeof candidate.role === "string" ? candidate.role : null,
+    ariaLabel: typeof candidate.ariaLabel === "string" ? candidate.ariaLabel : null,
+    text: typeof candidate.text === "string" ? candidate.text : "",
+    href: typeof candidate.href === "string" ? candidate.href : null,
+    name: typeof candidate.name === "string" ? candidate.name : null,
+    placeholder: typeof candidate.placeholder === "string" ? candidate.placeholder : null,
+  };
+}
+
 function normalizeDraftThreadEnvMode(
   value: unknown,
   fallbackWorktreePath: string | null,
@@ -661,6 +781,12 @@ function normalizePersistedDraftsByThreadId(
           return normalized ? [normalized] : [];
         })
       : [];
+    const previewContexts = Array.isArray(draftCandidate.previewContexts)
+      ? draftCandidate.previewContexts.flatMap((entry) => {
+          const normalized = normalizePersistedPreviewContextDraft(entry);
+          return normalized ? [normalized] : [];
+        })
+      : [];
     const provider = normalizeProviderKind(draftCandidate.provider);
     const model =
       typeof draftCandidate.model === "string"
@@ -681,6 +807,7 @@ function normalizePersistedDraftsByThreadId(
       promptCandidate.length === 0 &&
       attachments.length === 0 &&
       terminalContexts.length === 0 &&
+      previewContexts.length === 0 &&
       !provider &&
       !model &&
       modelOptions === null &&
@@ -693,6 +820,7 @@ function normalizePersistedDraftsByThreadId(
       prompt,
       attachments,
       ...(terminalContexts.length > 0 ? { terminalContexts } : {}),
+      ...(previewContexts.length > 0 ? { previewContexts } : {}),
       ...(provider ? { provider } : {}),
       ...(model ? { model } : {}),
       ...(modelOptions ? { modelOptions } : {}),
@@ -757,6 +885,7 @@ function partializeComposerDraftStoreState(
       draft.prompt.length === 0 &&
       draft.persistedAttachments.length === 0 &&
       draft.terminalContexts.length === 0 &&
+      draft.previewContexts.length === 0 &&
       draft.provider === null &&
       draft.model === null &&
       draft.modelOptions === null &&
@@ -778,6 +907,25 @@ function partializeComposerDraftStoreState(
               terminalLabel: context.terminalLabel,
               lineStart: context.lineStart,
               lineEnd: context.lineEnd,
+            })),
+          }
+        : {}),
+      ...(draft.previewContexts.length > 0
+        ? {
+            previewContexts: draft.previewContexts.map((context) => ({
+              id: context.id,
+              threadId: context.threadId,
+              createdAt: context.createdAt,
+              pageUrl: context.pageUrl,
+              pageTitle: context.pageTitle,
+              selector: context.selector,
+              tagName: context.tagName,
+              role: context.role,
+              ariaLabel: context.ariaLabel,
+              text: context.text,
+              href: context.href,
+              name: context.name,
+              placeholder: context.placeholder,
             })),
           }
         : {}),
@@ -963,6 +1111,7 @@ function toHydratedThreadDraft(
         ...context,
         text: "",
       })) ?? [],
+    previewContexts: persistedDraft.previewContexts?.map((context) => ({ ...context })) ?? [],
     provider: persistedDraft.provider ?? null,
     model: persistedDraft.model ?? null,
     modelOptions: persistedDraft.modelOptions ?? null,
@@ -1280,6 +1429,26 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
               normalizedContexts.length,
             ),
             terminalContexts: normalizedContexts,
+          };
+          const nextDraftsByThreadId = { ...state.draftsByThreadId };
+          if (shouldRemoveDraft(nextDraft)) {
+            delete nextDraftsByThreadId[threadId];
+          } else {
+            nextDraftsByThreadId[threadId] = nextDraft;
+          }
+          return { draftsByThreadId: nextDraftsByThreadId };
+        });
+      },
+      setPreviewContexts: (threadId, contexts) => {
+        if (threadId.length === 0) {
+          return;
+        }
+        const normalizedContexts = normalizePreviewContextsForThread(threadId, contexts);
+        set((state) => {
+          const existing = state.draftsByThreadId[threadId] ?? createEmptyThreadDraft();
+          const nextDraft: ComposerThreadDraftState = {
+            ...existing,
+            previewContexts: normalizedContexts,
           };
           const nextDraftsByThreadId = { ...state.draftsByThreadId };
           if (shouldRemoveDraft(nextDraft)) {
@@ -1675,6 +1844,80 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return { draftsByThreadId: nextDraftsByThreadId };
         });
       },
+      addPreviewContext: (threadId, context) => {
+        if (threadId.length === 0) {
+          return;
+        }
+        get().addPreviewContexts(threadId, [context]);
+      },
+      addPreviewContexts: (threadId, contexts) => {
+        if (threadId.length === 0 || contexts.length === 0) {
+          return;
+        }
+        set((state) => {
+          const existing = state.draftsByThreadId[threadId] ?? createEmptyThreadDraft();
+          const acceptedContexts = normalizePreviewContextsForThread(threadId, [
+            ...existing.previewContexts,
+            ...contexts,
+          ]).slice(existing.previewContexts.length);
+          if (acceptedContexts.length === 0) {
+            return state;
+          }
+          return {
+            draftsByThreadId: {
+              ...state.draftsByThreadId,
+              [threadId]: {
+                ...existing,
+                previewContexts: [...existing.previewContexts, ...acceptedContexts],
+              },
+            },
+          };
+        });
+      },
+      removePreviewContext: (threadId, contextId) => {
+        if (threadId.length === 0 || contextId.length === 0) {
+          return;
+        }
+        set((state) => {
+          const current = state.draftsByThreadId[threadId];
+          if (!current) {
+            return state;
+          }
+          const nextDraft: ComposerThreadDraftState = {
+            ...current,
+            previewContexts: current.previewContexts.filter((context) => context.id !== contextId),
+          };
+          const nextDraftsByThreadId = { ...state.draftsByThreadId };
+          if (shouldRemoveDraft(nextDraft)) {
+            delete nextDraftsByThreadId[threadId];
+          } else {
+            nextDraftsByThreadId[threadId] = nextDraft;
+          }
+          return { draftsByThreadId: nextDraftsByThreadId };
+        });
+      },
+      clearPreviewContexts: (threadId) => {
+        if (threadId.length === 0) {
+          return;
+        }
+        set((state) => {
+          const current = state.draftsByThreadId[threadId];
+          if (!current || current.previewContexts.length === 0) {
+            return state;
+          }
+          const nextDraft: ComposerThreadDraftState = {
+            ...current,
+            previewContexts: [],
+          };
+          const nextDraftsByThreadId = { ...state.draftsByThreadId };
+          if (shouldRemoveDraft(nextDraft)) {
+            delete nextDraftsByThreadId[threadId];
+          } else {
+            nextDraftsByThreadId[threadId] = nextDraft;
+          }
+          return { draftsByThreadId: nextDraftsByThreadId };
+        });
+      },
       clearPersistedAttachments: (threadId) => {
         if (threadId.length === 0) {
           return;
@@ -1744,6 +1987,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             nonPersistedImageIds: [],
             persistedAttachments: [],
             terminalContexts: [],
+            previewContexts: [],
           };
           const nextDraftsByThreadId = { ...state.draftsByThreadId };
           if (shouldRemoveDraft(nextDraft)) {

--- a/apps/web/src/lib/previewContext.ts
+++ b/apps/web/src/lib/previewContext.ts
@@ -1,0 +1,226 @@
+import { type DesktopPreviewElementSelection, type ThreadId } from "@okcode/contracts";
+
+export interface PreviewContextSelection extends DesktopPreviewElementSelection {}
+
+export interface PreviewContextDraft extends PreviewContextSelection {
+  id: string;
+  threadId: ThreadId;
+  createdAt: string;
+}
+
+export interface ParsedPreviewContextEntry {
+  header: string;
+  body: string;
+}
+
+export interface ExtractedPreviewContexts {
+  promptText: string;
+  contextCount: number;
+  previewTitle: string | null;
+  contexts: ParsedPreviewContextEntry[];
+}
+
+const TRAILING_PREVIEW_CONTEXT_BLOCK_PATTERN =
+  /\n*<preview_context>\n([\s\S]*?)\n<\/preview_context>\s*$/;
+
+function normalizePreviewContextField(value: string | null | undefined, maxLength = 180): string {
+  const normalized = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+export function buildPreviewContextDedupKey(context: {
+  pageUrl: string;
+  selector: string;
+}): string {
+  return `${context.pageUrl}\u0000${context.selector}`;
+}
+
+export function normalizePreviewContextSelection(
+  selection: PreviewContextSelection,
+): PreviewContextSelection | null {
+  const pageUrl = normalizePreviewContextField(selection.pageUrl, 400);
+  const selector = normalizePreviewContextField(selection.selector, 240);
+  const tagName = normalizePreviewContextField(selection.tagName, 40).toLowerCase();
+  if (pageUrl.length === 0 || selector.length === 0 || tagName.length === 0) {
+    return null;
+  }
+
+  return {
+    pageUrl,
+    pageTitle: normalizePreviewContextField(selection.pageTitle, 180) || null,
+    selector,
+    tagName,
+    role: normalizePreviewContextField(selection.role, 80) || null,
+    ariaLabel: normalizePreviewContextField(selection.ariaLabel, 120) || null,
+    text: normalizePreviewContextField(selection.text, 180),
+    href: normalizePreviewContextField(selection.href, 400) || null,
+    name: normalizePreviewContextField(selection.name, 120) || null,
+    placeholder: normalizePreviewContextField(selection.placeholder, 120) || null,
+  };
+}
+
+function formatPreviewContextPrimaryLabel(selection: {
+  ariaLabel: string | null;
+  text: string;
+  placeholder: string | null;
+  name: string | null;
+  selector: string;
+}): string {
+  const primary =
+    selection.ariaLabel ||
+    selection.text ||
+    selection.placeholder ||
+    selection.name ||
+    selection.selector;
+  if (primary === selection.selector) {
+    return selection.selector;
+  }
+  return `"${primary}"`;
+}
+
+export function formatPreviewContextLabel(selection: {
+  tagName: string;
+  role: string | null;
+  ariaLabel: string | null;
+  text: string;
+  placeholder: string | null;
+  name: string | null;
+  selector: string;
+}): string {
+  const kind = selection.role || selection.tagName || "element";
+  const primaryLabel = formatPreviewContextPrimaryLabel(selection);
+  return primaryLabel === selection.selector
+    ? `${kind} ${primaryLabel}`
+    : `${kind} ${primaryLabel}`;
+}
+
+export function buildInlinePreviewContextText(
+  contexts: ReadonlyArray<{
+    header: string;
+  }>,
+): string {
+  return contexts
+    .map((context) => context.header.trim())
+    .filter((header) => header.length > 0)
+    .join(" ");
+}
+
+function buildPreviewContextBodyLines(selection: PreviewContextSelection): string[] {
+  const lines = [
+    selection.pageTitle ? `page: ${selection.pageTitle}` : null,
+    `url: ${selection.pageUrl}`,
+    `selector: ${selection.selector}`,
+    `tag: ${selection.tagName}`,
+    selection.role ? `role: ${selection.role}` : null,
+    selection.ariaLabel ? `aria-label: ${selection.ariaLabel}` : null,
+    selection.text.length > 0 ? `text: ${selection.text}` : null,
+    selection.href ? `href: ${selection.href}` : null,
+    selection.name ? `name: ${selection.name}` : null,
+    selection.placeholder ? `placeholder: ${selection.placeholder}` : null,
+  ].filter((line): line is string => line !== null);
+
+  return lines.map((line) => `  ${line}`);
+}
+
+export function buildPreviewContextBlock(contexts: ReadonlyArray<PreviewContextSelection>): string {
+  const normalizedContexts = contexts
+    .map((context) => normalizePreviewContextSelection(context))
+    .filter((context): context is PreviewContextSelection => context !== null);
+  if (normalizedContexts.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+  for (let index = 0; index < normalizedContexts.length; index += 1) {
+    const context = normalizedContexts[index]!;
+    lines.push(`- ${formatPreviewContextLabel(context)}:`);
+    lines.push(...buildPreviewContextBodyLines(context));
+    if (index < normalizedContexts.length - 1) {
+      lines.push("");
+    }
+  }
+
+  return ["<preview_context>", ...lines, "</preview_context>"].join("\n");
+}
+
+export function appendPreviewContextsToPrompt(
+  prompt: string,
+  contexts: ReadonlyArray<PreviewContextSelection>,
+): string {
+  const trimmedPrompt = prompt.trim();
+  const contextBlock = buildPreviewContextBlock(contexts);
+  if (contextBlock.length === 0) {
+    return trimmedPrompt;
+  }
+  return trimmedPrompt.length > 0 ? `${trimmedPrompt}\n\n${contextBlock}` : contextBlock;
+}
+
+export function extractTrailingPreviewContexts(prompt: string): ExtractedPreviewContexts {
+  const match = TRAILING_PREVIEW_CONTEXT_BLOCK_PATTERN.exec(prompt);
+  if (!match) {
+    return {
+      promptText: prompt,
+      contextCount: 0,
+      previewTitle: null,
+      contexts: [],
+    };
+  }
+
+  const promptText = prompt.slice(0, match.index).replace(/\n+$/, "");
+  const parsedContexts = parsePreviewContextEntries(match[1] ?? "");
+  return {
+    promptText,
+    contextCount: parsedContexts.length,
+    previewTitle:
+      parsedContexts.length > 0
+        ? parsedContexts
+            .map(({ header, body }) => (body.length > 0 ? `${header}\n${body}` : header))
+            .join("\n\n")
+        : null,
+    contexts: parsedContexts,
+  };
+}
+
+function parsePreviewContextEntries(block: string): ParsedPreviewContextEntry[] {
+  const entries: ParsedPreviewContextEntry[] = [];
+  let current: { header: string; bodyLines: string[] } | null = null;
+
+  const commitCurrent = () => {
+    if (!current) {
+      return;
+    }
+    entries.push({
+      header: current.header,
+      body: current.bodyLines.join("\n").trimEnd(),
+    });
+    current = null;
+  };
+
+  for (const rawLine of block.split("\n")) {
+    const headerMatch = /^- (.+):$/.exec(rawLine);
+    if (headerMatch) {
+      commitCurrent();
+      current = {
+        header: headerMatch[1]!,
+        bodyLines: [],
+      };
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    if (rawLine.startsWith("  ")) {
+      current.bodyLines.push(rawLine.slice(2));
+      continue;
+    }
+    if (rawLine.length === 0) {
+      current.bodyLines.push("");
+    }
+  }
+
+  commitCurrent();
+  return entries;
+}

--- a/apps/web/src/lib/userMessageContext.test.ts
+++ b/apps/web/src/lib/userMessageContext.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendUserMessageContextsToPrompt,
+  deriveDisplayedUserMessageState,
+} from "./userMessageContext";
+
+describe("userMessageContext", () => {
+  it("appends and extracts terminal and preview context blocks together", () => {
+    const prompt = appendUserMessageContextsToPrompt("Check this button", {
+      terminalContexts: [
+        {
+          terminalId: "default",
+          terminalLabel: "Terminal 1",
+          lineStart: 7,
+          lineEnd: 8,
+          text: "bun run dev\nready in 1.2s",
+        },
+      ],
+      previewContexts: [
+        {
+          pageUrl: "http://localhost:3000/",
+          pageTitle: "Homepage",
+          selector: 'button[data-testid="submit"]',
+          tagName: "button",
+          role: "button",
+          ariaLabel: null,
+          text: "Submit",
+          href: null,
+          name: null,
+          placeholder: null,
+        },
+      ],
+    });
+
+    expect(prompt).toContain("<terminal_context>");
+    expect(prompt).toContain("<preview_context>");
+
+    expect(deriveDisplayedUserMessageState(prompt)).toEqual({
+      visibleText: "Check this button",
+      copyText: prompt,
+      contextCount: 2,
+      previewTitle: [
+        "Terminal 1 lines 7-8",
+        "7 | bun run dev",
+        "8 | ready in 1.2s",
+        "",
+        'button "Submit"',
+        "page: Homepage",
+        "url: http://localhost:3000/",
+        'selector: button[data-testid="submit"]',
+        "tag: button",
+        "role: button",
+        "text: Submit",
+      ].join("\n"),
+      terminalContexts: [
+        {
+          header: "Terminal 1 lines 7-8",
+          body: "7 | bun run dev\n8 | ready in 1.2s",
+        },
+      ],
+      previewContexts: [
+        {
+          header: 'button "Submit"',
+          body: [
+            "page: Homepage",
+            "url: http://localhost:3000/",
+            'selector: button[data-testid="submit"]',
+            "tag: button",
+            "role: button",
+            "text: Submit",
+          ].join("\n"),
+        },
+      ],
+    });
+  });
+
+  it("preserves plain prompt text when no hidden context blocks are present", () => {
+    expect(deriveDisplayedUserMessageState("Just a normal message")).toEqual({
+      visibleText: "Just a normal message",
+      copyText: "Just a normal message",
+      contextCount: 0,
+      previewTitle: null,
+      terminalContexts: [],
+      previewContexts: [],
+    });
+  });
+});

--- a/apps/web/src/lib/userMessageContext.ts
+++ b/apps/web/src/lib/userMessageContext.ts
@@ -1,0 +1,58 @@
+import {
+  appendTerminalContextsToPrompt,
+  extractTrailingTerminalContexts,
+  type ParsedTerminalContextEntry,
+  type TerminalContextSelection,
+} from "./terminalContext";
+import {
+  appendPreviewContextsToPrompt,
+  extractTrailingPreviewContexts,
+  type ParsedPreviewContextEntry,
+  type PreviewContextSelection,
+} from "./previewContext";
+
+export interface DisplayedUserMessageState {
+  visibleText: string;
+  copyText: string;
+  contextCount: number;
+  previewTitle: string | null;
+  terminalContexts: ParsedTerminalContextEntry[];
+  previewContexts: ParsedPreviewContextEntry[];
+}
+
+export function appendUserMessageContextsToPrompt(
+  prompt: string,
+  contexts: {
+    terminalContexts?: ReadonlyArray<TerminalContextSelection>;
+    previewContexts?: ReadonlyArray<PreviewContextSelection>;
+  },
+): string {
+  const withTerminalContexts = appendTerminalContextsToPrompt(
+    prompt,
+    contexts.terminalContexts ?? [],
+  );
+  return appendPreviewContextsToPrompt(withTerminalContexts, contexts.previewContexts ?? []);
+}
+
+export function deriveDisplayedUserMessageState(prompt: string): DisplayedUserMessageState {
+  const extractedPreviewContexts = extractTrailingPreviewContexts(prompt);
+  const extractedTerminalContexts = extractTrailingTerminalContexts(
+    extractedPreviewContexts.promptText,
+  );
+
+  const previewTitle = [
+    extractedTerminalContexts.previewTitle,
+    extractedPreviewContexts.previewTitle,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join("\n\n");
+
+  return {
+    visibleText: extractedTerminalContexts.promptText,
+    copyText: prompt,
+    contextCount: extractedTerminalContexts.contextCount + extractedPreviewContexts.contextCount,
+    previewTitle: previewTitle.length > 0 ? previewTitle : null,
+    terminalContexts: extractedTerminalContexts.contexts,
+    previewContexts: extractedPreviewContexts.contexts,
+  };
+}

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -1,6 +1,7 @@
+import { ProjectId } from "@okcode/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const STORAGE_KEY = "okcode:desktop-preview:v3";
+const STORAGE_KEY = "okcode:desktop-preview:v2";
 
 let usePreviewStateStore: typeof import("./previewStateStore").usePreviewStateStore;
 let storage: Map<string, string>;
@@ -26,33 +27,27 @@ describe("previewStateStore", () => {
 
     ({ usePreviewStateStore } = await import("./previewStateStore"));
     usePreviewStateStore.setState({
-      globalOpen: false,
+      openByThreadId: {},
       dockByThreadId: {},
       sizeByThreadId: {},
-      favoriteUrls: [],
+      urlByProjectId: {},
+      favoriteUrlByProjectId: {},
     });
     storage.clear();
   });
 
-  it("persists and clears favorite URLs", () => {
+  it("persists and clears the project favorite URL", () => {
+    const projectId = ProjectId.makeUnsafe("project-1");
     const store = usePreviewStateStore.getState();
 
-    store.addFavoriteUrl("http://localhost:3000/");
-    expect(usePreviewStateStore.getState().favoriteUrls).toContain("http://localhost:3000/");
-    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrls"');
+    store.setProjectFavoriteUrl(projectId, "http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBe(
+      "http://localhost:3000/",
+    );
+    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId"');
 
-    store.toggleFavoriteUrl("http://localhost:3000/");
-    expect(usePreviewStateStore.getState().favoriteUrls).not.toContain("http://localhost:3000/");
-  });
-
-  it("toggles globalOpen", () => {
-    const store = usePreviewStateStore.getState();
-
-    store.setGlobalOpen(true);
-    expect(usePreviewStateStore.getState().globalOpen).toBe(true);
-    expect(storage.get(STORAGE_KEY)).toContain('"globalOpen":true');
-
-    store.toggleGlobalOpen();
-    expect(usePreviewStateStore.getState().globalOpen).toBe(false);
+    store.toggleProjectFavorite(projectId, "http://localhost:3000/");
+    expect(usePreviewStateStore.getState().favoriteUrlByProjectId[projectId]).toBeUndefined();
+    expect(storage.get(STORAGE_KEY)).toContain('"favoriteUrlByProjectId":{}');
   });
 });

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -1,35 +1,70 @@
-import type { ThreadId } from "@okcode/contracts";
+import type { ProjectId, ThreadId } from "@okcode/contracts";
 import { create } from "zustand";
 
 export type PreviewDock = "left" | "right" | "top" | "bottom";
 
 interface PersistedPreviewUiState {
-  globalOpen: boolean;
+  openByThreadId: Record<string, boolean>;
   dockByThreadId: Record<string, PreviewDock>;
   sizeByThreadId: Record<string, number>;
-  favoriteUrls: string[];
+  urlByProjectId: Record<string, string>;
+  favoriteUrlByProjectId: Record<string, string>;
 }
 
 interface PreviewStateStore extends PersistedPreviewUiState {
-  setGlobalOpen: (open: boolean) => void;
-  toggleGlobalOpen: () => void;
+  setThreadOpen: (threadId: ThreadId, open: boolean) => void;
+  toggleThreadOpen: (threadId: ThreadId) => void;
   setThreadDock: (threadId: ThreadId, dock: PreviewDock) => void;
   toggleThreadLayout: (threadId: ThreadId) => void;
   setThreadSize: (threadId: ThreadId, size: number) => void;
-  addFavoriteUrl: (url: string) => void;
-  removeFavoriteUrl: (url: string) => void;
-  toggleFavoriteUrl: (url: string) => void;
+  setProjectUrl: (projectId: ProjectId, url: string) => void;
+  setProjectFavoriteUrl: (projectId: ProjectId, url: string | null) => void;
+  toggleProjectFavorite: (projectId: ProjectId, url: string) => void;
 }
 
-const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v3";
+const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v2";
 
 function createEmptyPersistedPreviewUiState(): PersistedPreviewUiState {
   return {
-    globalOpen: false,
+    openByThreadId: {},
     dockByThreadId: {},
     sizeByThreadId: {},
-    favoriteUrls: [],
+    urlByProjectId: {},
+    favoriteUrlByProjectId: {},
   };
+}
+
+function snapshotPreviewUiState(state: {
+  openByThreadId: PersistedPreviewUiState["openByThreadId"];
+  dockByThreadId: PersistedPreviewUiState["dockByThreadId"];
+  sizeByThreadId: PersistedPreviewUiState["sizeByThreadId"];
+  urlByProjectId: PersistedPreviewUiState["urlByProjectId"];
+  favoriteUrlByProjectId: PersistedPreviewUiState["favoriteUrlByProjectId"];
+}): PersistedPreviewUiState {
+  return {
+    openByThreadId: state.openByThreadId,
+    dockByThreadId: state.dockByThreadId,
+    sizeByThreadId: state.sizeByThreadId,
+    urlByProjectId: state.urlByProjectId,
+    favoriteUrlByProjectId: state.favoriteUrlByProjectId,
+  };
+}
+
+function normalizeUrlRecord(record: unknown): Record<string, string> {
+  if (!record || typeof record !== "object") {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).flatMap(([key, value]) => {
+      if (typeof key !== "string" || typeof value !== "string") {
+        return [];
+      }
+
+      const normalizedValue = value.trim();
+      return normalizedValue.length > 0 ? [[key, normalizedValue] as const] : [];
+    }),
+  );
 }
 
 function normalizePreviewSize(size: unknown): number | null {
@@ -52,7 +87,15 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
 
     const parsed = JSON.parse(raw) as Partial<PersistedPreviewUiState>;
     return {
-      globalOpen: parsed.globalOpen === true,
+      openByThreadId:
+        parsed.openByThreadId && typeof parsed.openByThreadId === "object"
+          ? Object.fromEntries(
+              Object.entries(parsed.openByThreadId).filter(
+                (entry): entry is [string, boolean] =>
+                  typeof entry[0] === "string" && entry[1] === true,
+              ),
+            )
+          : {},
       dockByThreadId:
         parsed.dockByThreadId && typeof parsed.dockByThreadId === "object"
           ? Object.fromEntries(
@@ -77,11 +120,8 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
               }),
             )
           : {},
-      favoriteUrls: Array.isArray(parsed.favoriteUrls)
-        ? parsed.favoriteUrls.filter(
-            (u): u is string => typeof u === "string" && u.trim().length > 0,
-          )
-        : [],
+      urlByProjectId: normalizeUrlRecord(parsed.urlByProjectId),
+      favoriteUrlByProjectId: normalizeUrlRecord(parsed.favoriteUrlByProjectId),
     };
   } catch {
     return createEmptyPersistedPreviewUiState();
@@ -97,10 +137,11 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
     window.localStorage.setItem(
       PREVIEW_STATE_STORAGE_KEY,
       JSON.stringify({
-        globalOpen: state.globalOpen,
+        openByThreadId: state.openByThreadId,
         dockByThreadId: state.dockByThreadId,
         sizeByThreadId: state.sizeByThreadId,
-        favoriteUrls: state.favoriteUrls,
+        urlByProjectId: state.urlByProjectId,
+        favoriteUrlByProjectId: state.favoriteUrlByProjectId,
       } satisfies PersistedPreviewUiState),
     );
   } catch {
@@ -108,30 +149,30 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
   }
 }
 
-function snapshotState(state: PreviewStateStore): PersistedPreviewUiState {
-  return {
-    globalOpen: state.globalOpen,
-    dockByThreadId: state.dockByThreadId,
-    sizeByThreadId: state.sizeByThreadId,
-    favoriteUrls: state.favoriteUrls,
-  };
-}
-
 const initialState = readPersistedPreviewUiState();
 
 export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
   ...initialState,
 
-  setGlobalOpen: (open) => {
+  setThreadOpen: (threadId, open) => {
     set((state) => {
-      const next = { ...snapshotState(state), globalOpen: open };
-      persistPreviewUiState(next);
-      return { globalOpen: open };
+      const nextOpenByThreadId = {
+        ...state.openByThreadId,
+        [threadId]: open,
+      };
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          openByThreadId: nextOpenByThreadId,
+        }),
+      );
+      return { openByThreadId: nextOpenByThreadId };
     });
   },
 
-  toggleGlobalOpen: () => {
-    get().setGlobalOpen(!get().globalOpen);
+  toggleThreadOpen: (threadId) => {
+    const current = get().openByThreadId[threadId] === true;
+    get().setThreadOpen(threadId, !current);
   },
 
   setThreadDock: (threadId, dock) => {
@@ -140,10 +181,12 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.dockByThreadId,
         [threadId]: dock,
       };
-      persistPreviewUiState({
-        ...snapshotState(state),
-        dockByThreadId: nextDockByThreadId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          dockByThreadId: nextDockByThreadId,
+        }),
+      );
       return { dockByThreadId: nextDockByThreadId };
     });
   },
@@ -172,41 +215,64 @@ export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
         ...state.sizeByThreadId,
         [threadId]: normalizedSize,
       };
-      persistPreviewUiState({
-        ...snapshotState(state),
-        sizeByThreadId: nextSizeByThreadId,
-      });
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          sizeByThreadId: nextSizeByThreadId,
+        }),
+      );
       return { sizeByThreadId: nextSizeByThreadId };
     });
   },
 
-  addFavoriteUrl: (url) => {
-    const normalized = url.trim();
-    if (normalized.length === 0) return;
+  setProjectUrl: (projectId, url) => {
+    const normalizedUrl = url.trim();
     set((state) => {
-      if (state.favoriteUrls.includes(normalized)) return state;
-      const nextFavorites = [...state.favoriteUrls, normalized];
-      persistPreviewUiState({ ...snapshotState(state), favoriteUrls: nextFavorites });
-      return { favoriteUrls: nextFavorites };
+      const nextUrlByProjectId = { ...state.urlByProjectId };
+      if (normalizedUrl.length > 0) {
+        nextUrlByProjectId[projectId] = normalizedUrl;
+      } else {
+        delete nextUrlByProjectId[projectId];
+      }
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          urlByProjectId: nextUrlByProjectId,
+        }),
+      );
+      return { urlByProjectId: nextUrlByProjectId };
     });
   },
 
-  removeFavoriteUrl: (url) => {
-    const normalized = url.trim();
+  setProjectFavoriteUrl: (projectId, url) => {
+    const normalizedUrl = url?.trim() ?? "";
     set((state) => {
-      const nextFavorites = state.favoriteUrls.filter((u) => u !== normalized);
-      persistPreviewUiState({ ...snapshotState(state), favoriteUrls: nextFavorites });
-      return { favoriteUrls: nextFavorites };
+      const nextFavoriteUrlByProjectId = { ...state.favoriteUrlByProjectId };
+      if (normalizedUrl.length > 0) {
+        nextFavoriteUrlByProjectId[projectId] = normalizedUrl;
+      } else {
+        delete nextFavoriteUrlByProjectId[projectId];
+      }
+      persistPreviewUiState(
+        snapshotPreviewUiState({
+          ...state,
+          favoriteUrlByProjectId: nextFavoriteUrlByProjectId,
+        }),
+      );
+      return { favoriteUrlByProjectId: nextFavoriteUrlByProjectId };
     });
   },
 
-  toggleFavoriteUrl: (url) => {
-    const normalized = url.trim();
-    if (normalized.length === 0) return;
-    if (get().favoriteUrls.includes(normalized)) {
-      get().removeFavoriteUrl(normalized);
-    } else {
-      get().addFavoriteUrl(normalized);
+  toggleProjectFavorite: (projectId, url) => {
+    const normalizedUrl = url.trim();
+    if (normalizedUrl.length === 0) {
+      return;
     }
+
+    const currentFavoriteUrl = get().favoriteUrlByProjectId[projectId] ?? null;
+    get().setProjectFavoriteUrl(
+      projectId,
+      currentFavoriteUrl === normalizedUrl ? null : normalizedUrl,
+    );
   },
 }));

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -285,8 +285,8 @@ function ChatThreadRouteView() {
   const closeCodeViewerStore = useCodeViewerStore((state) => state.close);
 
   // Preview state from Zustand store
-  const previewOpen = usePreviewStateStore((state) => state.globalOpen);
-  const setPreviewOpen = usePreviewStateStore((state) => state.setGlobalOpen);
+  const previewOpen = usePreviewStateStore((state) => state.openByThreadId[threadId] === true);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
 
   // TanStack Router keeps active route components mounted across param-only navigations
   // unless remountDeps are configured, so this stays warm across thread switches.
@@ -316,8 +316,8 @@ function ChatThreadRouteView() {
   }, [closeCodeViewerStore]);
 
   const closePreview = useCallback(() => {
-    setPreviewOpen(false);
-  }, [setPreviewOpen]);
+    setPreviewOpen(threadId, false);
+  }, [setPreviewOpen, threadId]);
 
   // Enforce mutual exclusivity: only one right-side panel open at a time.
   useMutuallyExclusivePanels(

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -136,6 +136,7 @@ export type DesktopPreviewStatus = "closed" | "loading" | "ready" | "error";
 export type DesktopPreviewErrorCode =
   | "invalid-url"
   | "non-local-url"
+  | "navigation-blocked"
   | "load-failed"
   | "process-gone";
 
@@ -154,26 +155,6 @@ export interface DesktopPreviewBounds {
   viewportHeight: number;
 }
 
-export type PreviewTabId = string;
-
-export interface PreviewTabState {
-  tabId: PreviewTabId;
-  status: DesktopPreviewStatus;
-  url: string | null;
-  title: string | null;
-  error: DesktopPreviewError | null;
-  canGoBack: boolean;
-  canGoForward: boolean;
-  devToolsOpen: boolean;
-}
-
-export interface PreviewTabsState {
-  tabs: PreviewTabState[];
-  activeTabId: PreviewTabId | null;
-  visible: boolean;
-}
-
-/** @deprecated Use PreviewTabsState instead */
 export interface DesktopPreviewState {
   status: DesktopPreviewStatus;
   url: string | null;
@@ -182,16 +163,43 @@ export interface DesktopPreviewState {
   error: DesktopPreviewError | null;
   canGoBack: boolean;
   canGoForward: boolean;
+  pickingElement: boolean;
 }
 
-export interface PreviewCreateTabResult {
-  tabId: PreviewTabId;
-  state: PreviewTabsState;
+export interface PreviewOpenResult {
+  accepted: boolean;
+  state: DesktopPreviewState;
 }
 
 export interface PreviewNavigateResult {
   accepted: boolean;
-  state: PreviewTabsState;
+  state: DesktopPreviewState;
+}
+
+export interface DesktopPreviewElementSelection {
+  pageUrl: string;
+  pageTitle: string | null;
+  selector: string;
+  tagName: string;
+  role: string | null;
+  ariaLabel: string | null;
+  text: string;
+  href: string | null;
+  name: string | null;
+  placeholder: string | null;
+}
+
+export type PreviewPickElementResultReason =
+  | "cancelled"
+  | "preview-unavailable"
+  | "already-picking"
+  | "selection-failed";
+
+export interface PreviewPickElementResult {
+  accepted: boolean;
+  selection: DesktopPreviewElementSelection | null;
+  reason: PreviewPickElementResultReason | null;
+  state: DesktopPreviewState;
 }
 
 export interface DesktopBridge {
@@ -212,18 +220,17 @@ export interface DesktopBridge {
   installUpdate: () => Promise<DesktopUpdateActionResult>;
   onUpdateState: (listener: (state: DesktopUpdateState) => void) => () => void;
   preview: {
-    createTab: (input: { url: string; title?: string | null }) => Promise<PreviewCreateTabResult>;
-    closeTab: (input: { tabId: PreviewTabId }) => Promise<PreviewTabsState>;
-    activateTab: (input: { tabId: PreviewTabId }) => Promise<PreviewTabsState>;
+    open: (input: { url: string; title?: string | null }) => Promise<PreviewOpenResult>;
+    close: () => Promise<void>;
     goBack: () => Promise<void>;
     goForward: () => Promise<void>;
     reload: () => Promise<void>;
     navigate: (input: { url: string }) => Promise<PreviewNavigateResult>;
-    toggleDevTools: () => Promise<void>;
+    pickElement: () => Promise<PreviewPickElementResult>;
+    cancelPickElement: () => Promise<void>;
+    getState: () => Promise<DesktopPreviewState>;
     setBounds: (bounds: DesktopPreviewBounds) => Promise<void>;
-    closeAll: () => Promise<void>;
-    getState: () => Promise<PreviewTabsState>;
-    onState: (listener: (state: PreviewTabsState) => void) => () => void;
+    onState: (listener: (state: DesktopPreviewState) => void) => () => void;
   };
 }
 


### PR DESCRIPTION
Add preview element selection as chat context.

This lets the desktop preview enter an element-picking mode, capture DOM metadata for the selected element, and carry that selection into the next chat message as structured context. It gives users a lightweight way to point at live UI in the local preview without copying selectors or describing the target by hand.

This is a narrowed version of the earlier draft. It intentionally keeps the PR scoped to the preview interaction and the desktop/web preview state plumbing needed to support it, without the unrelated server and runtime fixes that were bundled before.