### PR TITLE
Open PR review files in the code viewer

### DIFF
--- a/apps/web/src/components/pr-review/PrWorkspace.tsx
+++ b/apps/web/src/components/pr-review/PrWorkspace.tsx
@@ -16,13 +16,13 @@ import { cn } from "~/lib/utils";
 import { ensureNativeApi } from "~/nativeApi";
 import { Button } from "~/components/ui/button";
 import { joinPath, projectLabel } from "~/components/review/reviewUtils";
+import { useCodeViewerStore } from "~/codeViewerStore";
 import type { Project } from "~/types";
 import { PrFileCommentComposer } from "./PrFileCommentComposer";
 import { PrFileTabStrip, type FileViewMode } from "./PrFileTabStrip";
 import {
   PR_REVIEW_DIFF_UNSAFE_CSS,
   buildFileDiffRenderKey,
-  openPathInEditor,
   parseRenderablePatch,
   resolveFileDiffPath,
   shortCommentPreview,
@@ -52,6 +52,7 @@ export function PrWorkspace({
   onCreateThread: (input: { path: string; line: number; body: string }) => Promise<void>;
 }) {
   const { resolvedTheme } = useTheme();
+  const openFileInCodeViewer = useCodeViewerStore((state) => state.openFile);
   const [fileViewMode, setFileViewMode] = useLocalStorage(
     "okcode:pr-review:file-view-mode",
     "single",
@@ -227,7 +228,7 @@ export function PrWorkspace({
                     ) : null}
                     <Button
                       onClick={() => {
-                        void openPathInEditor(joinPath(project.cwd, filePath));
+                        openFileInCodeViewer(project.cwd, filePath);
                       }}
                       size="xs"
                       variant="outline"


### PR DESCRIPTION
## Summary
- Switched PR review file opening from the editor path helper to the shared code viewer store.
- Files now open through `openFileInCodeViewer(project.cwd, filePath)` so review navigation stays inside the app UI.
- Removed the unused `openPathInEditor` import from `PrWorkspace`.

## Testing
- Not run (PR summary only).
- Reviewed the diff to confirm the click handler now routes through the code viewer store.