### PR TITLE
Use nocookie YouTube embeds with JS API params

### DIFF
--- a/apps/web/src/youtubePlayerStore.ts
+++ b/apps/web/src/youtubePlayerStore.ts
@@ -186,8 +186,19 @@ export function parseYouTubeUrl(input: string): { type: "video" | "playlist"; id
 }
 
 export function buildYouTubeEmbedUrl(type: "video" | "playlist", id: string): string {
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : "";
+  const params = new URLSearchParams({
+    autoplay: "1",
+    enablejsapi: "1",
+    origin,
+    rel: "0",
+    modestbranding: "1",
+  });
+
   if (type === "playlist") {
-    return `https://www.youtube.com/embed/videoseries?list=${id}&autoplay=1`;
+    params.set("list", id);
+    return `https://www.youtube-nocookie.com/embed/videoseries?${params.toString()}`;
   }
-  return `https://www.youtube.com/embed/${id}?autoplay=1`;
+  return `https://www.youtube-nocookie.com/embed/${id}?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- Switched YouTube embeds to `youtube-nocookie.com` for both video and playlist playback.
- Added embed query params for autoplay, JS API support, origin, and reduced related videos/branding.
- Kept the existing URL parsing behavior unchanged; only embed URL construction changed.

## Testing
- Not run (PR content only).
- Reviewed the diff to confirm both video and playlist embed URLs now use the nocookie domain and include the new params.