### PR TITLE
Render image files in the code viewer

### DIFF
--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -844,7 +844,17 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           relativePath: body.relativePath,
           path,
         });
-        const MAX_READ_SIZE = 1_048_576; // 1MB
+        const MAX_READ_SIZE_TEXT = 1_048_576; // 1MB
+        const MAX_READ_SIZE_IMAGE = 10_485_760; // 10MB
+        const IMAGE_EXTENSIONS_SET = new Set([
+          ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp",
+          ".ico", ".tiff", ".tif", ".avif", ".svg",
+        ]);
+        const fileExt = target.relativePath
+          .substring(target.relativePath.lastIndexOf("."))
+          .toLowerCase();
+        const isImageExt = IMAGE_EXTENSIONS_SET.has(fileExt);
+        const MAX_READ_SIZE = isImageExt ? MAX_READ_SIZE_IMAGE : MAX_READ_SIZE_TEXT;
         const fileStat = yield* fileSystem.stat(target.absolutePath).pipe(
           Effect.mapError(
             (cause) =>
@@ -861,7 +871,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         const sizeBytes = Number(fileStat.size);
         if (sizeBytes > MAX_READ_SIZE) {
           return yield* new RouteRequestError({
-            message: `File is too large to display (${(sizeBytes / 1024 / 1024).toFixed(1)}MB). Maximum supported size is 1MB.`,
+            message: `File is too large to display (${(sizeBytes / 1024 / 1024).toFixed(1)}MB). Maximum supported size is ${(MAX_READ_SIZE / 1024 / 1024).toFixed(0)}MB.`,
           });
         }
         // Read raw bytes to detect binary files
@@ -875,12 +885,47 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         );
         // Check for null bytes in the first 8KB to detect binary files
         const checkLength = Math.min(rawBytes.length, 8192);
+        let isBinary = false;
         for (let i = 0; i < checkLength; i++) {
           if (rawBytes[i] === 0) {
-            return yield* new RouteRequestError({
-              message: `File appears to be binary and cannot be displayed: ${target.relativePath}`,
-            });
+            isBinary = true;
+            break;
           }
+        }
+        if (isBinary) {
+          // Check if the file is an image by extension
+          const IMAGE_EXTENSIONS: Record<string, string> = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".gif": "image/gif",
+            ".bmp": "image/bmp",
+            ".webp": "image/webp",
+            ".ico": "image/x-icon",
+            ".tiff": "image/tiff",
+            ".tif": "image/tiff",
+            ".avif": "image/avif",
+            ".svg": "image/svg+xml",
+          };
+          const ext = target.relativePath
+            .substring(target.relativePath.lastIndexOf("."))
+            .toLowerCase();
+          const mimeType = IMAGE_EXTENSIONS[ext];
+          if (mimeType) {
+            // Return image as base64 data URL
+            const base64 = Buffer.from(rawBytes).toString("base64");
+            const imageDataUrl = `data:${mimeType};base64,${base64}`;
+            return {
+              relativePath: target.relativePath,
+              contents: "",
+              sizeBytes,
+              truncated: false,
+              imageDataUrl,
+            };
+          }
+          return yield* new RouteRequestError({
+            message: `File appears to be binary and cannot be displayed: ${target.relativePath}`,
+          });
         }
         const contents = new TextDecoder().decode(rawBytes);
         return {

--- a/apps/web/src/components/CodeViewerPanel.tsx
+++ b/apps/web/src/components/CodeViewerPanel.tsx
@@ -86,10 +86,24 @@ const CodeViewerFileContent = memo(function CodeViewerFileContent(props: {
     );
   }
 
-  if (!query.data?.contents && query.data?.contents !== "") {
+  if (!query.data?.contents && query.data?.contents !== "" && !query.data?.imageDataUrl) {
     return (
       <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
         No content available.
+      </div>
+    );
+  }
+
+  // Render image files
+  if (query.data?.imageDataUrl) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+        <img
+          src={query.data.imageDataUrl}
+          alt={props.relativePath}
+          className="max-h-full max-w-full object-contain"
+          draggable={false}
+        />
       </div>
     );
   }

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -79,5 +79,7 @@ export const ProjectReadFileResult = Schema.Struct({
   contents: Schema.String,
   sizeBytes: Schema.Number,
   truncated: Schema.Boolean,
+  /** Base64 data URL for image files (e.g. "data:image/png;base64,...") */
+  imageDataUrl: Schema.optional(Schema.String),
 });
 export type ProjectReadFileResult = typeof ProjectReadFileResult.Type;


### PR DESCRIPTION
## Summary
- Added server-side handling for image files so `project/readFile` can return a base64 data URL for supported image extensions.
- Increased the read size limit for image files while keeping the existing 1 MB limit for text files.
- Updated the web code viewer to render image content directly instead of showing a binary-file error or empty state.
- Extended the shared project contract with an optional `imageDataUrl` field.

## Testing
- Not run (not requested).
- Verified the change set by reviewing the server, contract, and web UI paths affected by image file rendering.