### PR TITLE
Add GitHub clone flow from the home screen

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from "node:fs";
+
 import {
   Cache,
   Data,
@@ -33,6 +35,14 @@ import { ServerConfig } from "../../config.ts";
 import { decodeJsonResult } from "@okcode/shared/schemaJson";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { resolveRuntimeEnvironment } from "../../runtimeEnvironment.ts";
+
+function safeRealpath(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    return value;
+  }
+}
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
@@ -1850,6 +1860,37 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         ),
       );
 
+    const cloneRepository: GitCoreShape["cloneRepository"] = (input) =>
+      Effect.gen(function* () {
+        // Extract repo name from URL for the target directory name
+        const urlPath = input.url.replace(/\.git$/, "");
+        const repoName = urlPath.split("/").pop() ?? "repo";
+        const clonePath = path.join(input.targetDir, repoName);
+
+        const args = ["clone", input.url, clonePath];
+        if (input.branch) {
+          args.push("--branch", input.branch);
+        }
+
+        yield* executeGit("GitCore.cloneRepository", input.targetDir, args, {
+          timeoutMs: 5 * 60_000, // 5 minutes for large repos
+          fallbackErrorMessage: "git clone failed",
+        });
+
+        // Read the current branch from the cloned repo
+        const branchOutput = yield* runGitStdout("GitCore.cloneRepository.branch", clonePath, [
+          "rev-parse",
+          "--abbrev-ref",
+          "HEAD",
+        ]);
+        const branch = branchOutput.trim() || "main";
+
+        // Resolve to real path in case of symlinks
+        const resolvedPath = safeRealpath(clonePath);
+
+        return { path: resolvedPath, branch };
+      });
+
     return {
       execute,
       status,
@@ -1872,6 +1913,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       checkoutBranch,
       initRepo,
       listLocalBranchNames,
+      cloneRepository,
     } satisfies GitCoreShape;
   });
 

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -10,6 +10,8 @@ import { ServiceMap } from "effect";
 import type { Effect, Scope } from "effect";
 import type {
   GitCheckoutInput,
+  GitCloneRepositoryInput,
+  GitCloneRepositoryResult,
   GitCreateBranchInput,
   GitCreateWorktreeInput,
   GitCreateWorktreeResult,
@@ -267,6 +269,13 @@ export interface GitCoreShape {
    * List local branch names (short format).
    */
   readonly listLocalBranchNames: (cwd: string) => Effect.Effect<string[], GitCommandError>;
+
+  /**
+   * Clone a remote repository into a target directory.
+   */
+  readonly cloneRepository: (
+    input: GitCloneRepositoryInput,
+  ) => Effect.Effect<GitCloneRepositoryResult, GitCommandError>;
 }
 
 /**

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -1082,6 +1082,11 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return yield* git.initRepo(body);
       }
 
+      case WS_METHODS.gitCloneRepository: {
+        const body = stripRequestTag(request.body);
+        return yield* git.cloneRepository(body);
+      }
+
       case WS_METHODS.terminalOpen: {
         const body = stripRequestTag(request.body);
         const snapshot = yield* projectionReadModelQuery.getSnapshot();

--- a/apps/web/src/components/ChatHomeEmptyState.tsx
+++ b/apps/web/src/components/ChatHomeEmptyState.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   FolderOpenIcon,
   FolderIcon,
+  GitBranchIcon,
   GitMergeIcon,
   GitPullRequestIcon,
   SettingsIcon,
@@ -18,6 +19,7 @@ import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { newCommandId, newProjectId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
+import { CloneRepositoryDialog } from "./CloneRepositoryDialog";
 import { sortProjectsForSidebar } from "./Sidebar.logic";
 import { ProviderSetupCard } from "./chat/ProviderSetupCard";
 import { Button } from "./ui/button";
@@ -34,6 +36,7 @@ export function ChatHomeEmptyState() {
   const threads = useStore((store) => store.threads);
   const { handleNewThread } = useHandleNewThread();
   const [isOpeningProject, setIsOpeningProject] = useState(false);
+  const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
 
   const recentProjects = useMemo(
     () =>
@@ -113,6 +116,47 @@ export function ChatHomeEmptyState() {
     setIsOpeningProject(false);
   }, [appSettings.defaultThreadEnvMode, handleNewThread, isOpeningProject, projects]);
 
+  const handleCloned = useCallback(
+    async (result: { path: string; branch: string; repoName: string }) => {
+      const api = readNativeApi();
+      if (!api) return;
+
+      const existingProject = projects.find((project) => project.cwd === result.path);
+      if (existingProject) {
+        await handleNewThread(existingProject.id, {
+          envMode: appSettings.defaultThreadEnvMode,
+        }).catch(() => undefined);
+        return;
+      }
+
+      try {
+        const projectId = newProjectId();
+        await api.orchestration.dispatchCommand({
+          type: "project.create",
+          commandId: newCommandId(),
+          projectId,
+          title: result.repoName,
+          workspaceRoot: result.path,
+          defaultModel: DEFAULT_MODEL_BY_PROVIDER.codex,
+          createdAt: new Date().toISOString(),
+        });
+        await handleNewThread(projectId, {
+          envMode: appSettings.defaultThreadEnvMode,
+        }).catch(() => undefined);
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to add project",
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unexpected error occurred while adding the project.",
+        });
+      }
+    },
+    [appSettings.defaultThreadEnvMode, handleNewThread, projects],
+  );
+
   const startLatestThread = useCallback(async () => {
     if (!latestProject) {
       await openProjectFolder();
@@ -177,6 +221,14 @@ export function ChatHomeEmptyState() {
                   >
                     <FolderOpenIcon className="size-4" />
                     {isOpeningProject ? "Opening…" : "Open project folder"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="justify-start gap-2"
+                    onClick={() => setCloneDialogOpen(true)}
+                  >
+                    <GitBranchIcon className="size-4" />
+                    Clone from GitHub
                   </Button>
                   <Button
                     variant="outline"
@@ -253,6 +305,12 @@ export function ChatHomeEmptyState() {
           )}
         </div>
       </div>
+
+      <CloneRepositoryDialog
+        open={cloneDialogOpen}
+        onOpenChange={setCloneDialogOpen}
+        onCloned={handleCloned}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/CloneRepositoryDialog.tsx
+++ b/apps/web/src/components/CloneRepositoryDialog.tsx
@@ -1,0 +1,236 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FolderOpenIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { gitCloneRepositoryMutationOptions } from "~/lib/gitReactQuery";
+import { parseGitHubRepositoryUrl, type ParsedGitHubUrl } from "~/githubRepositoryUrl";
+import { readNativeApi } from "~/nativeApi";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Spinner } from "./ui/spinner";
+
+interface CloneRepositoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCloned: (result: { path: string; branch: string; repoName: string }) => Promise<void> | void;
+}
+
+export function CloneRepositoryDialog({
+  open,
+  onOpenChange,
+  onCloned,
+}: CloneRepositoryDialogProps) {
+  const queryClient = useQueryClient();
+  const urlInputRef = useRef<HTMLInputElement>(null);
+  const [url, setUrl] = useState("");
+  const [urlDirty, setUrlDirty] = useState(false);
+  const [targetDir, setTargetDir] = useState("");
+  const [isPickingFolder, setIsPickingFolder] = useState(false);
+
+  const cloneMutation = useMutation(gitCloneRepositoryMutationOptions({ queryClient }));
+
+  const parsed: ParsedGitHubUrl | null = useMemo(() => parseGitHubRepositoryUrl(url), [url]);
+
+  useEffect(() => {
+    if (!open) return;
+    setUrl("");
+    setUrlDirty(false);
+    setTargetDir("");
+    cloneMutation.reset();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = window.requestAnimationFrame(() => {
+      urlInputRef.current?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [open]);
+
+  const pickTargetDir = useCallback(async () => {
+    const api = readNativeApi();
+    if (!api || isPickingFolder) return;
+
+    setIsPickingFolder(true);
+    try {
+      const pickedPath = await api.dialogs.pickFolder();
+      if (pickedPath) {
+        setTargetDir(pickedPath);
+      }
+    } catch {
+      // Swallow folder picker errors
+    } finally {
+      setIsPickingFolder(false);
+    }
+  }, [isPickingFolder]);
+
+  const handleClone = useCallback(async () => {
+    if (!parsed) {
+      setUrlDirty(true);
+      return;
+    }
+    if (!targetDir) {
+      return;
+    }
+
+    try {
+      const result = await cloneMutation.mutateAsync({
+        url: parsed.cloneUrl,
+        targetDir,
+        ...(parsed.branch ? { branch: parsed.branch } : {}),
+      });
+      await onCloned({
+        path: result.path,
+        branch: result.branch,
+        repoName: parsed.repo,
+      });
+      onOpenChange(false);
+    } catch {
+      // Error is tracked through cloneMutation.error
+    }
+  }, [cloneMutation, onCloned, onOpenChange, parsed, targetDir]);
+
+  const validationMessage = !urlDirty
+    ? null
+    : url.trim().length === 0
+      ? "Paste a GitHub repository URL or enter owner/repo."
+      : parsed === null
+        ? "Use a GitHub URL (https://github.com/owner/repo) or owner/repo."
+        : null;
+
+  const errorMessage =
+    validationMessage ??
+    (cloneMutation.error instanceof Error
+      ? cloneMutation.error.message
+      : cloneMutation.error
+        ? "Failed to clone repository."
+        : null);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen: boolean) => {
+        if (!cloneMutation.isPending) {
+          onOpenChange(nextOpen);
+        }
+      }}
+    >
+      <DialogPopup className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Clone from GitHub</DialogTitle>
+          <DialogDescription>
+            Clone a GitHub repository and open it as a new project.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-4">
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-foreground">Repository URL</span>
+            <Input
+              ref={urlInputRef}
+              placeholder="https://github.com/owner/repo or owner/repo"
+              value={url}
+              onChange={(event) => {
+                setUrlDirty(true);
+                setUrl(event.target.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                if (parsed && targetDir && !cloneMutation.isPending) {
+                  void handleClone();
+                }
+              }}
+            />
+          </label>
+
+          {parsed ? (
+            <div className="rounded-xl border border-border/70 bg-muted/24 p-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">
+                  {parsed.owner}/{parsed.repo}
+                </p>
+                {parsed.branch ? (
+                  <p className="truncate text-xs text-muted-foreground">Branch: {parsed.branch}</p>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-foreground">Clone into</span>
+            <div className="flex gap-2">
+              <Input
+                placeholder="Select a parent directory..."
+                value={targetDir}
+                onChange={(event) => setTargetDir(event.target.value)}
+                className="flex-1"
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") return;
+                  event.preventDefault();
+                  if (parsed && targetDir && !cloneMutation.isPending) {
+                    void handleClone();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 gap-1.5"
+                onClick={() => void pickTargetDir()}
+                disabled={isPickingFolder || cloneMutation.isPending}
+              >
+                <FolderOpenIcon className="size-3.5" />
+                Browse
+              </Button>
+            </div>
+            {parsed && targetDir ? (
+              <p className="text-xs text-muted-foreground">
+                Will clone to: {targetDir}/{parsed.repo}
+              </p>
+            ) : null}
+          </label>
+
+          {cloneMutation.isPending ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Spinner className="size-3.5" />
+              Cloning repository...
+            </div>
+          ) : null}
+
+          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+        </DialogPanel>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={cloneMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleClone()}
+            disabled={!parsed || !targetDir || cloneMutation.isPending}
+          >
+            {cloneMutation.isPending ? "Cloning..." : "Clone & Open"}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/githubRepositoryUrl.test.ts
+++ b/apps/web/src/githubRepositoryUrl.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { parseGitHubRepositoryUrl } from "./githubRepositoryUrl";
+
+describe("parseGitHubRepositoryUrl", () => {
+  it("returns null for empty input", () => {
+    expect(parseGitHubRepositoryUrl("")).toBeNull();
+    expect(parseGitHubRepositoryUrl("  ")).toBeNull();
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseGitHubRepositoryUrl("not a url")).toBeNull();
+    expect(parseGitHubRepositoryUrl("https://google.com")).toBeNull();
+    expect(parseGitHubRepositoryUrl("https://gitlab.com/owner/repo")).toBeNull();
+  });
+
+  it("parses basic HTTPS URL", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("parses HTTPS URL with .git suffix", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo.git");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("parses HTTPS URL with tree/branch path", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo/tree/feature-branch");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: "feature-branch",
+    });
+  });
+
+  it("parses HTTPS URL with tree/branch/path", () => {
+    const result = parseGitHubRepositoryUrl(
+      "https://github.com/owner/repo/tree/main/src/components",
+    );
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: "main",
+    });
+  });
+
+  it("parses HTTPS URL with blob path", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo/blob/main/README.md");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: "main",
+    });
+  });
+
+  it("parses SSH URL", () => {
+    const result = parseGitHubRepositoryUrl("git@github.com:owner/repo.git");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("parses SSH URL without .git suffix", () => {
+    const result = parseGitHubRepositoryUrl("git@github.com:owner/repo");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("parses owner/repo shorthand", () => {
+    const result = parseGitHubRepositoryUrl("owner/repo");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("trims whitespace", () => {
+    const result = parseGitHubRepositoryUrl("  https://github.com/owner/repo  ");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("handles URL with query params", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo?tab=readme");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("handles URL with fragment", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/owner/repo#readme");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/owner/repo.git",
+      owner: "owner",
+      repo: "repo",
+      branch: null,
+    });
+  });
+
+  it("is case-insensitive for the domain", () => {
+    const result = parseGitHubRepositoryUrl("https://GitHub.com/Owner/Repo");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/Owner/Repo.git",
+      owner: "Owner",
+      repo: "Repo",
+      branch: null,
+    });
+  });
+
+  it("handles repos with dots and hyphens", () => {
+    const result = parseGitHubRepositoryUrl("https://github.com/my-org/my.repo-name");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/my-org/my.repo-name.git",
+      owner: "my-org",
+      repo: "my.repo-name",
+      branch: null,
+    });
+  });
+
+  it("handles shorthand with dots and hyphens", () => {
+    const result = parseGitHubRepositoryUrl("my-org/my.repo");
+    expect(result).toEqual({
+      cloneUrl: "https://github.com/my-org/my.repo.git",
+      owner: "my-org",
+      repo: "my.repo",
+      branch: null,
+    });
+  });
+});

--- a/apps/web/src/githubRepositoryUrl.ts
+++ b/apps/web/src/githubRepositoryUrl.ts
@@ -1,0 +1,80 @@
+/**
+ * Parses a GitHub repository URL into its components.
+ *
+ * Supports:
+ * - `https://github.com/owner/repo`
+ * - `https://github.com/owner/repo.git`
+ * - `https://github.com/owner/repo/tree/branch`
+ * - `https://github.com/owner/repo/tree/branch/path/to/dir`
+ * - `git@github.com:owner/repo.git`
+ * - `owner/repo` (shorthand)
+ */
+
+export interface ParsedGitHubUrl {
+  /** Full HTTPS clone URL */
+  cloneUrl: string;
+  /** Repository owner (user or org) */
+  owner: string;
+  /** Repository name (without .git suffix) */
+  repo: string;
+  /** Branch name if specified in the URL */
+  branch: string | null;
+}
+
+const GITHUB_HTTPS_URL_PATTERN =
+  /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\/(?:tree|blob)\/([^?\s]+?))?(?:[?#].*)?$/i;
+
+const GITHUB_SSH_URL_PATTERN = /^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i;
+
+const GITHUB_SHORTHAND_PATTERN = /^([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)$/;
+
+export function parseGitHubRepositoryUrl(input: string): ParsedGitHubUrl | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  // Try HTTPS URL
+  const httpsMatch = GITHUB_HTTPS_URL_PATTERN.exec(trimmed);
+  if (httpsMatch) {
+    const owner = httpsMatch[1]!;
+    const repo = httpsMatch[2]!;
+    const branchAndPath = httpsMatch[3]?.trim() ?? null;
+    // The branch is the first segment of the tree/blob path
+    const branch = branchAndPath?.split("/")[0] ?? null;
+    return {
+      cloneUrl: `https://github.com/${owner}/${repo}.git`,
+      owner,
+      repo,
+      branch: branch && branch.length > 0 ? branch : null,
+    };
+  }
+
+  // Try SSH URL
+  const sshMatch = GITHUB_SSH_URL_PATTERN.exec(trimmed);
+  if (sshMatch) {
+    const owner = sshMatch[1]!;
+    const repo = sshMatch[2]!;
+    return {
+      cloneUrl: `https://github.com/${owner}/${repo}.git`,
+      owner,
+      repo,
+      branch: null,
+    };
+  }
+
+  // Try shorthand (owner/repo)
+  const shorthandMatch = GITHUB_SHORTHAND_PATTERN.exec(trimmed);
+  if (shorthandMatch) {
+    const owner = shorthandMatch[1]!;
+    const repo = shorthandMatch[2]!;
+    return {
+      cloneUrl: `https://github.com/${owner}/${repo}.git`,
+      owner,
+      repo,
+      branch: null,
+    };
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -231,6 +231,31 @@ export function gitRemoveWorktreeMutationOptions(input: { queryClient: QueryClie
   });
 }
 
+export function gitCloneRepositoryMutationOptions(input: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationKey: ["git", "mutation", "clone-repository"] as const,
+    mutationFn: async ({
+      url,
+      targetDir,
+      branch,
+    }: {
+      url: string;
+      targetDir: string;
+      branch?: string;
+    }) => {
+      const api = ensureNativeApi();
+      return api.git.cloneRepository({
+        url,
+        targetDir,
+        ...(branch ? { branch } : {}),
+      });
+    },
+    onSettled: async () => {
+      await invalidateGitQueries(input.queryClient);
+    },
+  });
+}
+
 export function gitPreparePullRequestThreadMutationOptions(input: {
   cwd: string | null;
   queryClient: QueryClient;

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -215,6 +215,8 @@ export function createWsNativeApi(): NativeApi {
       },
     },
     git: {
+      cloneRepository: (input) =>
+        transport.request(WS_METHODS.gitCloneRepository, input, { timeoutMs: null }),
       pull: (input) => transport.request(WS_METHODS.gitPull, input),
       status: (input) => transport.request(WS_METHODS.gitStatus, input),
       runStackedAction: (input) =>

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -191,6 +191,24 @@ export const GitInitInput = Schema.Struct({
 });
 export type GitInitInput = typeof GitInitInput.Type;
 
+export const GitCloneRepositoryInput = Schema.Struct({
+  /** HTTPS clone URL (e.g. `https://github.com/owner/repo.git`) */
+  url: TrimmedNonEmptyStringSchema,
+  /** Absolute path to the parent directory where the repo will be cloned */
+  targetDir: TrimmedNonEmptyStringSchema,
+  /** Optional branch to checkout after cloning */
+  branch: Schema.optional(TrimmedNonEmptyStringSchema),
+});
+export type GitCloneRepositoryInput = typeof GitCloneRepositoryInput.Type;
+
+export const GitCloneRepositoryResult = Schema.Struct({
+  /** Absolute path to the cloned repository */
+  path: TrimmedNonEmptyStringSchema,
+  /** The checked-out branch after cloning */
+  branch: TrimmedNonEmptyStringSchema,
+});
+export type GitCloneRepositoryResult = typeof GitCloneRepositoryResult.Type;
+
 // RPC Results
 
 const GitStatusPr = Schema.Struct({

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1,6 +1,8 @@
 import type {
   GitCheckoutInput,
   GitActionProgressEvent,
+  GitCloneRepositoryInput,
+  GitCloneRepositoryResult,
   GitCreateBranchInput,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
@@ -268,6 +270,8 @@ export interface NativeApi {
     openExternal: (url: string) => Promise<void>;
   };
   git: {
+    // Clone
+    cloneRepository: (input: GitCloneRepositoryInput) => Promise<GitCloneRepositoryResult>;
     // Existing branch/worktree API
     listBranches: (input: GitListBranchesInput) => Promise<GitListBranchesResult>;
     createWorktree: (input: GitCreateWorktreeInput) => Promise<GitCreateWorktreeResult>;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -14,6 +14,7 @@ import {
 import {
   GitActionProgressEvent,
   GitCheckoutInput,
+  GitCloneRepositoryInput,
   GitCreateBranchInput,
   GitPreparePullRequestThreadInput,
   GitCreateWorktreeInput,
@@ -99,6 +100,7 @@ export const WS_METHODS = {
   gitCreateBranch: "git.createBranch",
   gitCheckout: "git.checkout",
   gitInit: "git.init",
+  gitCloneRepository: "git.cloneRepository",
   gitResolvePullRequest: "git.resolvePullRequest",
   gitPreparePullRequestThread: "git.preparePullRequestThread",
   gitListPullRequests: "git.listPullRequests",
@@ -189,6 +191,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.gitCreateBranch, GitCreateBranchInput),
   tagRequestBody(WS_METHODS.gitCheckout, GitCheckoutInput),
   tagRequestBody(WS_METHODS.gitInit, GitInitInput),
+  tagRequestBody(WS_METHODS.gitCloneRepository, GitCloneRepositoryInput),
   tagRequestBody(WS_METHODS.gitResolvePullRequest, GitPullRequestRefInput),
   tagRequestBody(WS_METHODS.gitPreparePullRequestThread, GitPreparePullRequestThreadInput),
   tagRequestBody(WS_METHODS.gitListPullRequests, GitListPullRequestsInput),


### PR DESCRIPTION
## Summary
- Added a new “Clone from GitHub” flow in the empty home state, including a dialog to enter a repository URL, choose a destination folder, and open the cloned repo as a project.
- Added GitHub URL parsing support for HTTPS, SSH, and `owner/repo` shorthand, with tests covering common URL forms and branch links.
- Wired a new `git.cloneRepository` contract and WebSocket/native API path through the server and client layers.
- Implemented server-side clone handling with branch detection and realpath resolution for the cloned repository.

## Testing
- `Not run`
- Added unit coverage in `apps/web/src/githubRepositoryUrl.test.ts` for URL parsing cases.
- Recommend running `bun fmt`, `bun lint`, and `bun typecheck` before merge.