### PR TITLE
Refresh UI fonts and theme presets

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&family=Inter:wght@300..800&family=Plus+Jakarta+Sans:wght@300..800&display=swap"
       rel="stylesheet"
     />
     <title>OK Code</title>

--- a/apps/web/src/components/MarkdownPreview.tsx
+++ b/apps/web/src/components/MarkdownPreview.tsx
@@ -99,7 +99,7 @@ export const MarkdownPreview = memo(function MarkdownPreview({ contents }: Markd
             "--cm-callout-bg": "var(--secondary)",
             "--cm-radius": "12px",
             "--cm-font":
-              '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+              'var(--font-ui, "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif)',
             "--cm-mono":
               '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
           } as CSSProperties

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -5,25 +5,39 @@ type ColorTheme =
   | "default"
   | "iridescent-void"
   | "solar-witch"
-  | "cursor-dark"
+  | "midnight-clarity"
+  | "carbon"
+  | "vapor"
   | "cathedral-circuit";
+
+type FontFamily = "dm-sans" | "inter" | "plus-jakarta-sans";
 
 type ThemeSnapshot = {
   theme: Theme;
   systemDark: boolean;
   colorTheme: ColorTheme;
+  fontFamily: FontFamily;
 };
 
 export const COLOR_THEMES: { id: ColorTheme; label: string }[] = [
   { id: "default", label: "Default" },
   { id: "iridescent-void", label: "Iridescent Void" },
   { id: "solar-witch", label: "Solar Witch" },
-  { id: "cursor-dark", label: "Cursor Dark" },
+  { id: "midnight-clarity", label: "Midnight Clarity" },
+  { id: "carbon", label: "Carbon" },
+  { id: "vapor", label: "Vapor" },
   { id: "cathedral-circuit", label: "Cathedral Circuit" },
+];
+
+export const FONT_FAMILIES: { id: FontFamily; label: string }[] = [
+  { id: "inter", label: "Inter" },
+  { id: "dm-sans", label: "DM Sans" },
+  { id: "plus-jakarta-sans", label: "Plus Jakarta Sans" },
 ];
 
 const STORAGE_KEY = "okcode:theme";
 const COLOR_THEME_STORAGE_KEY = "okcode:color-theme";
+const FONT_FAMILY_STORAGE_KEY = "okcode:font-family";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 let listeners: Array<() => void> = [];
@@ -49,12 +63,34 @@ function getStoredColorTheme(): ColorTheme {
     raw === "default" ||
     raw === "iridescent-void" ||
     raw === "solar-witch" ||
-    raw === "cursor-dark" ||
+    raw === "midnight-clarity" ||
+    raw === "carbon" ||
+    raw === "vapor" ||
     raw === "cathedral-circuit"
   ) {
     return raw;
   }
   return "default";
+}
+
+function getStoredFontFamily(): FontFamily {
+  const raw = localStorage.getItem(FONT_FAMILY_STORAGE_KEY);
+  if (raw === "dm-sans" || raw === "inter" || raw === "plus-jakarta-sans") {
+    return raw;
+  }
+  return "inter";
+}
+
+const FONT_FAMILY_MAP: Record<FontFamily, string> = {
+  inter: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  "dm-sans": '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  "plus-jakarta-sans":
+    '"Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+function applyFont(fontFamily?: FontFamily) {
+  const font = fontFamily ?? getStoredFontFamily();
+  document.documentElement.style.setProperty("--font-ui", FONT_FAMILY_MAP[font]);
 }
 
 function applyTheme(theme: Theme, suppressTransitions = false) {
@@ -77,6 +113,9 @@ function applyTheme(theme: Theme, suppressTransitions = false) {
   if (colorTheme !== "default") {
     document.documentElement.classList.add(`theme-${colorTheme}`);
   }
+
+  // Apply font family
+  applyFont();
 
   syncDesktopTheme(theme);
   if (suppressTransitions) {
@@ -110,17 +149,19 @@ function getSnapshot(): ThemeSnapshot {
   const theme = getStored();
   const systemDark = theme === "system" ? getSystemDark() : false;
   const colorTheme = getStoredColorTheme();
+  const fontFamily = getStoredFontFamily();
 
   if (
     lastSnapshot &&
     lastSnapshot.theme === theme &&
     lastSnapshot.systemDark === systemDark &&
-    lastSnapshot.colorTheme === colorTheme
+    lastSnapshot.colorTheme === colorTheme &&
+    lastSnapshot.fontFamily === fontFamily
   ) {
     return lastSnapshot;
   }
 
-  lastSnapshot = { theme, systemDark, colorTheme };
+  lastSnapshot = { theme, systemDark, colorTheme, fontFamily };
   return lastSnapshot;
 }
 
@@ -137,7 +178,11 @@ function subscribe(listener: () => void): () => void {
 
   // Listen for storage changes from other tabs
   const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY || e.key === COLOR_THEME_STORAGE_KEY) {
+    if (
+      e.key === STORAGE_KEY ||
+      e.key === COLOR_THEME_STORAGE_KEY ||
+      e.key === FONT_FAMILY_STORAGE_KEY
+    ) {
       applyTheme(getStored(), true);
       emitChange();
     }
@@ -155,6 +200,7 @@ export function useTheme() {
   const snapshot = useSyncExternalStore(subscribe, getSnapshot);
   const theme = snapshot.theme;
   const colorTheme = snapshot.colorTheme;
+  const fontFamily = snapshot.fontFamily;
 
   const resolvedTheme: "light" | "dark" =
     theme === "system" ? (snapshot.systemDark ? "dark" : "light") : theme;
@@ -171,10 +217,24 @@ export function useTheme() {
     emitChange();
   }, []);
 
+  const setFontFamily = useCallback((next: FontFamily) => {
+    localStorage.setItem(FONT_FAMILY_STORAGE_KEY, next);
+    applyFont(next);
+    emitChange();
+  }, []);
+
   // Keep DOM in sync on mount/change
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
 
-  return { theme, setTheme, resolvedTheme, colorTheme, setColorTheme } as const;
+  return {
+    theme,
+    setTheme,
+    resolvedTheme,
+    colorTheme,
+    setColorTheme,
+    fontFamily,
+    setFontFamily,
+  } as const;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -122,13 +122,15 @@
 }
 
 body {
-  font-family:
-    "DM Sans",
+  font-family: var(
+    --font-ui,
+    "Inter",
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
     system-ui,
-    sans-serif;
+    sans-serif
+  );
   margin: 0;
   padding: 0;
   min-height: 100vh;

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -34,7 +34,7 @@ import { SidebarInset } from "../components/ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../components/ui/tooltip";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { isElectron } from "../env";
-import { useTheme, COLOR_THEMES } from "../hooks/useTheme";
+import { useTheme, COLOR_THEMES, FONT_FAMILIES } from "../hooks/useTheme";
 import {
   environmentVariablesQueryKeys,
   globalEnvironmentVariablesQueryOptions,
@@ -209,7 +209,7 @@ function getErrorMessage(error: unknown): string {
 }
 
 function SettingsRouteView() {
-  const { theme, setTheme, colorTheme, setColorTheme } = useTheme();
+  const { theme, setTheme, colorTheme, setColorTheme, fontFamily, setFontFamily } = useTheme();
   const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const queryClient = useQueryClient();
@@ -300,6 +300,7 @@ function SettingsRouteView() {
   const changedSettingLabels = [
     ...(theme !== "system" ? ["Theme"] : []),
     ...(colorTheme !== "default" ? ["Color theme"] : []),
+    ...(fontFamily !== "inter" ? ["Font"] : []),
     ...(settings.timestampFormat !== defaults.timestampFormat ? ["Time format"] : []),
     ...(settings.diffWordWrap !== defaults.diffWordWrap ? ["Diff line wrapping"] : []),
     ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
@@ -445,6 +446,7 @@ function SettingsRouteView() {
 
     setTheme("system");
     setColorTheme("default");
+    setFontFamily("inter");
     resetSettings();
     setOpenInstallProviders({
       codex: false,
@@ -564,6 +566,39 @@ function SettingsRouteView() {
                       {COLOR_THEMES.map((t) => (
                         <SelectItem hideIndicator key={t.id} value={t.id}>
                           {t.label}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                }
+              />
+
+              <SettingsRow
+                title="Font"
+                description="Choose the typeface for the interface."
+                resetAction={
+                  fontFamily !== "inter" ? (
+                    <SettingResetButton label="font" onClick={() => setFontFamily("inter")} />
+                  ) : null
+                }
+                control={
+                  <Select
+                    value={fontFamily}
+                    onValueChange={(value) => {
+                      const match = FONT_FAMILIES.find((f) => f.id === value);
+                      if (!match) return;
+                      setFontFamily(match.id);
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-40" aria-label="Font family">
+                      <SelectValue>
+                        {FONT_FAMILIES.find((f) => f.id === fontFamily)?.label ?? "Inter"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup align="end" alignItemWithTrigger={false}>
+                      {FONT_FAMILIES.map((f) => (
+                        <SelectItem hideIndicator key={f.id} value={f.id}>
+                          {f.label}
                         </SelectItem>
                       ))}
                     </SelectPopup>

--- a/apps/web/src/themes.css
+++ b/apps/web/src/themes.css
@@ -123,64 +123,184 @@
   --warning-foreground: #f1a10d;
 }
 
-/* ─── Cursor Dark ─── sleek, focused, professional ─── */
+/* ─── Midnight Clarity ─── clean, intelligent, trustworthy (OpenAI-inspired) ─── */
 
-:root.theme-cursor-dark {
+:root.theme-midnight-clarity {
   color-scheme: light;
-  --background: #f5f5f5;
-  --foreground: #1e1e2e;
-  --card: #eeeeee;
-  --card-foreground: #1e1e2e;
-  --popover: #eeeeee;
-  --popover-foreground: #1e1e2e;
-  --primary: oklch(0.55 0.18 260);
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --card: #f7f7f8;
+  --card-foreground: #0d0d0d;
+  --popover: #f7f7f8;
+  --popover-foreground: #0d0d0d;
+  --primary: oklch(0.59 0.14 168);
   --primary-foreground: #ffffff;
-  --secondary: rgba(60, 60, 100, 0.06);
-  --secondary-foreground: #1e1e2e;
-  --muted: rgba(60, 60, 100, 0.06);
-  --muted-foreground: #6c6c80;
-  --accent: rgba(60, 60, 100, 0.08);
-  --accent-foreground: #1e1e2e;
+  --secondary: rgba(0, 0, 0, 0.04);
+  --secondary-foreground: #0d0d0d;
+  --muted: rgba(0, 0, 0, 0.04);
+  --muted-foreground: #6e6e80;
+  --accent: rgba(0, 0, 0, 0.05);
+  --accent-foreground: #0d0d0d;
+  --destructive: #ef4444;
+  --destructive-foreground: #dc2626;
+  --border: rgba(0, 0, 0, 0.08);
+  --input: rgba(0, 0, 0, 0.1);
+  --ring: oklch(0.59 0.14 168);
+  --info: #0ea5e9;
+  --info-foreground: #0284c7;
+  --success: #10a37f;
+  --success-foreground: #0d8a6a;
+  --warning: #f59e0b;
+  --warning-foreground: #b45309;
+}
+
+:root.theme-midnight-clarity.dark {
+  color-scheme: dark;
+  --background: #212121;
+  --foreground: #ececec;
+  --card: #2f2f2f;
+  --card-foreground: #ececec;
+  --popover: #2f2f2f;
+  --popover-foreground: #ececec;
+  --primary: oklch(0.72 0.14 168);
+  --primary-foreground: #0d0d0d;
+  --secondary: rgba(255, 255, 255, 0.05);
+  --secondary-foreground: #ececec;
+  --muted: rgba(255, 255, 255, 0.05);
+  --muted-foreground: #9a9a9a;
+  --accent: rgba(255, 255, 255, 0.06);
+  --accent-foreground: #ececec;
+  --destructive: #f87171;
+  --destructive-foreground: #fca5a5;
+  --border: rgba(255, 255, 255, 0.08);
+  --input: rgba(255, 255, 255, 0.1);
+  --ring: oklch(0.72 0.14 168);
+  --info: #38bdf8;
+  --info-foreground: #7dd3fc;
+  --success: #34d399;
+  --success-foreground: #6ee7b7;
+  --warning: #fbbf24;
+  --warning-foreground: #fcd34d;
+}
+
+/* ─── Carbon ─── stark, modern, performance-focused (Vercel-inspired) ─── */
+
+:root.theme-carbon {
+  color-scheme: light;
+  --background: #ffffff;
+  --foreground: #000000;
+  --card: #fafafa;
+  --card-foreground: #000000;
+  --popover: #ffffff;
+  --popover-foreground: #000000;
+  --primary: oklch(0.55 0.2 255);
+  --primary-foreground: #ffffff;
+  --secondary: rgba(0, 0, 0, 0.04);
+  --secondary-foreground: #000000;
+  --muted: rgba(0, 0, 0, 0.04);
+  --muted-foreground: #666666;
+  --accent: rgba(0, 0, 0, 0.05);
+  --accent-foreground: #000000;
+  --destructive: #ee0000;
+  --destructive-foreground: #cc0000;
+  --border: #eaeaea;
+  --input: #eaeaea;
+  --ring: oklch(0.55 0.2 255);
+  --info: #0070f3;
+  --info-foreground: #0060d0;
+  --success: #0070f3;
+  --success-foreground: #0060d0;
+  --warning: #f5a623;
+  --warning-foreground: #ab7a1a;
+}
+
+:root.theme-carbon.dark {
+  color-scheme: dark;
+  --background: #000000;
+  --foreground: #ededed;
+  --card: #111111;
+  --card-foreground: #ededed;
+  --popover: #111111;
+  --popover-foreground: #ededed;
+  --primary: oklch(0.65 0.2 255);
+  --primary-foreground: #000000;
+  --secondary: rgba(255, 255, 255, 0.05);
+  --secondary-foreground: #ededed;
+  --muted: rgba(255, 255, 255, 0.05);
+  --muted-foreground: #888888;
+  --accent: rgba(255, 255, 255, 0.06);
+  --accent-foreground: #ededed;
+  --destructive: #ff4444;
+  --destructive-foreground: #ff6666;
+  --border: #333333;
+  --input: #333333;
+  --ring: oklch(0.65 0.2 255);
+  --info: #0070f3;
+  --info-foreground: #3291ff;
+  --success: #0070f3;
+  --success-foreground: #3291ff;
+  --warning: #f5a623;
+  --warning-foreground: #f7b955;
+}
+
+/* ─── Vapor ─── refined, fluid, purposeful (Linear-inspired) ─── */
+
+:root.theme-vapor {
+  color-scheme: light;
+  --background: #f9f8fc;
+  --foreground: #1c1c25;
+  --card: #f1eff8;
+  --card-foreground: #1c1c25;
+  --popover: #f1eff8;
+  --popover-foreground: #1c1c25;
+  --primary: oklch(0.53 0.17 277);
+  --primary-foreground: #ffffff;
+  --secondary: rgba(94, 106, 210, 0.06);
+  --secondary-foreground: #1c1c25;
+  --muted: rgba(94, 106, 210, 0.06);
+  --muted-foreground: #6e6d80;
+  --accent: rgba(94, 106, 210, 0.08);
+  --accent-foreground: #1c1c25;
   --destructive: #e5484d;
   --destructive-foreground: #cd2b31;
-  --border: rgba(60, 60, 100, 0.1);
-  --input: rgba(60, 60, 100, 0.12);
-  --ring: oklch(0.55 0.18 260);
-  --info: #4f7be8;
-  --info-foreground: #3d65c4;
-  --success: #30a46c;
-  --success-foreground: #18794e;
+  --border: rgba(94, 106, 210, 0.1);
+  --input: rgba(94, 106, 210, 0.12);
+  --ring: oklch(0.53 0.17 277);
+  --info: #5e6ad2;
+  --info-foreground: #4c58b8;
+  --success: #45be82;
+  --success-foreground: #2d9a63;
   --warning: #e5a836;
   --warning-foreground: #ad7a18;
 }
 
-:root.theme-cursor-dark.dark {
+:root.theme-vapor.dark {
   color-scheme: dark;
-  --background: #181818;
-  --foreground: #cccccc;
-  --card: #1e1e1e;
-  --card-foreground: #cccccc;
-  --popover: #1e1e1e;
-  --popover-foreground: #cccccc;
-  --primary: oklch(0.68 0.16 260);
+  --background: #111119;
+  --foreground: #e2e0ea;
+  --card: #191924;
+  --card-foreground: #e2e0ea;
+  --popover: #191924;
+  --popover-foreground: #e2e0ea;
+  --primary: oklch(0.65 0.18 277);
   --primary-foreground: #ffffff;
-  --secondary: rgba(140, 140, 200, 0.06);
-  --secondary-foreground: #cccccc;
-  --muted: rgba(140, 140, 200, 0.06);
-  --muted-foreground: #808080;
-  --accent: rgba(140, 140, 200, 0.08);
-  --accent-foreground: #cccccc;
-  --destructive: #f14c4c;
-  --destructive-foreground: #f88;
-  --border: rgba(140, 140, 200, 0.08);
-  --input: rgba(140, 140, 200, 0.1);
-  --ring: oklch(0.68 0.16 260);
-  --info: #6b9eff;
-  --info-foreground: #8cb4ff;
-  --success: #3dd68c;
-  --success-foreground: #4cc38a;
-  --warning: #ffb224;
-  --warning-foreground: #f1a10d;
+  --secondary: rgba(140, 150, 230, 0.06);
+  --secondary-foreground: #e2e0ea;
+  --muted: rgba(140, 150, 230, 0.06);
+  --muted-foreground: #8a889e;
+  --accent: rgba(140, 150, 230, 0.08);
+  --accent-foreground: #e2e0ea;
+  --destructive: #ff6369;
+  --destructive-foreground: #ff9592;
+  --border: rgba(140, 150, 230, 0.08);
+  --input: rgba(140, 150, 230, 0.1);
+  --ring: oklch(0.65 0.18 277);
+  --info: #8b92e8;
+  --info-foreground: #a8aef0;
+  --success: #50d07a;
+  --success-foreground: #5ee090;
+  --warning: #f5c542;
+  --warning-foreground: #e8b830;
 }
 
 /* ─── Cathedral Circuit ─── sacred machine, techno-gothic ─── */


### PR DESCRIPTION
## Summary
- Add a font family preference with Inter, DM Sans, and Plus Jakarta Sans, persisted in local storage and exposed in Settings.
- Update the app and markdown preview to use a shared UI font token so the active font applies consistently across the interface.
- Replace the old Cursor Dark preset with new color themes: Midnight Clarity, Carbon, and Vapor.
- Extend theme storage, syncing, and reset behavior to keep font and theme preferences consistent across tabs.

## Testing
- Not run (`bun fmt`)
- Not run (`bun lint`)
- Not run (`bun typecheck`)