### PR TITLE
Add rec command option mapping

### DIFF
--- a/.claude/commands/rec.md
+++ b/.claude/commands/rec.md
@@ -1,0 +1,19 @@
+---
+argument-hint: <option>
+---
+
+Respond with ONLY the exact text for the matching option below. No extra commentary.
+
+Options:
+- `lgtm` → "LGTM — approved."
+- `ack` → "Acknowledged."
+- `done` → "Done."
+- `wip` → "Work in progress — not ready for review."
+- `fix` → "Needs changes — see comments."
+- `skip` → "Skipping."
+- `no` → "No."
+- `yes` → "Yes."
+
+Argument: $ARGUMENTS
+
+If the argument is empty or doesn't match an option, list all available options as a short table.


### PR DESCRIPTION
## Summary
- Added a new `.claude/commands/rec.md` command for mapping short review responses to exact canned text.
- Defined supported options for common acknowledgements and review outcomes: `lgtm`, `ack`, `done`, `wip`, `fix`, `skip`, `no`, and `yes`.
- Documented fallback behavior to list all options in a short table when no argument is provided or the argument is invalid.

## Testing
- Not run (documentation-only change).
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`