### PR TITLE
Prepare v0.22.0 release notes and widen websocket redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-04-09
+
+See [docs/releases/v0.22.0.md](docs/releases/v0.22.0.md) for full notes and [docs/releases/v0.22.0/assets.md](docs/releases/v0.22.0/assets.md) for release asset inventory.
+
+### Added
+
+- Add provider-aware SME conversation auth with persisted provider and auth method settings.
+- Add navigable settings sections and a dedicated SME conversation settings editor.
+
+### Changed
+
+- Refresh SME chat with a modern sidebar, composer, and message layout.
+- Restructure settings into section-specific panels with a mobile section picker.
+- Route SME conversation sends through provider-specific auth validation and runtime backends.
+
+### Fixed
+
+- Redact secrets from websocket errors across the server, transport, and UI paths.
+
 ## [0.21.0] - 2026-04-09
 
 See [docs/releases/v0.21.0.md](docs/releases/v0.21.0.md) for full notes and [docs/releases/v0.21.0/assets.md](docs/releases/v0.21.0/assets.md) for release asset inventory.
@@ -638,3 +657,4 @@ First public version tag. See [docs/releases/v0.0.1.md](docs/releases/v0.0.1.md)
 [0.18.0]: https://github.com/OpenKnots/okcode/releases/tag/v0.18.0
 [0.20.0]: https://github.com/OpenKnots/okcode/releases/tag/v0.20.0
 [0.21.0]: https://github.com/OpenKnots/okcode/releases/tag/v0.21.0
+[0.22.0]: https://github.com/OpenKnots/okcode/releases/tag/v0.22.0

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,6 +9,7 @@ Use this directory for versioned release notes and asset manifests only:
 
 | Version              | Summary                                                                                        | Assets                        |
 | -------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------- |
+| [0.22.0](v0.22.0.md) | Provider-aware SME auth, refreshed SME chat, settings navigation, and websocket redaction      | [manifest](v0.22.0/assets.md) |
 | [0.21.0](v0.21.0.md) | Terminal startup and project continuity improvements, SME auth recovery, and release alignment | [manifest](v0.21.0/assets.md) |
 | [0.20.0](v0.20.0.md) | Polish the sidebar app shell, stabilize SME chat and OpenCla                                   | [manifest](v0.20.0/assets.md) |
 | [0.19.0](v0.19.0.md) | Release workflow hardening, branch-handling fixes, and release-preflight cleanup               | [manifest](v0.19.0/assets.md) |

--- a/docs/releases/v0.22.0.md
+++ b/docs/releases/v0.22.0.md
@@ -1,0 +1,57 @@
+# OK Code v0.22.0
+
+**Date:** 2026-04-09
+**Tag:** [`v0.22.0`](https://github.com/OpenKnots/okcode/releases/tag/v0.22.0)
+
+## Summary
+
+Ship provider-aware SME conversation auth, refresh the SME chat and settings experience, and harden websocket error redaction across the app.
+
+## Highlights
+
+- **Persist provider and auth method per SME conversation so sends can be validated against the right backend.**
+- **Refresh the SME workspace with a modern sidebar, auto-sizing composer, and tighter message presentation.**
+- **Restructure settings into navigable sections with clearer headers and mobile section picking.**
+- **Redact secrets from websocket errors in the server, transport, and UI paths.**
+
+## Breaking changes
+
+- None.
+
+## Upgrade and install
+
+- **CLI:** `npm install -g okcodes@0.22.0` after the package is published to npm.
+- **Desktop:** Download from [GitHub Releases](https://github.com/OpenKnots/okcode/releases/tag/v0.22.0). Filenames are listed in [assets.md](v0.22.0/assets.md).
+- **iOS:** Available via TestFlight when the coordinated release workflow completes successfully.
+
+## Detailed changes
+
+### Security and error handling
+
+- Added shared redaction helpers and applied them to websocket server, transport, and UI error presentation so secrets stay out of surfaced errors and logs.
+- Covered the redaction behavior with unit tests to keep error handling predictable as message shapes change.
+
+### SME conversation auth
+
+- Persisted provider and auth method per SME conversation so the app can route messages through the correct backend after validation.
+- Added the validation and provider-runtime plumbing needed to dispatch SME sends through Anthropic or the provider runtime path.
+- Introduced an edit dialog and supporting store/config updates so conversation settings can be changed without leaving the workspace.
+- Added a persistence migration for the new conversation auth fields.
+
+### SME chat UX
+
+- Reworked the SME workspace with a cleaner sidebar, better empty/loading states, a more usable composer, and improved message bubble hierarchy.
+- Updated the conversation rail and knowledge panel spacing and actions so longer sessions remain easier to scan.
+
+### Settings navigation
+
+- Split settings into section-specific panels and added sidebar plus mobile section pickers for faster navigation.
+- Updated the settings header to reflect the active section and added descriptions to make each panel easier to understand at a glance.
+
+## Release verification references
+
+- Review the [asset manifest](v0.22.0/assets.md) to confirm every expected GitHub Release attachment is present.
+
+## Known limitations
+
+OK Code remains early work in progress. Expect rough edges around session recovery, streaming edge cases, and platform-specific desktop behavior. Report issues on GitHub.

--- a/docs/releases/v0.22.0/assets.md
+++ b/docs/releases/v0.22.0/assets.md
@@ -1,0 +1,60 @@
+# v0.22.0 — Release assets (manifest)
+
+Binaries are **not** stored in this git repository; they are attached to the [GitHub Release for `v0.22.0`](https://github.com/OpenKnots/okcode/releases/tag/v0.22.0) by the [coordinated release workflow](../../.github/workflows/release.yml).
+
+The GitHub Release also includes **documentation attachments** with stable filenames:
+
+| File                        | Source in repo                        |
+| --------------------------- | ------------------------------------- |
+| `okcode-CHANGELOG.md`       | [CHANGELOG.md](../../../CHANGELOG.md) |
+| `okcode-RELEASE-NOTES.md`   | [v0.22.0.md](../v0.22.0.md)           |
+| `okcode-ASSETS-MANIFEST.md` | This file                             |
+
+After the workflow completes, the release should contain the coordinated desktop outputs below. Filenames may include the product name `OK Code` and the version string `0.22.0`.
+
+## Desktop installers and payloads
+
+| Platform            | Kind           | Expected attachment pattern |
+| ------------------- | -------------- | --------------------------- |
+| macOS Apple Silicon | DMG (signed)   | `*.dmg` (arm64)             |
+| macOS               | ZIP (updater)  | `*.zip`                     |
+| Linux x64           | AppImage       | `*.AppImage`                |
+| Windows x64         | NSIS installer | `*.exe`                     |
+
+The release workflow also uploads updater manifests and differential payload metadata:
+
+- `latest-mac*.yml`
+- `latest-linux.yml`
+- `latest.yml`
+- `*.blockmap`
+
+### Intel compatibility artifact
+
+The separate [`release-intel-compat.yml`](../../.github/workflows/release-intel-compat.yml) workflow produces the non-blocking macOS x64 compatibility build. It is **not** part of the coordinated stable release attachment set unless it is uploaded separately after that workflow runs.
+
+### macOS code signing and notarization
+
+All coordinated macOS DMG and ZIP payloads are expected to be code-signed with the Apple Developer ID certificate and notarized before release publication. Gatekeeper verifies the signature on first launch.
+
+## Electron updater metadata
+
+| File               | Purpose                                                   |
+| ------------------ | --------------------------------------------------------- |
+| `latest-mac*.yml`  | macOS update manifest                                     |
+| `latest-linux.yml` | Linux update manifest                                     |
+| `latest.yml`       | Windows update manifest                                   |
+| `*.blockmap`       | Differential download block maps for Electron auto-update |
+
+## iOS (TestFlight)
+
+The iOS build is uploaded directly to App Store Connect / TestFlight by the coordinated release workflow. No IPA is attached to the GitHub Release.
+
+| Detail            | Value                         |
+| ----------------- | ----------------------------- |
+| Bundle ID         | `com.openknots.okcode.mobile` |
+| Marketing version | `0.22.0`                      |
+| Build number      | Set from `GITHUB_RUN_NUMBER`  |
+
+## Checksums
+
+SHA-256 checksums are not committed in-repo. Verify downloads through the GitHub release UI or with `gh release download` followed by local checksum generation if needed.

--- a/packages/shared/src/redaction.ts
+++ b/packages/shared/src/redaction.ts
@@ -5,7 +5,7 @@ const BEARER_TOKEN_PATTERN = /\b(Bearer\s+)([^\s,;]+)/gi;
 const SENSITIVE_QUERY_PARAM_PATTERN =
   /([?&](?:access[_-]?token|api[_-]?key|auth(?:orization)?|client[_-]?secret|password|refresh[_-]?token|secret|session[_-]?token|token)=)([^&#\s]+)/gi;
 const SENSITIVE_FIELD_PATTERN =
-  /((?:"|')?(?:access[_-]?token|api[_-]?key|auth(?:orization)?|client[_-]?secret|password|refresh[_-]?token|secret|session[_-]?token|token)(?:"|')?\s*[:=]\s*)(["'`]?)([^"'`\s,}]+)(\2)/gi;
+  /((?:"|')?(?:access[_-]?token|api[_-]?key|auth(?:orization)?|client[_-]?secret|password|refresh[_-]?token|secret|session[_-]?token|token)(?:"|')?\s*[:=]\s*)(["'`]?)(?!Bearer\b)([^"'`\s,&}]+)(\2)/gi;
 const PROCESS_ENV_PATTERN =
   /\b((?:process\.)?env\.[A-Za-z_][A-Za-z0-9_]*\s*(?:=|:)\s*)(["'`]?)([^"'`\s,}]+)(\2)/g;
 const ENV_ASSIGNMENT_PATTERN = /\b([A-Z][A-Z0-9_]{1,63}\s*=\s*)(["'`]?)([^"'`\s]+)(\2)/g;


### PR DESCRIPTION
## Summary
- Document the v0.22.0 release in the changelog and release docs.
- Add a release asset manifest and link the new release from the release index.
- Broaden shared redaction so websocket error payloads also mask bearer-style secrets in sensitive fields.

## Testing
- Not run (documentation and redaction-only changes).
- Reviewed the updated release notes and asset manifest for v0.22.0 links and filenames.
- Reviewed the redaction regex change to confirm Bearer-prefixed values are excluded from sensitive-field captures.