### PR TITLE
Add OpenClaw maintainer workflow skills

### DIFF
--- a/.agents/skills/openclaw-ghsa/SKILL.md
+++ b/.agents/skills/openclaw-ghsa/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: openclaw-ghsa
+description: Handle OpenClaw GHSA work with speed-first, low-noise maintainer coordination and direct-to-main judgment.
+version: 1.0.0
+author: OK Code
+tags:
+  - openclaw
+  - maintainer
+  - ghsa
+  - security
+tools:
+  - terminal
+  - filesystem
+  - git
+triggers:
+  - use when the user asks about OpenClaw GHSA handling
+  - use when the user asks to coordinate a security fix
+  - use when the user mentions maintainer-security-ops
+  - use when the user asks for a fast security workflow
+---
+
+# OpenClaw GHSA
+
+Use this skill for maintainer-facing security fixes and coordination.
+Security work is treated differently from normal PR flow.
+
+## Source of truth
+
+- `openclaw/maintainers/security/README.md`
+- `openclaw/openclaw/SECURITY.md`
+- `openclaw/maintainers/README.md`
+
+## Rules
+
+- Speed first.
+- Usually go directly to `main` instead of opening a normal PR.
+- Keep public metadata vague while the fix rolls out.
+- Keep real discussion in maintainer channels, not in GHSA comments.
+- Only the designated owner should make GHSA state changes.
+
+## Coordination
+
+- Post the GHSA link in `maintainer-security-ops` when you pick it up.
+- Mark it complete or update the coordination thread when the fix lands.
+- Ask for help early if the scope or exploit path is unclear.

--- a/.agents/skills/openclaw-pr-merge/SKILL.md
+++ b/.agents/skills/openclaw-pr-merge/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: openclaw-pr-merge
+description: Perform deterministic OpenClaw PR merge, verify merged state, and clean up after landing.
+version: 1.0.0
+author: OK Code
+tags:
+  - openclaw
+  - maintainer
+  - pr-merge
+  - git
+tools:
+  - terminal
+  - filesystem
+  - git
+triggers:
+  - use when the user asks to merge an OpenClaw PR
+  - use when the user says merge-pr
+  - use when the user wants the PR landed and cleaned up
+  - use when the user asks for a deterministic squash merge flow
+---
+
+# OpenClaw PR Merge
+
+Use this skill only after review and prepare are complete.
+The goal is a deterministic landing with verification, attribution, and cleanup.
+
+## Source of truth
+
+- `openclaw/maintainers/.agents/skills/PR_WORKFLOW.md`
+- Repo-local policy in the target repo, especially `AGENTS.md`
+
+## Merge rules
+
+- Merge only when findings are resolved and checks are green.
+- Prefer deterministic squash merge flow with explicit subject/body.
+- Verify the PR ends in `MERGED` state.
+- Do not use auto-merge to bypass maintainer judgment.
+
+## After merge
+
+- Leave a PR comment that explains what was merged and include the SHAs.
+- Clean up the PR worktree.
+- Run contributor attribution updates when a new contributor landed and the repo
+  policy requires it.
+
+## Go / no-go
+
+- Required checks are green or intentionally absent.
+- Branch is not behind `main` in a way that matters for the merge.
+- Review and prep artifacts exist and are consistent.

--- a/.agents/skills/openclaw-pr-ops/SKILL.md
+++ b/.agents/skills/openclaw-pr-ops/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: openclaw-pr-ops
+description: Queue, claim, hand off, and record OpenClaw PR maintainer work using the pr-ops layer.
+version: 1.0.0
+author: OK Code
+tags:
+  - openclaw
+  - maintainer
+  - pr-ops
+  - pull-requests
+tools:
+  - terminal
+  - filesystem
+  - git
+triggers:
+  - use when the user asks to plan or queue PRs for OpenClaw
+  - use when the user asks for the next PR to review
+  - use when the user needs a Codex/Claude PR handoff prompt
+  - use when the user asks to record merge, close, or defer decisions
+  - use when the user mentions pr-ops, claims, queue, or stats
+---
+
+# OpenClaw PR Ops
+
+Use this skill for the maintainer queue layer in the `openclaw/maintainers` repo.
+The goal is to pick the next useful PR, prepare the reviewer handoff, and record
+the final decision without doing GitHub write actions in pr-ops.
+
+## Source of truth
+
+- `openclaw/maintainers/README.md`
+- `openclaw/maintainers/.agents/skills/PR_WORKFLOW.md`
+
+## Core rules
+
+- Keep the queue dedupe-first.
+- Prefer claim-aware selection when multiple maintainers or agents are active.
+- `pr-ops` plans and tracks work; the reviewer agent in `openclaw/openclaw`
+  performs review, merge, and close actions.
+- Do not merge or close PRs directly from this layer.
+
+## Workflow
+
+1. Refresh the queue with `scripts/pr-plan`.
+2. Select the next item with `scripts/pr-next`.
+3. Generate the reviewer prompt with `scripts/pr-handoff --tool codex`.
+4. After the reviewer finishes, persist the outcome with
+   `scripts/pr-decide --decision <merge|close_duplicate|close_not_planned|defer> --pr <number>`.
+5. Check progress with `scripts/pr-stats`.
+
+## Required handoff content
+
+- Representative PR and URL
+- Origin PR when the item is part of a cluster
+- Cluster members and pending members
+- Queue lane and rationale
+- Policy flags, if any
+- Explicit boundary: the reviewer agent does GitHub actions; pr-ops records state
+
+## Decision rules
+
+- `merge` for the PR that actually landed.
+- `close_duplicate` for cluster duplicates that are now redundant.
+- `close_not_planned` when the PR is not part of the current plan.
+- `defer` only when the PR needs more time or a broader dependency is unresolved.

--- a/.agents/skills/openclaw-pr-prepare/SKILL.md
+++ b/.agents/skills/openclaw-pr-prepare/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: openclaw-pr-prepare
+description: Fix OpenClaw PR findings on the PR head branch, run gates, and make the branch ready for merge.
+version: 1.0.0
+author: OK Code
+tags:
+  - openclaw
+  - maintainer
+  - pr-prepare
+  - implementation
+tools:
+  - terminal
+  - filesystem
+  - git
+triggers:
+  - use when the user asks to prepare an OpenClaw PR for merge
+  - use when the user asks to fix review findings on a PR
+  - use when the user says prepare-pr
+  - use when the user wants the PR head branch updated and gated
+---
+
+# OpenClaw PR Prepare
+
+Use this skill after review findings exist and the PR needs implementation work.
+The job is to make the PR merge-ready on its head branch, not to merge it.
+
+## Source of truth
+
+- `openclaw/maintainers/.agents/skills/PR_WORKFLOW.md`
+- Repo-local policy in the target repo, especially `AGENTS.md`
+
+## Working rules
+
+- Start from the PR head branch.
+- Fix blocker and important findings first.
+- Reuse existing logic where possible instead of adding parallel code paths.
+- Keep types strict and boundaries validated.
+- Prefer root-cause fixes over local patches.
+
+## Gates
+
+- Run the repo-local gate set before declaring ready.
+- In OpenClaw, default to `pnpm build`, `pnpm check`, and `pnpm test`
+  unless the repo-local policy explicitly allows a docs-only exception.
+- Treat unrelated baseline failures as background noise only when they are
+  reproduced on `origin/main` and are clearly not caused by the PR.
+
+## Commit hygiene
+
+- Use concise, action-oriented commit subjects.
+- Keep changes grouped by concern.
+- Add changelog or docs updates when repo policy requires them.
+
+## Exit criteria
+
+- Findings resolved or explicitly deferred with reason.
+- Verification run and recorded.
+- Branch is ready for `/merge-pr`.

--- a/.agents/skills/openclaw-pr-review/SKILL.md
+++ b/.agents/skills/openclaw-pr-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: openclaw-pr-review
+description: Review OpenClaw PRs for correctness, scope, tests, docs, and security before any fixes are made.
+version: 1.0.0
+author: OK Code
+tags:
+  - openclaw
+  - maintainer
+  - pr-review
+  - code-review
+tools:
+  - terminal
+  - filesystem
+  - git
+triggers:
+  - use when the user asks to review an OpenClaw PR
+  - use when the user wants findings before fixing code
+  - use when the user says review-pr or pr review
+  - use when the user asks for review-only, not implementation
+---
+
+# OpenClaw PR Review
+
+Use this skill to review a PR without changing code.
+The output should be a clear recommendation plus actionable findings.
+
+## Source of truth
+
+- `openclaw/maintainers/.agents/skills/PR_WORKFLOW.md`
+- `openclaw/maintainers/README.md`
+- Repo-local policy in the target repo, especially `AGENTS.md`
+
+## Review mode
+
+- Stay on review-only paths.
+- Prefer `gh pr view` and `gh pr diff` over ad hoc exploration.
+- Do not switch branches or mutate the target codebase during review.
+
+## What to check
+
+- Does the PR solve a real problem?
+- Is the implementation the best scoped fix?
+- Are tests meaningful and sufficient?
+- Are docs, changelog, and user-facing notes updated when required?
+- Are there correctness, security, or trust-boundary issues?
+
+## Output shape
+
+- Recommendation: `ready`, `needs work`, `needs discussion`, or `close`
+- Findings ordered by severity
+- Test coverage and validation gaps
+- Any follow-up questions or required assumptions
+
+## Stop conditions
+
+- Do not approve behavior you cannot verify.
+- Stop if the problem statement is unclear or unconfirmed.
+- Escalate if the fix would require broad architecture changes outside the PR scope.

--- a/apps/web/src/components/sme/SmeChatWorkspace.tsx
+++ b/apps/web/src/components/sme/SmeChatWorkspace.tsx
@@ -1,14 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  ArrowUpIcon,
-  BookOpenIcon,
-  Settings2Icon,
-  SparklesIcon,
-  XIcon,
-} from "lucide-react";
+import { ArrowUpIcon, BookOpenIcon, Settings2Icon, SparklesIcon, XIcon } from "lucide-react";
 import type { SmeConversationId, SmeMessage, SmeMessageId } from "@okcode/contracts";
-import type { RegisteredRouter } from "@tanstack/react-router";
 
 import { getProviderStartOptions, useAppSettings } from "~/appSettings";
 import { ProviderHealthBanner } from "~/components/chat/ProviderHealthBanner";
@@ -36,7 +29,6 @@ export function SmeChatWorkspace({
   onToggleKnowledge,
   knowledgePanelOpen,
 }: SmeChatWorkspaceProps) {
-  const navigate = useNavigate();
   const { settings } = useAppSettings();
   const providerOptions = useMemo(() => getProviderStartOptions(settings), [settings]);
   const conversations = useSmeStore((state) => state.conversations);


### PR DESCRIPTION
## Summary
- Add five new OpenClaw maintainer workflow skills for GHSA handling, PR ops, PR review, PR prepare, and PR merge.
- Document the intended maintainer flow for queueing, handoff, review, implementation, and deterministic merge cleanup.
- Make a small cleanup in `SmeChatWorkspace` by removing unused imports and an unused router dependency.

## Testing
- Not run (PR content draft only).
- No code changes were made in this response.