### PR TITLE
Fix InlineDiffBlock hook ordering for empty diffs

### DIFF
--- a/apps/web/src/components/chat/InlineDiffBlock.tsx
+++ b/apps/web/src/components/chat/InlineDiffBlock.tsx
@@ -267,8 +267,6 @@ export const InlineDiffBlock = memo(function InlineDiffBlock(props: {
     });
   }, [allLines]);
 
-  if (allLines.length === 0) return null;
-
   const needsTruncation = allLines.length > MAX_VISIBLE_LINES;
   const visibleLines =
     needsTruncation && !isExpanded ? keyedLines.slice(0, MAX_VISIBLE_LINES) : keyedLines;
@@ -327,6 +325,10 @@ export const InlineDiffBlock = memo(function InlineDiffBlock(props: {
       setCachedHighlightedHtml(line.text, languageId, diffThemeName, cacheScope, fullHtml);
     }
   }, [highlightedLines, languageId, diffThemeName]);
+
+  if (allLines.length === 0) {
+    return null;
+  }
 
   return (
     <div className="overflow-hidden rounded-xl border border-border/70">


### PR DESCRIPTION
## Summary
- Move the empty-diff early return until after hook setup in `InlineDiffBlock`.
- Preserve hook call order while still rendering nothing for empty diffs.
- Reduce the risk of hook-related render errors when diff data is empty.

## Testing
- Not run (PR body only).
- Verified the change is limited to `apps/web/src/components/chat/InlineDiffBlock.tsx`.
- Confirmed the empty-diff guard now happens after the hook declarations.