### PR TITLE
Use Oxanium and Space Grotesk as default web fonts

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -125,9 +125,9 @@
   --sidebar-accent-foreground: var(--accent-foreground);
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-  --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
-  --font-mono: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --font-sans: Oxanium, sans-serif;
+  --font-serif: "Space Grotesk", serif;
+  --font-mono: Oxanium, sans-serif;
   --spacing: 0.25rem;
   --tracking-normal: 0em;
 
@@ -177,10 +177,7 @@
 }
 
 body {
-  font-family: var(
-    --font-ui,
-    var(--font-sans, "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif)
-  );
+  font-family: var(--font-ui, var(--font-sans, Oxanium, sans-serif));
   margin: 0;
   padding: 0;
   min-height: 100vh;
@@ -214,15 +211,7 @@ pre,
 code,
 textarea,
 input {
-  font-family: var(
-    --font-mono,
-    "SF Mono",
-    "SFMono-Regular",
-    Consolas,
-    "Liberation Mono",
-    Menlo,
-    monospace
-  );
+  font-family: var(--font-mono, Oxanium, sans-serif);
 }
 
 /* Window drag region (frameless titlebar) */


### PR DESCRIPTION
## Summary
- Switch the web app’s default font variables from system fallbacks to `Oxanium` and `Space Grotesk`.
- Update the body and form/control font fallbacks to use the new font defaults consistently.
- Keep the change scoped to `apps/web/src/index.css`.

## Testing
- Not run (change is CSS-only).
- Expected check: verify the app renders with the updated font stack in the browser.
- Expected check: confirm text inputs, code blocks, and other monospace-styled elements still inherit the intended font rules.