### PR TITLE
Add hotkey settings editor and reset flow

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -348,6 +348,52 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("replaces every rule for a command and restores defaults when cleared", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+        { key: "ctrl+`", command: "terminal.toggle" },
+        { key: "mod+r", command: "script.run-tests.run" },
+      ]);
+
+      const keybindings = yield* Keybindings;
+      const replaced = yield* keybindings.replaceKeybindingRules("terminal.toggle", [
+        { key: "mod+shift+t", command: "terminal.toggle" },
+        { key: "ctrl+shift+`", command: "terminal.toggle" },
+      ]);
+
+      const persistedAfterReplace = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.deepEqual(
+        persistedAfterReplace.map(({ key, command }) => ({ key, command })),
+        [
+          { key: "mod+r", command: "script.run-tests.run" },
+          { key: "mod+shift+t", command: "terminal.toggle" },
+          { key: "ctrl+shift+`", command: "terminal.toggle" },
+        ],
+      );
+      assert.deepEqual(
+        replaced
+          .filter((entry) => entry.command === "terminal.toggle")
+          .map((entry) => Schema.encodeSync(ResolvedKeybindingFromConfig)(entry).key),
+        ["mod+shift+t", "ctrl+shift+`"],
+      );
+
+      const restored = yield* keybindings.replaceKeybindingRules("terminal.toggle", []);
+      const persistedAfterRestore = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.deepEqual(
+        persistedAfterRestore.map(({ key, command }) => ({ key, command })),
+        [{ key: "mod+r", command: "script.run-tests.run" }],
+      );
+      assert.deepEqual(
+        restored
+          .filter((entry) => entry.command === "terminal.toggle")
+          .map((entry) => Schema.encodeSync(ResolvedKeybindingFromConfig)(entry).key),
+        ["mod+j", "ctrl+`"],
+      );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("refuses to overwrite malformed keybindings config", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -17,6 +17,11 @@ import {
   ResolvedKeybindingsConfig,
   type ServerConfigIssue,
 } from "@okcode/contracts";
+import {
+  DEFAULT_KEYBINDINGS as SHARED_DEFAULT_KEYBINDINGS,
+  encodeKeybindingShortcut,
+  parseKeybindingShortcut as parseSharedKeybindingShortcut,
+} from "@okcode/shared/keybindings";
 import { Mutable } from "effect/Types";
 import {
   Array,
@@ -64,90 +69,10 @@ type WhenToken =
   | { type: "lparen" }
   | { type: "rparen" };
 
-export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
-  { key: "mod+j", command: "terminal.toggle" },
-  { key: "ctrl+`", command: "terminal.toggle" },
-  { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
-  { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
-  { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
-  { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
-  { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
-  { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
-  { key: "mod+down", command: "git.pullRequest", when: "!terminalFocus" },
-  { key: "mod+shift+p", command: "git.pullRequest", when: "!terminalFocus" },
-  { key: "mod+o", command: "editor.openFavorite" },
-];
-
-function normalizeKeyToken(token: string): string {
-  if (token === "space") return " ";
-  if (token === "esc") return "escape";
-  return token;
-}
+export const DEFAULT_KEYBINDINGS = SHARED_DEFAULT_KEYBINDINGS;
 
 /** @internal - Exported for testing */
-export function parseKeybindingShortcut(value: string): KeybindingShortcut | null {
-  const rawTokens = value
-    .toLowerCase()
-    .split("+")
-    .map((token) => token.trim());
-  const tokens = [...rawTokens];
-  let trailingEmptyCount = 0;
-  while (tokens[tokens.length - 1] === "") {
-    trailingEmptyCount += 1;
-    tokens.pop();
-  }
-  if (trailingEmptyCount > 0) {
-    tokens.push("+");
-  }
-  if (tokens.some((token) => token.length === 0)) {
-    return null;
-  }
-  if (tokens.length === 0) return null;
-
-  let key: string | null = null;
-  let metaKey = false;
-  let ctrlKey = false;
-  let shiftKey = false;
-  let altKey = false;
-  let modKey = false;
-
-  for (const token of tokens) {
-    switch (token) {
-      case "cmd":
-      case "meta":
-        metaKey = true;
-        break;
-      case "ctrl":
-      case "control":
-        ctrlKey = true;
-        break;
-      case "shift":
-        shiftKey = true;
-        break;
-      case "alt":
-      case "option":
-        altKey = true;
-        break;
-      case "mod":
-        modKey = true;
-        break;
-      default: {
-        if (key !== null) return null;
-        key = normalizeKeyToken(token);
-      }
-    }
-  }
-
-  if (key === null) return null;
-  return {
-    key,
-    metaKey,
-    ctrlKey,
-    shiftKey,
-    altKey,
-    modKey,
-  };
-}
+export const parseKeybindingShortcut = parseSharedKeybindingShortcut;
 
 function tokenizeWhenExpression(expression: string): WhenToken[] | null {
   const tokens: WhenToken[] = [];
@@ -383,16 +308,7 @@ function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): bo
 }
 
 function encodeShortcut(shortcut: KeybindingShortcut): string | null {
-  const modifiers: string[] = [];
-  if (shortcut.modKey) modifiers.push("mod");
-  if (shortcut.metaKey) modifiers.push("meta");
-  if (shortcut.ctrlKey) modifiers.push("ctrl");
-  if (shortcut.altKey) modifiers.push("alt");
-  if (shortcut.shiftKey) modifiers.push("shift");
-  if (!shortcut.key) return null;
-  if (shortcut.key !== "+" && shortcut.key.includes("+")) return null;
-  const key = shortcut.key === " " ? "space" : shortcut.key;
-  return [...modifiers, key].join("+");
+  return encodeKeybindingShortcut(shortcut);
 }
 
 function encodeWhenAst(node: KeybindingWhenNode): string {
@@ -520,6 +436,17 @@ export interface KeybindingsShape {
    */
   readonly upsertKeybindingRule: (
     rule: KeybindingRule,
+  ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
+
+  /**
+   * Replace every persisted rule for a command with the provided rules.
+   *
+   * Passing an empty array removes custom rules for the command so defaults
+   * can flow through again for built-in commands.
+   */
+  readonly replaceKeybindingRules: (
+    command: KeybindingRule["command"],
+    rules: readonly KeybindingRule[],
   ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
 }
 
@@ -854,6 +781,46 @@ const makeKeybindings = Effect.gen(function* () {
     yield* Deferred.succeed(startedDeferred, undefined).pipe(Effect.orDie);
   });
 
+  const replaceKeybindingRules = (
+    command: KeybindingRule["command"],
+    rules: readonly KeybindingRule[],
+  ) =>
+    upsertSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        if (rules.some((rule) => rule.command !== command)) {
+          return yield* new KeybindingsConfigError({
+            configPath: keybindingsConfigPath,
+            detail: `received mismatched command rules for ${command}`,
+          });
+        }
+        const customConfig = yield* loadWritableCustomKeybindingsConfig();
+        const nextConfig = [...customConfig.filter((entry) => entry.command !== command), ...rules];
+        const cappedConfig =
+          nextConfig.length > MAX_KEYBINDINGS_COUNT
+            ? nextConfig.slice(-MAX_KEYBINDINGS_COUNT)
+            : nextConfig;
+        if (nextConfig.length > MAX_KEYBINDINGS_COUNT) {
+          yield* Effect.logWarning("truncating keybindings config to max entries", {
+            path: keybindingsConfigPath,
+            maxEntries: MAX_KEYBINDINGS_COUNT,
+          });
+        }
+        yield* writeConfigAtomically(cappedConfig);
+        const nextResolved = mergeWithDefaultKeybindings(
+          compileResolvedKeybindingsConfig(cappedConfig),
+        );
+        yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
+          keybindings: nextResolved,
+          issues: [],
+        });
+        yield* emitChange({
+          keybindings: nextResolved,
+          issues: [],
+        });
+        return nextResolved;
+      }),
+    );
+
   return {
     start,
     ready: Deferred.await(startedDeferred),
@@ -863,39 +830,8 @@ const makeKeybindings = Effect.gen(function* () {
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);
     },
-    upsertKeybindingRule: (rule) =>
-      upsertSemaphore.withPermits(1)(
-        Effect.gen(function* () {
-          const customConfig = yield* loadWritableCustomKeybindingsConfig();
-          const nextConfig = [
-            ...customConfig.filter((entry) => entry.command !== rule.command),
-            rule,
-          ];
-          const cappedConfig =
-            nextConfig.length > MAX_KEYBINDINGS_COUNT
-              ? nextConfig.slice(-MAX_KEYBINDINGS_COUNT)
-              : nextConfig;
-          if (nextConfig.length > MAX_KEYBINDINGS_COUNT) {
-            yield* Effect.logWarning("truncating keybindings config to max entries", {
-              path: keybindingsConfigPath,
-              maxEntries: MAX_KEYBINDINGS_COUNT,
-            });
-          }
-          yield* writeConfigAtomically(cappedConfig);
-          const nextResolved = mergeWithDefaultKeybindings(
-            compileResolvedKeybindingsConfig(cappedConfig),
-          );
-          yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
-            keybindings: nextResolved,
-            issues: [],
-          });
-          yield* emitChange({
-            keybindings: nextResolved,
-            issues: [],
-          });
-          return nextResolved;
-        }),
-      ),
+    replaceKeybindingRules,
+    upsertKeybindingRule: (rule) => replaceKeybindingRules(rule.command, [rule]),
   } satisfies KeybindingsShape;
 });
 

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -1620,6 +1620,15 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return { keybindings: keybindingsConfig, issues: [] };
       }
 
+      case WS_METHODS.serverReplaceKeybindingRules: {
+        const body = stripRequestTag(request.body);
+        const keybindingsConfig = yield* keybindingsManager.replaceKeybindingRules(
+          body.command,
+          body.rules,
+        );
+        return { keybindings: keybindingsConfig, issues: [] };
+      }
+
       case WS_METHODS.serverGetGlobalEnvironmentVariables:
         return yield* environmentVariables.getGlobal();
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1979,8 +1979,12 @@ export default function ChatView({ threadId, onMinimize }: ChatViewProps) {
           })
         : null;
 
-      if (isElectron && keybindingRule) {
-        await api.server.upsertKeybinding(keybindingRule);
+      if (isElectron && input.keybindingCommand) {
+        await api.server.replaceKeybindingRules(
+          keybindingRule
+            ? { command: input.keybindingCommand, rules: [keybindingRule] }
+            : { command: input.keybindingCommand, rules: [] },
+        );
         await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
       }
     },

--- a/apps/web/src/components/KeybindingRecorderField.tsx
+++ b/apps/web/src/components/KeybindingRecorderField.tsx
@@ -1,0 +1,98 @@
+import {
+  keybindingValueFromShortcutEvent,
+  parseKeybindingShortcut,
+} from "@okcode/shared/keybindings";
+import type * as React from "react";
+import { useMemo, useState } from "react";
+
+import { formatShortcutLabel } from "~/keybindings";
+import { cn } from "~/lib/utils";
+
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+
+function resolvePlatform(): string {
+  return typeof navigator === "undefined" ? "unknown" : navigator.platform;
+}
+
+export function formatRecordedKeybindingValue(value: string, platform = resolvePlatform()): string {
+  const shortcut = parseKeybindingShortcut(value);
+  return shortcut ? formatShortcutLabel(shortcut, platform) : value;
+}
+
+export interface KeybindingRecorderFieldProps extends Omit<
+  React.ComponentProps<typeof Input>,
+  "onChange" | "readOnly" | "value"
+> {
+  readonly value: string;
+  readonly onChange: (nextValue: string) => void;
+  readonly clearLabel?: string;
+}
+
+export function KeybindingRecorderField({
+  value,
+  onChange,
+  placeholder = "Press shortcut",
+  className,
+  disabled,
+  clearLabel = "Clear",
+  onFocus,
+  onBlur,
+  onKeyDown,
+  ...props
+}: KeybindingRecorderFieldProps) {
+  const [isFocused, setIsFocused] = useState(false);
+  const platform = resolvePlatform();
+  const displayValue = useMemo(
+    () => (value ? formatRecordedKeybindingValue(value, platform) : ""),
+    [platform, value],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    if (event.key === "Tab") return;
+
+    event.preventDefault();
+    const hasModifier = event.metaKey || event.ctrlKey || event.altKey || event.shiftKey;
+    if ((event.key === "Backspace" || event.key === "Delete") && !hasModifier) {
+      onChange("");
+      return;
+    }
+
+    const nextValue = keybindingValueFromShortcutEvent(event, platform);
+    if (!nextValue) return;
+    onChange(nextValue);
+  };
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Input
+        {...props}
+        className="min-w-0 flex-1"
+        disabled={disabled}
+        placeholder={isFocused ? "Press shortcut now" : placeholder}
+        readOnly
+        value={displayValue}
+        onBlur={(event) => {
+          setIsFocused(false);
+          onBlur?.(event);
+        }}
+        onFocus={(event) => {
+          setIsFocused(true);
+          onFocus?.(event);
+        }}
+        onKeyDown={handleKeyDown}
+      />
+      <Button
+        type="button"
+        size="xs"
+        variant="outline"
+        disabled={disabled || value.length === 0}
+        onClick={() => onChange("")}
+      >
+        {clearLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -14,7 +14,7 @@ import {
   SettingsIcon,
   WrenchIcon,
 } from "lucide-react";
-import React, { type FormEvent, type KeyboardEvent, useCallback, useMemo, useState } from "react";
+import React, { type FormEvent, useCallback, useMemo, useState } from "react";
 
 import { ensureNativeApi } from "~/nativeApi";
 import {
@@ -35,7 +35,6 @@ import {
   resolvePackageManagerResolution,
 } from "~/projectScriptDefaults";
 import { shortcutLabelForCommand } from "~/keybindings";
-import { isMacPlatform } from "~/lib/utils";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -46,6 +45,7 @@ import {
   AlertDialogTitle,
 } from "./ui/alert-dialog";
 import { Button } from "./ui/button";
+import { KeybindingRecorderField } from "./KeybindingRecorderField";
 import {
   Dialog,
   DialogDescription,
@@ -108,57 +108,6 @@ interface ProjectScriptsControlProps {
   onImportScripts: (scripts: ProjectScriptDraft[]) => Promise<void> | void;
 }
 
-function normalizeShortcutKeyToken(key: string): string | null {
-  const normalized = key.toLowerCase();
-  if (
-    normalized === "meta" ||
-    normalized === "control" ||
-    normalized === "ctrl" ||
-    normalized === "shift" ||
-    normalized === "alt" ||
-    normalized === "option"
-  ) {
-    return null;
-  }
-  if (normalized === " ") return "space";
-  if (normalized === "escape") return "esc";
-  if (normalized === "arrowup") return "arrowup";
-  if (normalized === "arrowdown") return "arrowdown";
-  if (normalized === "arrowleft") return "arrowleft";
-  if (normalized === "arrowright") return "arrowright";
-  if (normalized.length === 1) return normalized;
-  if (normalized.startsWith("f") && normalized.length <= 3) return normalized;
-  if (normalized === "enter" || normalized === "tab" || normalized === "backspace") {
-    return normalized;
-  }
-  if (normalized === "delete" || normalized === "home" || normalized === "end") {
-    return normalized;
-  }
-  if (normalized === "pageup" || normalized === "pagedown") return normalized;
-  return null;
-}
-
-function keybindingFromEvent(event: KeyboardEvent<HTMLInputElement>): string | null {
-  const keyToken = normalizeShortcutKeyToken(event.key);
-  if (!keyToken) return null;
-
-  const parts: string[] = [];
-  if (isMacPlatform(navigator.platform)) {
-    if (event.metaKey) parts.push("mod");
-    if (event.ctrlKey) parts.push("ctrl");
-  } else {
-    if (event.ctrlKey) parts.push("mod");
-    if (event.metaKey) parts.push("meta");
-  }
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (parts.length === 0) {
-    return null;
-  }
-  parts.push(keyToken);
-  return parts.join("+");
-}
-
 export default function ProjectScriptsControl({
   projectCwd,
   scripts,
@@ -209,18 +158,6 @@ export default function ProjectScriptsControl({
       packageManager: selectedPackageManager,
     });
   }, [importInventory, selectedPackageManager]);
-
-  const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
-    event.preventDefault();
-    if (event.key === "Backspace" || event.key === "Delete") {
-      setKeybinding("");
-      return;
-    }
-    const next = keybindingFromEvent(event);
-    if (!next) return;
-    setKeybinding(next);
-  };
 
   const submitAddScript = async (event: FormEvent) => {
     event.preventDefault();
@@ -523,15 +460,14 @@ export default function ProjectScriptsControl({
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="script-keybinding">Keybinding</Label>
-                <Input
+                <KeybindingRecorderField
                   id="script-keybinding"
-                  placeholder="Press shortcut"
                   value={keybinding}
-                  readOnly
-                  onKeyDown={captureKeybinding}
+                  onChange={setKeybinding}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Press a shortcut. Use <code>Backspace</code> to clear.
+                  Focus the field and press a shortcut. Use at least one modifier. Plain{" "}
+                  <code>Backspace</code> or <code>Delete</code> clears it.
                 </p>
               </div>
               <div className="space-y-1.5">

--- a/apps/web/src/components/settings/HotkeysSettingsSection.tsx
+++ b/apps/web/src/components/settings/HotkeysSettingsSection.tsx
@@ -1,0 +1,563 @@
+import type {
+  KeybindingCommand,
+  KeybindingRule,
+  ResolvedKeybindingsConfig,
+  ServerConfigIssue,
+} from "@okcode/contracts";
+import {
+  defaultKeybindingRulesForCommand,
+  HOTKEY_COMMAND_DEFINITIONS,
+  type HotkeyCommandDefinition,
+  keybindingValuesForCommand,
+  parseKeybindingShortcut,
+} from "@okcode/shared/keybindings";
+import { AlertTriangleIcon, KeyboardIcon, PlusIcon, RotateCcwIcon, XIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  KeybindingRecorderField,
+  formatRecordedKeybindingValue,
+} from "~/components/KeybindingRecorderField";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "~/components/ui/dialog";
+
+const MAX_EDITABLE_SHORTCUTS = 4;
+
+interface DraftShortcutSlot {
+  readonly id: string;
+  readonly value: string;
+}
+
+function resolvePlatform(): string {
+  return typeof navigator === "undefined" ? "unknown" : navigator.platform;
+}
+
+function normalizeShortcutValues(values: readonly string[]): string[] {
+  const seenValues = new Set<string>();
+  const normalizedValues: string[] = [];
+
+  for (const value of values) {
+    const trimmedValue = value.trim();
+    if (trimmedValue.length === 0) continue;
+    if (!parseKeybindingShortcut(trimmedValue)) {
+      throw new Error(`Invalid shortcut: ${trimmedValue}`);
+    }
+    if (seenValues.has(trimmedValue)) continue;
+    seenValues.add(trimmedValue);
+    normalizedValues.push(trimmedValue);
+  }
+
+  return normalizedValues;
+}
+
+function haveSameShortcutValues(left: readonly string[], right: readonly string[]): boolean {
+  const normalizeForCompare = (values: readonly string[]) =>
+    [...normalizeShortcutValues(values)].toSorted((first, second) => first.localeCompare(second));
+
+  const normalizedLeft = normalizeForCompare(left);
+  const normalizedRight = normalizeForCompare(right);
+  return JSON.stringify(normalizedLeft) === JSON.stringify(normalizedRight);
+}
+
+function buildRulesForCommand(
+  command: KeybindingCommand,
+  values: readonly string[],
+  when: string | undefined,
+): KeybindingRule[] {
+  return normalizeShortcutValues(values).map(
+    (value) =>
+      Object.assign({ key: value, command }, when ? { when } : {}) satisfies KeybindingRule,
+  );
+}
+
+function labelsForValues(values: readonly string[], platform: string): string[] {
+  return normalizeShortcutValues(values).map((value) =>
+    formatRecordedKeybindingValue(value, platform),
+  );
+}
+
+function createDraftShortcutSlot(value = ""): DraftShortcutSlot {
+  const id =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return { id, value };
+}
+
+interface HotkeysSettingsSectionProps {
+  readonly keybindings: ResolvedKeybindingsConfig;
+  readonly issues: readonly ServerConfigIssue[];
+  readonly keybindingsConfigPath: string | null;
+  readonly isOpeningKeybindings: boolean;
+  readonly openKeybindingsError: string | null;
+  readonly onOpenKeybindingsFile: () => void;
+  readonly onReplaceKeybindingRules: (
+    command: KeybindingCommand,
+    rules: readonly KeybindingRule[],
+  ) => Promise<void>;
+}
+
+interface HotkeyCommandState {
+  readonly definition: HotkeyCommandDefinition;
+  readonly currentValues: string[];
+  readonly defaultValues: string[];
+}
+
+export function HotkeysSettingsSection({
+  keybindings,
+  issues,
+  keybindingsConfigPath,
+  isOpeningKeybindings,
+  openKeybindingsError,
+  onOpenKeybindingsFile,
+  onReplaceKeybindingRules,
+}: HotkeysSettingsSectionProps) {
+  const platform = resolvePlatform();
+  const [editingCommand, setEditingCommand] = useState<HotkeyCommandState | null>(null);
+  const [draftShortcutSlots, setDraftShortcutSlots] = useState<DraftShortcutSlot[]>([]);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasMalformedConfig = issues.some((issue) => issue.kind === "keybindings.malformed-config");
+  const invalidEntryCount = issues.filter(
+    (issue) => issue.kind === "keybindings.invalid-entry",
+  ).length;
+  const isEditingDisabled = hasMalformedConfig || isSaving;
+
+  const commandStates = useMemo<HotkeyCommandState[]>(
+    () =>
+      HOTKEY_COMMAND_DEFINITIONS.map((definition) => {
+        const currentValues = keybindingValuesForCommand(keybindings, definition.command);
+        const defaultValues = defaultKeybindingRulesForCommand(definition.command).map(
+          (rule) => rule.key,
+        );
+        return {
+          definition,
+          currentValues,
+          defaultValues,
+        };
+      }),
+    [keybindings],
+  );
+
+  const groupedCommandStates = useMemo(
+    () => ({
+      Workspace: commandStates.filter((state) => state.definition.group === "Workspace"),
+      Terminal: commandStates.filter((state) => state.definition.group === "Terminal"),
+    }),
+    [commandStates],
+  );
+
+  const openEditor = (state: HotkeyCommandState) => {
+    setEditingCommand(state);
+    setDraftShortcutSlots(
+      (state.currentValues.length > 0 ? state.currentValues : [""]).map((value) =>
+        createDraftShortcutSlot(value),
+      ),
+    );
+    setSaveError(null);
+  };
+
+  const closeEditor = () => {
+    setEditingCommand(null);
+    setDraftShortcutSlots([]);
+    setSaveError(null);
+  };
+
+  const replaceShortcutValue = (slotId: string, nextValue: string) => {
+    setDraftShortcutSlots((currentSlots) =>
+      currentSlots.map((slot) => (slot.id === slotId ? { id: slot.id, value: nextValue } : slot)),
+    );
+  };
+
+  const removeShortcutSlot = (slotId: string) => {
+    setDraftShortcutSlots((currentSlots) => currentSlots.filter((slot) => slot.id !== slotId));
+  };
+
+  const addShortcutSlot = () => {
+    setDraftShortcutSlots((currentSlots) =>
+      currentSlots.length >= MAX_EDITABLE_SHORTCUTS
+        ? currentSlots
+        : [...currentSlots, createDraftShortcutSlot()],
+    );
+  };
+
+  const saveShortcutRules = async () => {
+    if (!editingCommand) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const rules = buildRulesForCommand(
+        editingCommand.definition.command,
+        draftShortcutSlots.map((slot) => slot.value),
+        editingCommand.definition.when,
+      );
+      await onReplaceKeybindingRules(editingCommand.definition.command, rules);
+      closeEditor();
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to save hotkeys.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const restoreDefaults = async (definition: HotkeyCommandDefinition) => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await onReplaceKeybindingRules(definition.command, []);
+      closeEditor();
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to restore defaults.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const renderShortcutBadges = (values: readonly string[], emptyLabel: string) => {
+    const labels = labelsForValues(values, platform);
+    if (labels.length === 0) {
+      return (
+        <span className="text-xs text-muted-foreground" data-slot="hotkey-empty-state">
+          {emptyLabel}
+        </span>
+      );
+    }
+    return (
+      <div className="flex flex-wrap gap-2">
+        {labels.map((label) => (
+          <Badge key={label} variant="secondary" size="lg">
+            {label}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-foreground">Hotkeys</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Record, review, and restore the built-in keyboard shortcuts used across OK Code.
+          </p>
+        </div>
+      </div>
+
+      <div className="relative overflow-hidden rounded-xl border border-border/60 bg-card text-card-foreground">
+        <div className="border-b border-border/60 bg-muted/20 px-4 py-4 sm:px-5">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="rounded-xl border border-border/60 bg-background/80 p-3.5">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <KeyboardIcon className="size-4 text-muted-foreground" />
+                Recording
+              </div>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                Click <span className="font-medium text-foreground">Edit</span>, focus a shortcut
+                field, and press the combination you want. Use at least one modifier. Plain{" "}
+                <code>Backspace</code> or <code>Delete</code> clears a slot.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background/80 p-3.5">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <RotateCcwIcon className="size-4 text-muted-foreground" />
+                Context rules
+              </div>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                Each command here keeps the same focus rules as the built-in defaults. Use{" "}
+                <code>keybindings.json</code> below if you need custom <code>when</code> expressions
+                or project-action bindings.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {hasMalformedConfig ? (
+          <div className="border-b border-border/60 px-4 py-4 sm:px-5">
+            <Alert variant="error">
+              <AlertTriangleIcon />
+              <AlertTitle>Hotkey editing is blocked</AlertTitle>
+              <AlertDescription>
+                <span>
+                  <code>keybindings.json</code> is malformed, so OK Code can only fall back to the
+                  built-in shortcuts right now.
+                </span>
+                <span>Fix the file first, then return here to record shortcuts.</span>
+              </AlertDescription>
+              <AlertAction>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  disabled={!keybindingsConfigPath || isOpeningKeybindings}
+                  onClick={onOpenKeybindingsFile}
+                >
+                  {isOpeningKeybindings ? "Opening..." : "Open keybindings.json"}
+                </Button>
+              </AlertAction>
+            </Alert>
+          </div>
+        ) : null}
+
+        {!hasMalformedConfig && invalidEntryCount > 0 ? (
+          <div className="border-b border-border/60 px-4 py-4 sm:px-5">
+            <Alert variant="warning">
+              <AlertTriangleIcon />
+              <AlertTitle>Some custom keybindings are invalid</AlertTitle>
+              <AlertDescription>
+                <span>
+                  {invalidEntryCount} invalid entr{invalidEntryCount === 1 ? "y is" : "ies are"}{" "}
+                  being ignored.
+                </span>
+                <span>
+                  Saving from this screen keeps the valid rules and discards the broken ones.
+                </span>
+              </AlertDescription>
+            </Alert>
+          </div>
+        ) : null}
+
+        {(["Workspace", "Terminal"] as const).map((group) => (
+          <div key={group}>
+            <div className="border-b border-border/60 px-4 py-3 sm:px-5">
+              <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                {group}
+              </span>
+            </div>
+            {groupedCommandStates[group].map((state) => {
+              const currentLabels = labelsForValues(state.currentValues, platform);
+              const defaultLabels = labelsForValues(state.defaultValues, platform);
+              const isCustomized = !haveSameShortcutValues(
+                state.currentValues,
+                state.defaultValues,
+              );
+              return (
+                <div
+                  key={state.definition.command}
+                  className="border-b border-border/60 px-4 py-4 last:border-b-0 sm:px-5"
+                >
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-sm font-medium text-foreground">
+                          {state.definition.title}
+                        </h3>
+                        <Badge variant={isCustomized ? "info" : "outline"}>
+                          {isCustomized ? "Custom" : "Default"}
+                        </Badge>
+                        <Badge variant="outline">{state.definition.contextLabel}</Badge>
+                      </div>
+                      <p className="mt-1.5 text-sm text-muted-foreground">
+                        {state.definition.description}
+                      </p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {currentLabels.length > 0 ? (
+                          currentLabels.map((label) => (
+                            <Badge key={label} variant="secondary" size="lg">
+                              {label}
+                            </Badge>
+                          ))
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            No shortcut assigned.
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        {isCustomized
+                          ? `Defaults: ${defaultLabels.join(", ")}`
+                          : "Using the built-in defaults."}
+                      </p>
+                    </div>
+
+                    <div className="flex shrink-0 items-center gap-2">
+                      {isCustomized ? (
+                        <Button
+                          type="button"
+                          size="xs"
+                          variant="outline"
+                          disabled={isSaving}
+                          onClick={() => void restoreDefaults(state.definition)}
+                        >
+                          Restore defaults
+                        </Button>
+                      ) : null}
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        disabled={isEditingDisabled}
+                        onClick={() => openEditor(state)}
+                      >
+                        Edit
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+
+        <div className="px-4 py-4 sm:px-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-medium text-foreground">Advanced JSON</h3>
+                <Badge variant="outline">Manual editing</Badge>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Open the persisted <code>keybindings.json</code> file to manage project-action
+                bindings, custom <code>when</code> expressions, or anything more advanced than this
+                screen supports.
+              </p>
+              <div className="mt-2 text-[11px] text-muted-foreground">
+                <span className="block break-all font-mono text-foreground">
+                  {keybindingsConfigPath ?? "Resolving keybindings path..."}
+                </span>
+                {openKeybindingsError ? (
+                  <span className="mt-1 block text-destructive">{openKeybindingsError}</span>
+                ) : (
+                  <span className="mt-1 block">Opens in your preferred editor.</span>
+                )}
+              </div>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                disabled={!keybindingsConfigPath || isOpeningKeybindings}
+                onClick={onOpenKeybindingsFile}
+              >
+                {isOpeningKeybindings ? "Opening..." : "Open keybindings.json"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Dialog
+        open={editingCommand !== null}
+        onOpenChange={(open) => (!open ? closeEditor() : null)}
+      >
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{editingCommand?.definition.title ?? "Edit hotkey"}</DialogTitle>
+            <DialogDescription>
+              {editingCommand?.definition.description}
+              {editingCommand ? (
+                <span className="mt-2 block text-xs text-muted-foreground">
+                  Context: {editingCommand.definition.contextLabel}
+                </span>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <div className="space-y-3">
+              {draftShortcutSlots.map((slot, index) => (
+                <div key={slot.id} className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                      {index === 0 ? "Primary shortcut" : `Alternate ${index}`}
+                    </div>
+                    {draftShortcutSlots.length > 1 ? (
+                      <Button
+                        type="button"
+                        size="icon-xs"
+                        variant="ghost"
+                        aria-label={`Remove shortcut ${index + 1}`}
+                        disabled={isSaving}
+                        onClick={() => removeShortcutSlot(slot.id)}
+                      >
+                        <XIcon className="size-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                  <KeybindingRecorderField
+                    autoFocus={index === 0}
+                    value={slot.value}
+                    onChange={(nextValue) => replaceShortcutValue(slot.id, nextValue)}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/15 px-3.5 py-3">
+              <p className="text-xs text-muted-foreground">
+                Add up to {MAX_EDITABLE_SHORTCUTS} alternate shortcuts here. Use the JSON file for
+                anything more complex.
+              </p>
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                disabled={isSaving || draftShortcutSlots.length >= MAX_EDITABLE_SHORTCUTS}
+                onClick={addShortcutSlot}
+              >
+                <PlusIcon className="size-3.5" />
+                Add alternate
+              </Button>
+            </div>
+
+            {editingCommand ? (
+              <div className="rounded-xl border border-border/60 bg-muted/15 px-3.5 py-3">
+                <div className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  Defaults
+                </div>
+                <div className="mt-2">
+                  {renderShortcutBadges(editingCommand.defaultValues, "No default shortcut")}
+                </div>
+              </div>
+            ) : null}
+
+            {saveError ? <p className="text-sm text-destructive">{saveError}</p> : null}
+          </DialogPanel>
+          <DialogFooter>
+            {editingCommand ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="mr-auto"
+                disabled={isSaving}
+                onClick={() => void restoreDefaults(editingCommand.definition)}
+              >
+                Restore defaults
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={isSaving}
+              onClick={closeEditor}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={isSaving}
+              onClick={() => void saveShortcutRules()}
+            >
+              {isSaving ? "Saving..." : "Save hotkeys"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -4,6 +4,7 @@ import {
   type KeybindingRule,
   type ResolvedKeybindingsConfig,
 } from "@okcode/contracts";
+import { keybindingValuesForCommand } from "@okcode/shared/keybindings";
 import { Schema } from "effect";
 
 export const PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE = "Invalid keybinding.";
@@ -36,24 +37,5 @@ export function keybindingValueForCommand(
   keybindings: ResolvedKeybindingsConfig,
   command: KeybindingCommand,
 ): string | null {
-  for (let index = keybindings.length - 1; index >= 0; index -= 1) {
-    const binding = keybindings[index];
-    if (!binding || binding.command !== command) continue;
-
-    const parts: string[] = [];
-    if (binding.shortcut.modKey) parts.push("mod");
-    if (binding.shortcut.ctrlKey) parts.push("ctrl");
-    if (binding.shortcut.metaKey) parts.push("meta");
-    if (binding.shortcut.altKey) parts.push("alt");
-    if (binding.shortcut.shiftKey) parts.push("shift");
-    const keyToken =
-      binding.shortcut.key === " "
-        ? "space"
-        : binding.shortcut.key === "escape"
-          ? "esc"
-          : binding.shortcut.key;
-    parts.push(keyToken);
-    return parts.join("+");
-  }
-  return null;
+  return keybindingValuesForCommand(keybindings, command)[0] ?? null;
 }

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -6,6 +6,7 @@ import {
   CpuIcon,
   GitBranchIcon,
   ImportIcon,
+  KeyboardIcon,
   Loader2Icon,
   PaletteIcon,
   PlusIcon,
@@ -22,6 +23,8 @@ import { type ReactNode, useCallback, useEffect, useState } from "react";
 import type { TestOpenclawGatewayHostKind, TestOpenclawGatewayResult } from "@okcode/contracts";
 import {
   type BuildMetadata,
+  type KeybindingCommand,
+  type KeybindingRule,
   type ProjectId,
   type ProviderKind,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
@@ -53,6 +56,7 @@ import { APP_BUILD_INFO } from "../branding";
 import { Button } from "../components/ui/button";
 import { Collapsible, CollapsibleContent } from "../components/ui/collapsible";
 import { EnvironmentVariablesEditor } from "../components/EnvironmentVariablesEditor";
+import { HotkeysSettingsSection } from "../components/settings/HotkeysSettingsSection";
 import { Input } from "../components/ui/input";
 import {
   Select,
@@ -91,7 +95,7 @@ import {
   setStoredRadiusOverride,
   type CustomThemeData,
 } from "../lib/customTheme";
-import { serverConfigQueryOptions } from "../lib/serverReactQuery";
+import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
 import { cn } from "../lib/utils";
 import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
@@ -100,7 +104,14 @@ import { PairingLink } from "../components/mobile/PairingLink";
 // ---------------------------------------------------------------------------
 // Settings navigation sections
 // ---------------------------------------------------------------------------
-type SettingsSectionId = "general" | "environment" | "git" | "models" | "mobile" | "advanced";
+type SettingsSectionId =
+  | "general"
+  | "hotkeys"
+  | "environment"
+  | "git"
+  | "models"
+  | "mobile"
+  | "advanced";
 
 interface SettingsNavItem {
   id: SettingsSectionId;
@@ -112,6 +123,7 @@ interface SettingsNavItem {
 function useSettingsNavItems(): SettingsNavItem[] {
   return [
     { id: "general", label: "General", icon: <PaletteIcon className="size-4" /> },
+    { id: "hotkeys", label: "Hotkeys", icon: <KeyboardIcon className="size-4" /> },
     { id: "environment", label: "Environment", icon: <VariableIcon className="size-4" /> },
     { id: "git", label: "Git", icon: <GitBranchIcon className="size-4" /> },
     { id: "models", label: "Models", icon: <CpuIcon className="size-4" /> },
@@ -786,6 +798,15 @@ function SettingsRouteView() {
         setIsOpeningKeybindings(false);
       });
   }, [availableEditors, keybindingsConfigPath]);
+
+  const replaceKeybindingRules = useCallback(
+    async (command: KeybindingCommand, rules: readonly KeybindingRule[]) => {
+      const api = ensureNativeApi();
+      await api.server.replaceKeybindingRules({ command, rules: [...rules] });
+      await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
+    },
+    [queryClient],
+  );
 
   const saveGlobalEnvironmentVariables = useCallback(
     async (entries: ReadonlyArray<{ key: string; value: string }>) => {
@@ -2122,6 +2143,18 @@ function SettingsRouteView() {
                   </SettingsSection>
                 )}
 
+                {activeSection === "hotkeys" && (
+                  <HotkeysSettingsSection
+                    keybindings={serverConfigQuery.data?.keybindings ?? []}
+                    issues={serverConfigQuery.data?.issues ?? []}
+                    keybindingsConfigPath={keybindingsConfigPath}
+                    isOpeningKeybindings={isOpeningKeybindings}
+                    openKeybindingsError={openKeybindingsError}
+                    onOpenKeybindingsFile={openKeybindingsFile}
+                    onReplaceKeybindingRules={replaceKeybindingRules}
+                  />
+                )}
+
                 {activeSection === "environment" && (
                   <SettingsSection
                     title="Environment"
@@ -2473,7 +2506,7 @@ function SettingsRouteView() {
                 {activeSection === "advanced" && (
                   <SettingsSection
                     title="Advanced"
-                    description="Provider paths, keybindings, and build info."
+                    description="Provider paths, gateway diagnostics, and build info."
                   >
                     <SettingsRow
                       title="Provider installs"
@@ -2953,35 +2986,6 @@ function SettingsRouteView() {
                         )}
                       </div>
                     </SettingsRow>
-
-                    <SettingsRow
-                      title="Keybindings"
-                      description="Open the persisted `keybindings.json` file to edit advanced bindings directly."
-                      status={
-                        <>
-                          <span className="block break-all font-mono text-[11px] text-foreground">
-                            {keybindingsConfigPath ?? "Resolving keybindings path..."}
-                          </span>
-                          {openKeybindingsError ? (
-                            <span className="mt-1 block text-destructive">
-                              {openKeybindingsError}
-                            </span>
-                          ) : (
-                            <span className="mt-1 block">Opens in your preferred editor.</span>
-                          )}
-                        </>
-                      }
-                      control={
-                        <Button
-                          size="xs"
-                          variant="outline"
-                          disabled={!keybindingsConfigPath || isOpeningKeybindings}
-                          onClick={openKeybindingsFile}
-                        >
-                          {isOpeningKeybindings ? "Opening..." : "Open file"}
-                        </Button>
-                      }
-                    />
 
                     <SettingsRow
                       title="Build"

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -396,6 +396,8 @@ export function createWsNativeApi(): NativeApi {
       saveProjectEnvironmentVariables: (input) =>
         transport.request(WS_METHODS.serverSaveProjectEnvironmentVariables, input),
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
+      replaceKeybindingRules: (input) =>
+        transport.request(WS_METHODS.serverReplaceKeybindingRules, input),
       testOpenclawGateway: (input) =>
         transport.request(WS_METHODS.serverTestOpenclawGateway, input),
     },

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -90,6 +90,8 @@ import type {
   TerminalWriteInput,
 } from "./terminal";
 import type {
+  ServerReplaceKeybindingRulesInput,
+  ServerReplaceKeybindingRulesResult,
   ServerUpsertKeybindingInput,
   ServerUpsertKeybindingResult,
   ServerUpdateInfo,
@@ -476,6 +478,9 @@ export interface NativeApi {
       input: SaveProjectEnvironmentVariablesInput,
     ) => Promise<ProjectEnvironmentVariablesResult>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+    replaceKeybindingRules: (
+      input: ServerReplaceKeybindingRulesInput,
+    ) => Promise<ServerReplaceKeybindingRulesResult>;
     testOpenclawGateway: (input: TestOpenclawGatewayInput) => Promise<TestOpenclawGatewayResult>;
   };
   orchestration: {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -1,7 +1,12 @@
 import { Schema } from "effect";
 import { DeviceId, IsoDateTime, PairingId, TrimmedNonEmptyString } from "./baseSchemas";
 import { BuildMetadata } from "./buildInfo";
-import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
+import {
+  KeybindingCommand,
+  KeybindingRule,
+  MAX_KEYBINDINGS_COUNT,
+  ResolvedKeybindingsConfig,
+} from "./keybindings";
 import { EditorId } from "./editor";
 import { ProviderKind } from "./orchestration";
 
@@ -65,6 +70,15 @@ export const ServerUpsertKeybindingResult = Schema.Struct({
   issues: ServerConfigIssues,
 });
 export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.Type;
+
+export const ServerReplaceKeybindingRulesInput = Schema.Struct({
+  command: KeybindingCommand,
+  rules: Schema.Array(KeybindingRule).check(Schema.isMaxLength(MAX_KEYBINDINGS_COUNT)),
+});
+export type ServerReplaceKeybindingRulesInput = typeof ServerReplaceKeybindingRulesInput.Type;
+
+export const ServerReplaceKeybindingRulesResult = ServerUpsertKeybindingResult;
+export type ServerReplaceKeybindingRulesResult = typeof ServerReplaceKeybindingRulesResult.Type;
 
 export const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -87,6 +87,7 @@ import {
   RevokePairedDeviceInput,
   RevokeTokenInput,
   ServerConfigUpdatedPayload,
+  ServerReplaceKeybindingRulesInput,
   TestOpenclawGatewayInput,
 } from "./server";
 import { GitHubGetIssueInput, GitHubListIssuesInput, GitHubPostCommentInput } from "./github";
@@ -209,6 +210,7 @@ export const WS_METHODS = {
   serverGetProjectEnvironmentVariables: "server.getProjectEnvironmentVariables",
   serverSaveProjectEnvironmentVariables: "server.saveProjectEnvironmentVariables",
   serverUpsertKeybinding: "server.upsertKeybinding",
+  serverReplaceKeybindingRules: "server.replaceKeybindingRules",
   serverPickFolder: "server.pickFolder",
 
   // Token management (legacy)
@@ -390,6 +392,7 @@ const WebSocketRequestBody = Schema.Union([
     SaveProjectEnvironmentVariablesInput,
   ),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
+  tagRequestBody(WS_METHODS.serverReplaceKeybindingRules, ServerReplaceKeybindingRulesInput),
   tagRequestBody(WS_METHODS.serverPickFolder, Schema.Struct({})),
 
   // Token management (legacy)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -55,6 +55,10 @@
     "./redaction": {
       "types": "./src/redaction.ts",
       "import": "./src/redaction.ts"
+    },
+    "./keybindings": {
+      "types": "./src/keybindings.ts",
+      "import": "./src/keybindings.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/keybindings.test.ts
+++ b/packages/shared/src/keybindings.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import type { ResolvedKeybindingsConfig } from "@okcode/contracts";
+
+import {
+  DEFAULT_KEYBINDINGS,
+  defaultKeybindingRulesForCommand,
+  encodeKeybindingShortcut,
+  keybindingValueFromShortcutEvent,
+  keybindingValuesForCommand,
+  normalizeRecordedShortcutKeyToken,
+  parseKeybindingShortcut,
+} from "./keybindings";
+
+describe("parseKeybindingShortcut", () => {
+  it("parses plus-key shortcuts", () => {
+    expect(parseKeybindingShortcut("mod++")).toEqual({
+      key: "+",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: true,
+    });
+  });
+
+  it("normalizes esc and space tokens", () => {
+    expect(parseKeybindingShortcut("mod+esc")?.key).toBe("escape");
+    expect(parseKeybindingShortcut("mod+space")?.key).toBe(" ");
+  });
+});
+
+describe("encodeKeybindingShortcut", () => {
+  it("encodes escape with the shared token format", () => {
+    expect(
+      encodeKeybindingShortcut({
+        key: "escape",
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        modKey: true,
+      }),
+    ).toBe("mod+esc");
+  });
+});
+
+describe("normalizeRecordedShortcutKeyToken", () => {
+  it("ignores modifier-only keys", () => {
+    expect(normalizeRecordedShortcutKeyToken("Meta")).toBeNull();
+    expect(normalizeRecordedShortcutKeyToken("Shift")).toBeNull();
+  });
+
+  it("accepts punctuation and navigation keys", () => {
+    expect(normalizeRecordedShortcutKeyToken("+")).toBe("+");
+    expect(normalizeRecordedShortcutKeyToken("ArrowDown")).toBe("arrowdown");
+  });
+});
+
+describe("keybindingValueFromShortcutEvent", () => {
+  it("records mod on macOS using the meta key", () => {
+    expect(
+      keybindingValueFromShortcutEvent(
+        {
+          key: "k",
+          metaKey: true,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+        },
+        "MacIntel",
+      ),
+    ).toBe("mod+k");
+  });
+
+  it("records mod on Windows using control and preserves meta separately", () => {
+    expect(
+      keybindingValueFromShortcutEvent(
+        {
+          key: "k",
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: false,
+          altKey: false,
+        },
+        "Win32",
+      ),
+    ).toBe("mod+meta+k");
+  });
+
+  it("requires at least one modifier", () => {
+    expect(
+      keybindingValueFromShortcutEvent(
+        {
+          key: "k",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+        },
+        "Linux",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("defaultKeybindingRulesForCommand", () => {
+  it("returns the built-in alternate defaults for terminal.toggle", () => {
+    expect(defaultKeybindingRulesForCommand("terminal.toggle")).toEqual(
+      DEFAULT_KEYBINDINGS.filter((rule) => rule.command === "terminal.toggle"),
+    );
+  });
+});
+
+describe("keybindingValuesForCommand", () => {
+  it("returns encoded values from resolved keybindings without duplicates", () => {
+    const bindings = [
+      {
+        command: "chat.new",
+        shortcut: {
+          key: "n",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          modKey: true,
+        },
+      },
+      {
+        command: "chat.new",
+        shortcut: {
+          key: "n",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          modKey: true,
+        },
+      },
+      {
+        command: "chat.new",
+        shortcut: {
+          key: "o",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: true,
+          altKey: false,
+          modKey: true,
+        },
+      },
+    ] satisfies ResolvedKeybindingsConfig;
+
+    expect(keybindingValuesForCommand(bindings, "chat.new")).toEqual(["mod+n", "mod+shift+o"]);
+  });
+});

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -1,0 +1,279 @@
+import type {
+  KeybindingCommand,
+  KeybindingRule,
+  KeybindingShortcut,
+  ResolvedKeybindingsConfig,
+} from "@okcode/contracts";
+
+export interface HotkeyCommandDefinition {
+  readonly command: KeybindingCommand;
+  readonly title: string;
+  readonly description: string;
+  readonly group: "Workspace" | "Terminal";
+  readonly when?: string;
+  readonly contextLabel: string;
+}
+
+export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
+  { key: "mod+j", command: "terminal.toggle" },
+  { key: "ctrl+`", command: "terminal.toggle" },
+  { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
+  { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
+  { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
+  { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
+  { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
+  { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+down", command: "git.pullRequest", when: "!terminalFocus" },
+  { key: "mod+shift+p", command: "git.pullRequest", when: "!terminalFocus" },
+  { key: "mod+o", command: "editor.openFavorite" },
+] as const;
+
+export const HOTKEY_COMMAND_DEFINITIONS = [
+  {
+    command: "chat.new",
+    title: "New thread",
+    description: "Start a fresh conversation in the current project.",
+    group: "Workspace",
+    when: "!terminalFocus",
+    contextLabel: "When the terminal is not focused",
+  },
+  {
+    command: "chat.newLocal",
+    title: "New local thread",
+    description: "Start a local or worktree-backed thread without leaving the current project.",
+    group: "Workspace",
+    when: "!terminalFocus",
+    contextLabel: "When the terminal is not focused",
+  },
+  {
+    command: "git.pullRequest",
+    title: "Pull request",
+    description: "Open the active pull request or start the PR flow for the current branch.",
+    group: "Workspace",
+    when: "!terminalFocus",
+    contextLabel: "When the terminal is not focused",
+  },
+  {
+    command: "editor.openFavorite",
+    title: "Favorite editor",
+    description: "Jump straight to the editor you last used for this project.",
+    group: "Workspace",
+    contextLabel: "Available anywhere",
+  },
+  {
+    command: "terminal.toggle",
+    title: "Toggle terminal",
+    description: "Show or hide the terminal drawer from anywhere in the app.",
+    group: "Terminal",
+    contextLabel: "Available anywhere",
+  },
+  {
+    command: "terminal.split",
+    title: "Split terminal",
+    description: "Open another terminal pane beside the active one.",
+    group: "Terminal",
+    when: "terminalFocus",
+    contextLabel: "When the terminal is focused",
+  },
+  {
+    command: "terminal.new",
+    title: "New terminal",
+    description: "Create a fresh terminal session while you stay in context.",
+    group: "Terminal",
+    when: "terminalFocus",
+    contextLabel: "When the terminal is focused",
+  },
+  {
+    command: "terminal.close",
+    title: "Close terminal",
+    description: "Close the active terminal session.",
+    group: "Terminal",
+    when: "terminalFocus",
+    contextLabel: "When the terminal is focused",
+  },
+] as const satisfies ReadonlyArray<HotkeyCommandDefinition>;
+
+export interface ShortcutRecordingEventLike {
+  readonly key: string;
+  readonly metaKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly shiftKey: boolean;
+  readonly altKey: boolean;
+}
+
+function isMacLikePlatform(platform: string): boolean {
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+function normalizeKeyToken(token: string): string {
+  if (token === "space") return " ";
+  if (token === "esc") return "escape";
+  return token;
+}
+
+export function parseKeybindingShortcut(value: string): KeybindingShortcut | null {
+  const rawTokens = value
+    .toLowerCase()
+    .split("+")
+    .map((token) => token.trim());
+  const tokens = [...rawTokens];
+  let trailingEmptyCount = 0;
+  while (tokens[tokens.length - 1] === "") {
+    trailingEmptyCount += 1;
+    tokens.pop();
+  }
+  if (trailingEmptyCount > 0) {
+    tokens.push("+");
+  }
+  if (tokens.some((token) => token.length === 0)) {
+    return null;
+  }
+  if (tokens.length === 0) return null;
+
+  let key: string | null = null;
+  let metaKey = false;
+  let ctrlKey = false;
+  let shiftKey = false;
+  let altKey = false;
+  let modKey = false;
+
+  for (const token of tokens) {
+    switch (token) {
+      case "cmd":
+      case "meta":
+        metaKey = true;
+        break;
+      case "ctrl":
+      case "control":
+        ctrlKey = true;
+        break;
+      case "shift":
+        shiftKey = true;
+        break;
+      case "alt":
+      case "option":
+        altKey = true;
+        break;
+      case "mod":
+        modKey = true;
+        break;
+      default: {
+        if (key !== null) return null;
+        key = normalizeKeyToken(token);
+      }
+    }
+  }
+
+  if (key === null) return null;
+  return {
+    key,
+    metaKey,
+    ctrlKey,
+    shiftKey,
+    altKey,
+    modKey,
+  };
+}
+
+export function encodeKeybindingShortcut(shortcut: KeybindingShortcut): string | null {
+  const modifiers: string[] = [];
+  if (shortcut.modKey) modifiers.push("mod");
+  if (shortcut.metaKey) modifiers.push("meta");
+  if (shortcut.ctrlKey) modifiers.push("ctrl");
+  if (shortcut.altKey) modifiers.push("alt");
+  if (shortcut.shiftKey) modifiers.push("shift");
+  if (!shortcut.key) return null;
+  if (shortcut.key !== "+" && shortcut.key.includes("+")) return null;
+  const key = shortcut.key === " " ? "space" : shortcut.key === "escape" ? "esc" : shortcut.key;
+  return [...modifiers, key].join("+");
+}
+
+export function normalizeRecordedShortcutKeyToken(key: string): string | null {
+  const normalized = key.toLowerCase();
+  if (
+    normalized === "meta" ||
+    normalized === "os" ||
+    normalized === "control" ||
+    normalized === "ctrl" ||
+    normalized === "shift" ||
+    normalized === "alt" ||
+    normalized === "option" ||
+    normalized === "capslock" ||
+    normalized === "dead"
+  ) {
+    return null;
+  }
+  if (normalized === " " || normalized === "spacebar") return "space";
+  if (normalized === "escape" || normalized === "esc") return "esc";
+  if (normalized === "up") return "arrowup";
+  if (normalized === "down") return "arrowdown";
+  if (normalized === "left") return "arrowleft";
+  if (normalized === "right") return "arrowright";
+  if (
+    normalized === "arrowup" ||
+    normalized === "arrowdown" ||
+    normalized === "arrowleft" ||
+    normalized === "arrowright" ||
+    normalized === "enter" ||
+    normalized === "tab" ||
+    normalized === "backspace" ||
+    normalized === "delete" ||
+    normalized === "home" ||
+    normalized === "end" ||
+    normalized === "pageup" ||
+    normalized === "pagedown"
+  ) {
+    return normalized;
+  }
+  if (/^f\d{1,2}$/.test(normalized)) return normalized;
+  if (normalized.length === 1 && !/\s/.test(normalized)) return normalized;
+  return null;
+}
+
+export function keybindingValueFromShortcutEvent(
+  event: ShortcutRecordingEventLike,
+  platform: string,
+): string | null {
+  const keyToken = normalizeRecordedShortcutKeyToken(event.key);
+  if (!keyToken) return null;
+
+  const parts: string[] = [];
+  if (isMacLikePlatform(platform)) {
+    if (event.metaKey) parts.push("mod");
+    if (event.ctrlKey) parts.push("ctrl");
+  } else {
+    if (event.ctrlKey) parts.push("mod");
+    if (event.metaKey) parts.push("meta");
+  }
+  if (event.altKey) parts.push("alt");
+  if (event.shiftKey) parts.push("shift");
+  if (parts.length === 0) {
+    return null;
+  }
+  parts.push(keyToken);
+  return parts.join("+");
+}
+
+export function defaultKeybindingRulesForCommand(
+  command: KeybindingCommand,
+): ReadonlyArray<KeybindingRule> {
+  return DEFAULT_KEYBINDINGS.filter((binding) => binding.command === command);
+}
+
+export function keybindingValuesForCommand(
+  keybindings: ResolvedKeybindingsConfig,
+  command: KeybindingCommand,
+): string[] {
+  const values: string[] = [];
+  const seenValues = new Set<string>();
+
+  for (const binding of keybindings) {
+    if (!binding || binding.command !== command) continue;
+    const encoded = encodeKeybindingShortcut(binding.shortcut);
+    if (!encoded || seenValues.has(encoded)) continue;
+    seenValues.add(encoded);
+    values.push(encoded);
+  }
+
+  return values;
+}


### PR DESCRIPTION
## Summary
- Add a dedicated Hotkeys settings section for viewing, editing, and restoring built-in keyboard shortcuts.
- Introduce a shared keybinding recorder field used by both hotkey settings and project script keybinding inputs.
- Move keybinding parsing/encoding and default shortcut definitions into `packages/shared` so server and web use the same logic.
- Add a server-side `replaceKeybindingRules` path that can replace or clear all custom rules for a command, enabling reset-to-default behavior.
- Update the settings UI to surface malformed config warnings, invalid-entry warnings, and an advanced JSON editing entrypoint.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Added/updated unit coverage for shared keybinding parsing and server keybinding replacement behavior.
- Not run: `bun run test`