### PR TITLE
Fix main branch lint and typecheck regressions

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -40,7 +40,6 @@ import { ProviderUnsupportedError } from "../src/provider/Errors.ts";
 import { ProviderAdapterRegistry } from "../src/provider/Services/ProviderAdapterRegistry.ts";
 import { ProviderRuntimeEventFeedLive } from "../src/provider/Layers/ProviderRuntimeEventFeed.ts";
 import { ProviderSessionDirectoryLive } from "../src/provider/Layers/ProviderSessionDirectory.ts";
-import { ProviderRuntimeEventFeedLive } from "../src/provider/Layers/ProviderRuntimeEventFeed.ts";
 import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.ts";
 import { makeCodexAdapterLive } from "../src/provider/Layers/CodexAdapter.ts";
 import { CodexAdapter } from "../src/provider/Services/CodexAdapter.ts";

--- a/apps/server/integration/providerService.integration.test.ts
+++ b/apps/server/integration/providerService.integration.test.ts
@@ -8,7 +8,6 @@ import { ProviderUnsupportedError } from "../src/provider/Errors.ts";
 import { ProviderAdapterRegistry } from "../src/provider/Services/ProviderAdapterRegistry.ts";
 import { ProviderRuntimeEventFeedLive } from "../src/provider/Layers/ProviderRuntimeEventFeed.ts";
 import { ProviderSessionDirectoryLive } from "../src/provider/Layers/ProviderSessionDirectory.ts";
-import { ProviderRuntimeEventFeedLive } from "../src/provider/Layers/ProviderRuntimeEventFeed.ts";
 import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.ts";
 import {
   ProviderService,

--- a/apps/server/src/openclaw/GatewayClient.ts
+++ b/apps/server/src/openclaw/GatewayClient.ts
@@ -466,7 +466,7 @@ export class OpenclawGatewayClient {
 
       if (frame.type === "event" && typeof frame.event === "string") {
         let matchedWaiter = false;
-        for (const waiter of [...this.pendingEventWaiters]) {
+        for (const waiter of this.pendingEventWaiters) {
           if (waiter.eventName === frame.event) {
             matchedWaiter = true;
             this.pendingEventWaiters.delete(waiter);

--- a/apps/server/src/persistence/Layers/OpenclawGatewayConfig.ts
+++ b/apps/server/src/persistence/Layers/OpenclawGatewayConfig.ts
@@ -68,7 +68,7 @@ function normalizeScopes(scopes: ReadonlyArray<string> | undefined): string[] {
       unique.add(trimmed);
     }
   }
-  return [...unique].sort((left, right) => left.localeCompare(right));
+  return [...unique].toSorted((left, right) => left.localeCompare(right));
 }
 
 function fromGeneratedIdentity(identity: ReturnType<typeof generateOpenclawDeviceIdentity>) {


### PR DESCRIPTION
## Summary
This branch cleans up regressions that were present on current `main` after the recent extraction merges, so the branch is ready for the next release cycle.

It fixes:
- duplicate `ProviderRuntimeEventFeedLive` imports in the server integration harnesses that broke lint and TypeScript
- an unnecessary array spread while iterating OpenClaw pending event waiters
- a mutating `sort()` call in OpenClaw gateway scope normalization

## Why this matters
`main` was not gate-clean after pulling the latest merged work. This PR restores the expected repository baseline so release prep starts from a passing branch instead of carrying forward avoidable CI noise.

## Verification
- `bun fmt`
- `bun lint`
- `bun typecheck`
