### PR TITLE
Support direct Anthropic creds for Claude SME Chat

### DIFF
--- a/apps/web/src/components/PreviewPanel.test.ts
+++ b/apps/web/src/components/PreviewPanel.test.ts
@@ -30,6 +30,15 @@ describe("PreviewPanel", () => {
     expect(hasBlockingPreviewOverlay(root)).toBe(true);
   });
 
+  it("treats error notifications as blocking overlays", () => {
+    const root = {
+      querySelector: (selector: string) =>
+        selector.includes('[data-slot="error-notification-bar"]') ? {} : null,
+    } as unknown as ParentNode;
+
+    expect(hasBlockingPreviewOverlay(root)).toBe(true);
+  });
+
   it("ignores empty overlay containers", () => {
     const root = {
       querySelector: () => null,

--- a/apps/web/src/components/PreviewPanel.tsx
+++ b/apps/web/src/components/PreviewPanel.tsx
@@ -71,6 +71,7 @@ const POPUP_POSITIONER_SELECTOR = [
   '[data-slot="select-positioner"]',
   '[data-slot="combobox-positioner"]',
   '[data-slot="autocomplete-positioner"]',
+  '[data-slot="error-notification-bar"]',
   '[data-slot="toast-viewport"]:not(:empty)',
   '[data-slot="toast-viewport-anchored"]:not(:empty)',
   '[data-slot="toast-positioner"]:not(:empty)',
@@ -445,7 +446,7 @@ export function PreviewPanel({ projectId, threadId, onClose }: PreviewPanelProps
   const isFavorite = currentPageUrl !== null && favoriteUrls.includes(currentPageUrl);
 
   return (
-    <div className="flex h-full min-w-0 flex-col bg-background">
+    <div className="relative isolate flex h-full min-w-0 flex-col overflow-hidden bg-background">
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border/60 px-3 py-2">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/chat/ErrorNotificationBar.tsx
+++ b/apps/web/src/components/chat/ErrorNotificationBar.tsx
@@ -241,7 +241,7 @@ export const ErrorNotificationBar = memo(function ErrorNotificationBar({
   }, "info");
 
   return (
-    <div className="mx-auto w-full max-w-7xl px-3 pt-2 sm:px-5">
+    <div data-slot="error-notification-bar" className="mx-auto w-full max-w-7xl px-3 pt-2 sm:px-5">
       <div
         className={cn(
           "overflow-hidden rounded-lg border transition-all duration-200",


### PR DESCRIPTION
## Summary
- Make Claude SME Chat resolve credentials directly from Anthropic API key, auth token, or auth token helper command instead of depending on Claude CLI login.
- Default Claude SME conversations to `auto` auth and update the UI copy/options to explain the direct-credential flow.
- Treat Claude CLI auth status as ready when logged into Claude.ai, while keeping preview error notifications visible as blocking overlays.
- Add coverage for the new auth resolution behavior and preview overlay detection.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Not run: `bun run test`