### PR TITLE
Add panel keyboard shortcuts and update Claude SME auth handling

### DIFF
--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -17,6 +17,7 @@ import {
   isTerminalSplitShortcut,
   isTerminalToggleShortcut,
   resolveShortcutCommand,
+  panelNavigationShortcutData,
   shortcutLabelForCommand,
   shortcutLabelsForCommand,
   terminalNavigationShortcutData,
@@ -509,6 +510,34 @@ describe("terminalNavigationShortcutData", () => {
         event({ type: "keyup", key: "ArrowLeft", altKey: true }),
         "MacIntel",
       ),
+    );
+  });
+});
+
+describe("panelNavigationShortcutData", () => {
+  it("maps Ctrl+Left to the left sidebar", () => {
+    assert.strictEqual(
+      panelNavigationShortcutData(event({ key: "ArrowLeft", ctrlKey: true })),
+      "sidebar",
+    );
+  });
+
+  it("maps Ctrl+Right to the right panel", () => {
+    assert.strictEqual(
+      panelNavigationShortcutData(event({ key: "ArrowRight", ctrlKey: true })),
+      "right-panel",
+    );
+  });
+
+  it("ignores unsupported modifier combinations", () => {
+    assert.isNull(panelNavigationShortcutData(event({ key: "ArrowLeft", metaKey: true })));
+    assert.isNull(panelNavigationShortcutData(event({ key: "ArrowRight", altKey: true })));
+    assert.isNull(panelNavigationShortcutData(event({ key: "ArrowLeft", shiftKey: true })));
+  });
+
+  it("ignores non-keydown events", () => {
+    assert.isNull(
+      panelNavigationShortcutData(event({ type: "keyup", key: "ArrowLeft", ctrlKey: true })),
     );
   });
 });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -318,3 +318,26 @@ export function terminalNavigationShortcutData(
 
   return null;
 }
+
+export type PanelNavigationShortcutTarget = "sidebar" | "right-panel";
+
+export function panelNavigationShortcutData(
+  event: ShortcutEventLike,
+): PanelNavigationShortcutTarget | null {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return null;
+  }
+
+  if (event.metaKey || event.altKey || event.shiftKey || !event.ctrlKey) {
+    return null;
+  }
+
+  const key = normalizeEventKey(event.key);
+  if (key === "arrowleft") {
+    return "sidebar";
+  }
+  if (key === "arrowright") {
+    return "right-panel";
+  }
+  return null;
+}

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -13,7 +13,13 @@ import {
 } from "react";
 import { RightPanelHeader } from "~/components/RightPanelHeader";
 import { WorkspacePanel } from "~/components/WorkspacePanel";
-import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import {
+  Sidebar,
+  SidebarInset,
+  SidebarProvider,
+  SidebarRail,
+  useSidebar,
+} from "~/components/ui/sidebar";
 import { WorkspaceFileTree } from "~/components/WorkspaceFileTree";
 import { useChatWidgetStore } from "../chatWidgetStore";
 import { useCodeViewerStore } from "../codeViewerStore";
@@ -24,6 +30,8 @@ import { useDiffViewerStore } from "../diffViewerStore";
 import { isMobileShell } from "../env";
 import { useClientMode } from "../hooks/useClientMode";
 import { useTheme } from "../hooks/useTheme";
+import { isTerminalFocused } from "../lib/terminalFocus";
+import { panelNavigationShortcutData } from "../keybindings";
 import { useRightPanelStore } from "../rightPanelStore";
 import { useSimulationViewerStore } from "../simulationViewerStore";
 import { useStore } from "../store";
@@ -169,6 +177,7 @@ const RightPanelSheet = (props: { open: boolean; onClose: () => void; children: 
 function ChatThreadRouteView() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const navigate = useNavigate();
+  const { toggleSidebar } = useSidebar();
   const threadId = Route.useParams({
     select: (params) => ThreadId.makeUnsafe(params.threadId),
   });
@@ -227,6 +236,45 @@ function ChatThreadRouteView() {
   const closeSimulation = useCallback(() => {
     closeSimulationStore();
   }, [closeSimulationStore]);
+
+  useEffect(() => {
+    const onWindowKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.repeat) return;
+      if (isTerminalFocused()) return;
+
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        if (
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+
+      const shortcutTarget = panelNavigationShortcutData(event);
+      if (shortcutTarget === null) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (shortcutTarget === "sidebar") {
+        toggleSidebar();
+        return;
+      }
+
+      if (rightPanelOpen) {
+        closeRightPanel();
+      } else {
+        openRightPanel();
+      }
+    };
+
+    window.addEventListener("keydown", onWindowKeyDown);
+    return () => window.removeEventListener("keydown", onWindowKeyDown);
+  }, [closeRightPanel, openRightPanel, rightPanelOpen, toggleSidebar]);
 
   // ── Sync sub-panel opens → right panel tab ────────────────────────
   // When code viewer opens (or a new file is activated), switch to workspace tab.


### PR DESCRIPTION
## Summary
- Add `Ctrl+Left` and `Ctrl+Right` shortcuts to toggle the sidebar and right panel in the chat thread view.
- Treat error notifications as blocking preview overlays so panels stay out of the way when errors are visible.
- Rename the Cotton Candy color theme to Purple Stuff and migrate stored theme values.
- Update Claude SME Chat to use direct Anthropic credentials, with `auto` preferring auth token/helper command before falling back to `ANTHROPIC_API_KEY`.
- Refresh provider health and SME settings copy to match the new Claude auth behavior.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Added and updated unit tests for keybindings, preview overlay detection, provider health parsing, and SME auth resolution behavior.