### PR TITLE
Allow unsigned Windows release artifacts when signing is unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,9 +223,6 @@ jobs:
               "$AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME" \
               "$AZURE_TRUSTED_SIGNING_PUBLISHER_NAME"; then
               args+=(--signed --require-signed)
-            elif [[ "${{ needs.preflight.outputs.is_prerelease }}" == "false" ]]; then
-              echo "Missing Azure Trusted Signing secrets for a stable Windows release." >&2
-              exit 1
             else
               echo "Azure Trusted Signing secrets not configured; building unsigned Windows artifact." >&2
             fi


### PR DESCRIPTION
## Summary
- Remove the release-workflow hard failure when Azure Trusted Signing secrets are missing.
- Keep Windows release builds moving by falling back to unsigned artifacts and logging the condition.
- Preserve signed artifacts when signing credentials are present.

## Testing
- Not run (workflow-only change).
- Verified the release workflow no longer exits early on missing Azure Trusted Signing secrets for Windows.