### PR TITLE
Clarify OpenClaw gateway auth terminology

### DIFF
--- a/apps/server/src/openclawGatewayTest.test.ts
+++ b/apps/server/src/openclawGatewayTest.test.ts
@@ -140,8 +140,8 @@ describe("runOpenclawGatewayTest", () => {
     expect(connectParams?.client?.mode).toBe("backend");
     expect(connectParams?.client?.displayName).toBe("OK Code gateway test");
     expect(connectParams?.client?.deviceFamily).toBe("server");
-    expect(connectParams?.auth?.password).toBe("topsecret");
-    expect(connectParams?.auth?.token).toBeUndefined();
+    expect(connectParams?.auth?.token).toBe("topsecret");
+    expect(connectParams?.auth?.password).toBeUndefined();
     expect(connectParams?.auth?.deviceToken).toBeUndefined();
     expect(connectParams?.device?.id).toMatch(/^[a-f0-9]{64}$/);
     expect(connectParams?.device?.id).not.toMatch(/^device_/);

--- a/apps/server/src/provider/Layers/OpenClawGatewayClient.ts
+++ b/apps/server/src/provider/Layers/OpenClawGatewayClient.ts
@@ -436,7 +436,7 @@ function buildConnectParams(input: {
   const auth =
     input.auth.kind === "password"
       ? {
-          password: input.auth.value,
+          token: input.auth.value,
         }
       : input.auth.kind === "deviceToken"
         ? {

--- a/apps/web/src/components/sme/smeConversationConfig.test.ts
+++ b/apps/web/src/components/sme/smeConversationConfig.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getDefaultSmeAuthMethod, getSmeAuthMethodOptions } from "./smeConversationConfig";
+
+describe("smeConversationConfig", () => {
+  it("keeps OpenClaw auth copy aligned with shared secret/token terminology", () => {
+    const options = getSmeAuthMethodOptions("openclaw");
+
+    expect(getDefaultSmeAuthMethod("openclaw")).toBe("password");
+    expect(options).toEqual([
+      { value: "password", label: "Gateway Shared Secret / Token" },
+      { value: "none", label: "Device Token Only" },
+      { value: "auto", label: "Auto (prefer shared secret/token)" },
+    ]);
+  });
+});

--- a/apps/web/src/components/sme/smeConversationConfig.ts
+++ b/apps/web/src/components/sme/smeConversationConfig.ts
@@ -44,9 +44,9 @@ export function getSmeAuthMethodOptions(
       ];
     case "openclaw":
       return [
-        { value: "password", label: "Gateway Shared Secret" },
+        { value: "password", label: "Gateway Shared Secret / Token" },
         { value: "none", label: "Device Token Only" },
-        { value: "auto", label: "Auto (prefer shared secret)" },
+        { value: "auto", label: "Auto (prefer shared secret/token)" },
       ];
     case "gemini":
       return [

--- a/apps/web/src/lib/settingsProviderMetadata.test.ts
+++ b/apps/web/src/lib/settingsProviderMetadata.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER_AUTH_GUIDES } from "./settingsProviderMetadata";
+
+describe("PROVIDER_AUTH_GUIDES", () => {
+  it("describes OpenClaw auth as a shared secret/token flow", () => {
+    const guide = PROVIDER_AUTH_GUIDES.openclaw;
+
+    expect(guide.authCmd).toBe("Use gateway shared secret/token");
+    expect(guide.note).toContain("shared secret/token");
+    expect(guide.note).toContain("remote gateways");
+  });
+});

--- a/apps/web/src/lib/settingsProviderMetadata.tsx
+++ b/apps/web/src/lib/settingsProviderMetadata.tsx
@@ -101,7 +101,8 @@ export const PROVIDER_AUTH_GUIDES: Record<ProviderKind, ProviderAuthGuide> = {
     note: "GitHub Copilot must be installed and signed in before it appears in the thread picker.",
   },
   openclaw: {
+    authCmd: "Use gateway shared secret/token",
     verifyCmd: "Test Connection",
-    note: "OpenClaw uses the gateway URL and shared secret below rather than a local CLI login. Shared-secret auth usually works without device pairing and is the recommended default for Tailscale and remote gateways.",
+    note: "OpenClaw uses the gateway URL and shared secret/token below rather than a local CLI login. Shared-secret auth usually works without device pairing and is the recommended default for Tailscale and remote gateways.",
   },
 };

--- a/apps/web/src/routes/_chat.settings.index.tsx
+++ b/apps/web/src/routes/_chat.settings.index.tsx
@@ -335,7 +335,7 @@ function AuthenticationStatusCard({
         <div className="rounded-lg border border-border/60 bg-card/60 px-3 py-2">
           <div className="font-medium text-foreground">Authenticate</div>
           <code className="mt-1 block break-all text-[11px]">
-            {guide.authCmd ?? "Use gateway password"}
+            {guide.authCmd ?? "Use gateway shared secret/token"}
           </code>
         </div>
         <div className="rounded-lg border border-border/60 bg-card/60 px-3 py-2">
@@ -1565,7 +1565,9 @@ function SettingsRouteView() {
                   </span>
                 </label>
                 <label htmlFor="openclaw-password" className="block">
-                  <span className="block text-xs font-medium text-foreground">Password</span>
+                  <span className="block text-xs font-medium text-foreground">
+                    Shared Secret / Token
+                  </span>
                   <Input
                     id="openclaw-password"
                     className="mt-1"


### PR DESCRIPTION
## Summary
- Renamed OpenClaw gateway auth copy from “password” to “shared secret/token” across server and web UI.
- Updated the OpenClaw connect payload to send the shared secret under `auth.token` instead of `auth.password`.
- Added coverage to lock in the updated auth terminology in both server and web tests.

## Testing
- Not run
- Added/updated Vitest coverage for OpenClaw gateway auth payload mapping.
- Added/updated Vitest coverage for SME auth method labels and provider metadata copy.