### PR TITLE
Remove stitch border setting from settings UI

### DIFF
--- a/apps/web/src/components/settings/SettingsRouteContext.tsx
+++ b/apps/web/src/components/settings/SettingsRouteContext.tsx
@@ -109,7 +109,6 @@ export function SettingsRouteContextProvider({ children }: { children: ReactNode
           : []),
         ...(settings.timestampFormat !== defaults.timestampFormat ? ["Time format"] : []),
         ...(settings.locale !== defaults.locale ? ["Language"] : []),
-        ...(settings.showStitchBorder !== defaults.showStitchBorder ? ["Stitch border"] : []),
         ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
           ? ["Assistant output"]
           : []),

--- a/apps/web/src/routes/_chat.settings.index.tsx
+++ b/apps/web/src/routes/_chat.settings.index.tsx
@@ -867,34 +867,6 @@ function SettingsRouteView() {
             />
 
             <SettingsRow
-              title="Stitch border"
-              description="Show the decorative stitch border around the viewport."
-              resetAction={
-                settings.showStitchBorder !== defaults.showStitchBorder ? (
-                  <SettingResetButton
-                    label="stitch border"
-                    onClick={() =>
-                      updateSettings({
-                        showStitchBorder: defaults.showStitchBorder,
-                      })
-                    }
-                  />
-                ) : null
-              }
-              control={
-                <Switch
-                  checked={settings.showStitchBorder}
-                  onCheckedChange={(checked) =>
-                    updateSettings({
-                      showStitchBorder: Boolean(checked),
-                    })
-                  }
-                  aria-label="Show stitch border"
-                />
-              }
-            />
-
-            <SettingsRow
               title="Assistant output"
               description="Show token-by-token output while a response is in progress."
               resetAction={

--- a/apps/web/src/routes/_chat.settings.style.tsx
+++ b/apps/web/src/routes/_chat.settings.style.tsx
@@ -352,34 +352,6 @@ function SettingsStyleRouteView() {
               />
             }
           />
-
-          <SettingsRow
-            title="Stitch border"
-            description="Show the decorative stitch border around the viewport."
-            resetAction={
-              settings.showStitchBorder !== defaults.showStitchBorder ? (
-                <SettingResetButton
-                  label="stitch border"
-                  onClick={() =>
-                    updateSettings({
-                      showStitchBorder: defaults.showStitchBorder,
-                    })
-                  }
-                />
-              ) : null
-            }
-            control={
-              <Switch
-                checked={settings.showStitchBorder}
-                onCheckedChange={(checked) =>
-                  updateSettings({
-                    showStitchBorder: Boolean(checked),
-                  })
-                }
-                aria-label="Show stitch border"
-              />
-            }
-          />
         </SettingsSection>
 
         <SettingsSection


### PR DESCRIPTION
## Summary
- Remove the `Stitch border` toggle from both the main settings page and the style settings page.
- Stop surfacing `showStitchBorder` as a changed setting in the settings route context.
- Leave the underlying setting state intact; this change only hides the UI entrypoints.

## Testing
- Not run (PR description only).