### PR TITLE
Polish settings navigation and project icon picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,22 @@ See [docs/releases/v0.25.0.md](docs/releases/v0.25.0.md) for full notes and [doc
 ### Added
 
 - Add project icon file picker.
+- Add file-content search to workspace results.
+- Add hot tamale theme fonts and tokens.
+- Add Claude Opus 4.7 model support.
 
 ### Changed
 
 - Clarify OpenClaw gateway auth terminology.
 - Extract provider status refresh button.
 - Allow unsigned Windows artifacts when signing is unavailable.
+- Dock terminal below the right panel on desktop.
+- Remove stitch border setting from settings UI.
+
+### Fixed
+
+- Fix transport state snapshots in React hooks.
+- Fix settings deep-link for projects section.
 
 ## [0.24.0] - 2026-04-14
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -146,6 +146,12 @@ export function findLatestRevertableUserMessageId(
   return null;
 }
 
+/**
+ * Extension point for injecting hidden provider-level input alongside user
+ * messages.  Currently returns `undefined` — no hidden guidance is added.
+ * The function signature is kept so the call sites and tests stay wired up;
+ * future prompt-enhancement features will implement the body.
+ */
 export function buildHiddenProviderInput(options: {
   prompt: string;
   terminalContexts: ReadonlyArray<TerminalContextDraft>;

--- a/apps/web/src/hooks/useProjectIconFilePicker.ts
+++ b/apps/web/src/hooks/useProjectIconFilePicker.ts
@@ -2,9 +2,12 @@ import { useCallback, useRef, type ChangeEvent } from "react";
 
 import { readFileAsDataUrl } from "~/lib/fileData";
 
-export function useProjectIconFilePicker(options: { onFileSelected: (dataUrl: string) => void }) {
+export function useProjectIconFilePicker(options: {
+  onFileSelected: (dataUrl: string) => void;
+  onError?: (error: unknown) => void;
+}) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { onFileSelected } = options;
+  const { onFileSelected, onError } = options;
 
   const openFilePicker = useCallback(() => {
     fileInputRef.current?.click();
@@ -22,10 +25,10 @@ export function useProjectIconFilePicker(options: { onFileSelected: (dataUrl: st
         const dataUrl = await readFileAsDataUrl(file);
         onFileSelected(dataUrl);
       } catch (error) {
-        console.error("Failed to read project icon image:", error);
+        onError?.(error);
       }
     },
-    [onFileSelected],
+    [onFileSelected, onError],
   );
 
   return {

--- a/apps/web/src/routes/_chat.settings.index.tsx
+++ b/apps/web/src/routes/_chat.settings.index.tsx
@@ -2142,6 +2142,7 @@ export const Route = createFileRoute("/_chat/settings/")({
       section === "authentication" ||
       section === "hotkeys" ||
       section === "environment" ||
+      section === "projects" ||
       section === "git" ||
       section === "models" ||
       section === "mobile" ||


### PR DESCRIPTION
## Summary
- Add support for the `projects` settings deep-link so the projects section opens correctly.
- Let the project icon file picker surface read errors through an optional callback instead of logging directly.
- Add a brief code comment for the hidden provider input helper to clarify its current no-op behavior.
- Update the changelog with the latest release notes.

## Testing
- Not run (not requested).
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`