### PR TITLE
Widen sidebar footer separator and align Capacitor versions

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -704,7 +704,7 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
 function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
-      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      className={cn("mx-2 w-[calc(100%-1rem)] bg-sidebar-border", className)}
       data-sidebar="separator"
       data-slot="sidebar-separator"
       {...props}


### PR DESCRIPTION
## Summary
- Widened the sidebar footer separator so it spans the full content width instead of stopping short.
- Aligned the mobile app’s Capacitor dependencies and lockfile to `8.3.0`.
- Updated the SwiftPM pin for `capacitor-swift-pm` to match the same Capacitor version set.

## Testing
- Not run (changes reviewed from diff only).
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`