### PR TITLE
Scope preview open state to thread and add streaming code cards

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -434,10 +434,10 @@ export default function ChatView({
   const navigate = useNavigate();
   const activeProjectId = threads.find((t) => t.id === threadId)?.projectId ?? null;
   const previewOpen = usePreviewStateStore((state) =>
-    activeProjectId ? (state.openByProjectId[activeProjectId] ?? false) : false,
+    activeThreadId ? (state.openByThreadId[activeThreadId] ?? false) : false,
   );
-  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleProjectOpen);
-  const setPreviewOpen = usePreviewStateStore((state) => state.setProjectOpen);
+  const togglePreviewOpen = usePreviewStateStore((state) => state.toggleThreadOpen);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
   const previewDock = usePreviewStateStore((state) =>
     activeProjectId ? (state.dockByProjectId[activeProjectId] ?? "top") : "top",
   );
@@ -1747,7 +1747,7 @@ export default function ChatView({
   const handlePreviewUrl = useCallback(
     (url: string) => {
       if (!activeProject || !activeThread) return;
-      setPreviewOpen(activeProject.id, true);
+      setPreviewOpen(activeThread.id, true);
       void previewBridgeRef?.createTab({ url });
     },
     [activeProject, activeThread, setPreviewOpen, previewBridgeRef],
@@ -4937,7 +4937,7 @@ export default function ChatView({
           onImportProjectScripts={importProjectScripts}
           onToggleTerminal={toggleTerminalVisibility}
           onPrefetchTerminal={preloadThreadTerminalDrawer}
-          onTogglePreview={() => activeProjectId && togglePreviewOpen(activeProjectId)}
+          onTogglePreview={() => activeThreadId && togglePreviewOpen(activeThreadId)}
           onTogglePreviewLayout={() => activeProjectId && togglePreviewLayout(activeProjectId)}
           onMinimize={onMinimize}
         />
@@ -4980,7 +4980,7 @@ export default function ChatView({
                   key={previewPanelKey ?? undefined}
                   projectId={activeProject!.id}
                   threadId={threadId}
-                  onClose={() => setPreviewOpen(activeProject!.id, false)}
+                  onClose={() => setPreviewOpen(threadId, false)}
                 />
               </div>
               <div
@@ -5003,7 +5003,7 @@ export default function ChatView({
                 key={previewPanelKey ?? undefined}
                 projectId={activeProject!.id}
                 threadId={threadId}
-                onClose={() => setPreviewOpen(activeProject!.id, false)}
+                onClose={() => setPreviewOpen(threadId, false)}
               />
             </div>
           ) : null}
@@ -5884,7 +5884,7 @@ export default function ChatView({
                   key={previewPanelKey ?? undefined}
                   projectId={activeProject!.id}
                   threadId={threadId}
-                  onClose={() => setPreviewOpen(activeProject!.id, false)}
+                  onClose={() => setPreviewOpen(threadId, false)}
                 />
               </div>
             </>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -367,7 +367,7 @@ export default function GitActionsControl({
   activeProjectId,
 }: GitActionsControlProps) {
   const { settings } = useAppSettings();
-  const setPreviewOpen = usePreviewStateStore((state) => state.setProjectOpen);
+  const setPreviewOpen = usePreviewStateStore((state) => state.setThreadOpen);
   const openFileInViewer = useFileViewNavigation();
   const threadToastData = useMemo(
     () => (activeThreadId ? { threadId: activeThreadId } : undefined),

--- a/apps/web/src/components/PreviewPanel.tsx
+++ b/apps/web/src/components/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import type { PreviewTabsState, PreviewTabState, ProjectId } from "@okcode/contracts";
+import type { PreviewTabsState, PreviewTabState, ProjectId, ThreadId } from "@okcode/contracts";
 import { type FormEvent, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   ChevronLeftIcon,
@@ -111,7 +111,7 @@ function tabDisplayTitle(tab: PreviewTabState): string {
 
 interface PreviewPanelProps {
   projectId: ProjectId;
-  threadId: string;
+  threadId: ThreadId;
   onClose: () => void;
 }
 
@@ -149,7 +149,7 @@ function resolveViewportDimensions(
 export function PreviewPanel({ projectId, threadId, onClose }: PreviewPanelProps) {
   const { settings } = useAppSettings();
   const previewBridge = readDesktopPreviewBridge();
-  const setProjectOpen = usePreviewStateStore((state) => state.setProjectOpen);
+  const setThreadOpen = usePreviewStateStore((state) => state.setThreadOpen);
   const favoriteUrls = usePreviewStateStore((state) => state.favoriteUrls);
   const toggleFavoriteUrl = usePreviewStateStore((state) => state.toggleFavoriteUrl);
   const presetId = usePreviewStateStore((state) => state.presetByProjectId[projectId] ?? null);
@@ -422,7 +422,7 @@ export function PreviewPanel({ projectId, threadId, onClose }: PreviewPanelProps
   };
 
   const onClosePreview = () => {
-    setProjectOpen(projectId, false);
+    setThreadOpen(threadId, false);
     void previewBridge?.closeAll();
     onClose();
   };

--- a/apps/web/src/hooks/useLayoutActions.ts
+++ b/apps/web/src/hooks/useLayoutActions.ts
@@ -137,7 +137,7 @@ export function useLayoutActions(): UseLayoutActionsResult {
       const diffViewerOpen = diffState.isOpen;
       const simulationOpen = useSimulationViewerStore.getState().isOpen;
       const previewState = usePreviewStateStore.getState();
-      const previewOpen = projectId ? (previewState.openByProjectId[projectId] ?? false) : false;
+      const previewOpen = threadId ? (previewState.openByThreadId[threadId] ?? false) : false;
 
       const terminalStoreState = useTerminalStateStore.getState();
       const threadTerminal = threadId
@@ -184,8 +184,8 @@ export function useLayoutActions(): UseLayoutActionsResult {
       if (codeViewerStore.isOpen) codeViewerStore.close();
       if (diffViewerStore.isOpen) diffViewerStore.close();
       if (simulationStore.isOpen) simulationStore.close();
-      if (projectId && previewStore.openByProjectId[projectId]) {
-        previewStore.setProjectOpen(projectId, false);
+      if (threadId && previewStore.openByThreadId[threadId]) {
+        previewStore.setThreadOpen(threadId, false);
       }
 
       // ── 2. Open the target panel ───────────────────────────────
@@ -199,8 +199,8 @@ export function useLayoutActions(): UseLayoutActionsResult {
           }
           break;
         case "preview":
-          if (projectId) {
-            usePreviewStateStore.getState().setProjectOpen(projectId, true);
+          if (threadId) {
+            usePreviewStateStore.getState().setThreadOpen(threadId, true);
           }
           break;
         case "simulation":

--- a/apps/web/src/lib/openGitHubUrl.ts
+++ b/apps/web/src/lib/openGitHubUrl.ts
@@ -10,7 +10,7 @@ export interface OpenGitHubUrlInput {
   threadId: ThreadId | null;
   nativeApi?: NativeApi | undefined;
   previewBridge?: DesktopBridge["preview"] | null | undefined;
-  setPreviewOpen?: ((projectId: ProjectId, open: boolean) => void) | undefined;
+  setPreviewOpen?: ((threadId: ThreadId, open: boolean) => void) | undefined;
 }
 
 function isGitHubHttpUrl(url: string): boolean {

--- a/apps/web/src/lib/openUrlInAppBrowser.test.ts
+++ b/apps/web/src/lib/openUrlInAppBrowser.test.ts
@@ -29,7 +29,7 @@ describe("openUrlInAppBrowser", () => {
     });
 
     expect(result).toBe("preview");
-    expect(setPreviewOpen).toHaveBeenCalledWith(projectId("project-1"), true);
+    expect(setPreviewOpen).toHaveBeenCalledWith(threadId("thread-1"), true);
     expect(createTab).toHaveBeenCalledWith({
       url: "https://tweakcn.com",
       threadId: threadId("thread-1"),

--- a/apps/web/src/lib/openUrlInAppBrowser.ts
+++ b/apps/web/src/lib/openUrlInAppBrowser.ts
@@ -10,7 +10,7 @@ export interface OpenUrlInAppBrowserInput {
   threadId: ThreadId | null;
   nativeApi?: NativeApi | undefined;
   previewBridge?: DesktopBridge["preview"] | null | undefined;
-  setPreviewOpen?: ((projectId: ProjectId, open: boolean) => void) | undefined;
+  setPreviewOpen?: ((threadId: ThreadId, open: boolean) => void) | undefined;
   popOut?: boolean | undefined;
 }
 
@@ -18,10 +18,10 @@ export async function openUrlInAppBrowser(
   input: OpenUrlInAppBrowserInput,
 ): Promise<"preview" | "popout" | "external"> {
   const previewBridge = input.previewBridge ?? readDesktopPreviewBridge();
-  const setPreviewOpen = input.setPreviewOpen ?? usePreviewStateStore.getState().setProjectOpen;
+  const setPreviewOpen = input.setPreviewOpen ?? usePreviewStateStore.getState().setThreadOpen;
 
   if (previewBridge !== null && input.projectId !== null && input.threadId !== null) {
-    setPreviewOpen(input.projectId, true);
+    setPreviewOpen(input.threadId, true);
     await previewBridge.createTab({ url: input.url, threadId: input.threadId });
     if (input.popOut) {
       await previewBridge.popOut();

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const STORAGE_KEY = "okcode:desktop-preview:v5";
+const STORAGE_KEY = "okcode:desktop-preview:v6";
 
 let usePreviewStateStore: typeof import("./previewStateStore").usePreviewStateStore;
 let storage: Map<string, string>;
@@ -26,7 +26,7 @@ describe("previewStateStore", () => {
 
     ({ usePreviewStateStore } = await import("./previewStateStore"));
     usePreviewStateStore.setState({
-      openByProjectId: {},
+      openByThreadId: {},
       dockByProjectId: {},
       sizeByProjectId: {},
       presetByProjectId: {},
@@ -50,29 +50,47 @@ describe("previewStateStore", () => {
     expect(usePreviewStateStore.getState().favoriteUrls).not.toContain("http://localhost:3000/");
   });
 
-  it("toggles project open state", () => {
+  it("toggles thread open state", () => {
     const store = usePreviewStateStore.getState();
-    const projectId = "test-project-id" as any;
+    const threadId = "test-thread-id" as any;
 
-    store.setProjectOpen(projectId, true);
-    expect(usePreviewStateStore.getState().openByProjectId[projectId]).toBe(true);
-    expect(storage.get(STORAGE_KEY)).toContain('"openByProjectId"');
+    store.setThreadOpen(threadId, true);
+    expect(usePreviewStateStore.getState().openByThreadId[threadId]).toBe(true);
+    expect(storage.get(STORAGE_KEY)).toContain('"openByThreadId"');
 
-    store.toggleProjectOpen(projectId);
-    expect(usePreviewStateStore.getState().openByProjectId[projectId]).toBe(false);
+    store.toggleThreadOpen(threadId);
+    expect(usePreviewStateStore.getState().openByThreadId[threadId]).toBe(false);
   });
 
-  it("scopes open state per project", () => {
+  it("scopes open state per thread", () => {
     const store = usePreviewStateStore.getState();
-    const projectA = "project-a" as any;
-    const projectB = "project-b" as any;
+    const threadA = "thread-a" as any;
+    const threadB = "thread-b" as any;
 
-    store.setProjectOpen(projectA, true);
-    expect(usePreviewStateStore.getState().openByProjectId[projectA]).toBe(true);
-    expect(usePreviewStateStore.getState().openByProjectId[projectB]).toBeUndefined();
+    store.setThreadOpen(threadA, true);
+    expect(usePreviewStateStore.getState().openByThreadId[threadA]).toBe(true);
+    expect(usePreviewStateStore.getState().openByThreadId[threadB]).toBeUndefined();
 
-    store.setProjectOpen(projectB, false);
-    expect(usePreviewStateStore.getState().openByProjectId[projectA]).toBe(true);
-    expect(usePreviewStateStore.getState().openByProjectId[projectB]).toBe(false);
+    store.setThreadOpen(threadB, false);
+    expect(usePreviewStateStore.getState().openByThreadId[threadA]).toBe(true);
+    expect(usePreviewStateStore.getState().openByThreadId[threadB]).toBe(false);
+  });
+
+  it("does not migrate old project-scoped open state into the new thread-scoped field", async () => {
+    storage.set(
+      "okcode:desktop-preview:v5",
+      JSON.stringify({
+        openByProjectId: { "project-a": true },
+        dockByProjectId: { "project-a": "top" },
+        sizeByProjectId: { "project-a": 420 },
+      }),
+    );
+
+    vi.resetModules();
+    ({ usePreviewStateStore } = await import("./previewStateStore"));
+
+    expect(usePreviewStateStore.getState().openByThreadId).toEqual({});
+    expect(usePreviewStateStore.getState().dockByProjectId["project-a"]).toBe("top");
+    expect(usePreviewStateStore.getState().sizeByProjectId["project-a"]).toBe(420);
   });
 });

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -1,4 +1,4 @@
-import type { ProjectId } from "@okcode/contracts";
+import type { ProjectId, ThreadId } from "@okcode/contracts";
 import { create } from "zustand";
 
 import type { BrowserPresetId } from "./lib/browserPresets";
@@ -13,7 +13,7 @@ export interface CustomViewport {
 }
 
 interface PersistedPreviewUiState {
-  openByProjectId: Record<string, boolean>;
+  openByThreadId: Record<string, boolean>;
   dockByProjectId: Record<string, PreviewDock>;
   sizeByProjectId: Record<string, number>;
   presetByProjectId: Record<string, BrowserPresetId>;
@@ -26,8 +26,8 @@ interface PersistedPreviewUiState {
 }
 
 interface PreviewStateStore extends PersistedPreviewUiState {
-  setProjectOpen: (projectId: ProjectId, open: boolean) => void;
-  toggleProjectOpen: (projectId: ProjectId) => void;
+  setThreadOpen: (threadId: ThreadId, open: boolean) => void;
+  toggleThreadOpen: (threadId: ThreadId) => void;
   setProjectDock: (projectId: ProjectId, dock: PreviewDock) => void;
   toggleProjectLayout: (projectId: ProjectId) => void;
   setProjectSize: (projectId: ProjectId, size: number) => void;
@@ -42,7 +42,8 @@ interface PreviewStateStore extends PersistedPreviewUiState {
   toggleFullscreen: (projectId: ProjectId) => void;
 }
 
-const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v5";
+const PREVIEW_STATE_STORAGE_KEY = "okcode:desktop-preview:v6";
+const PREVIEW_STATE_STORAGE_KEY_V5 = "okcode:desktop-preview:v5";
 const PREVIEW_STATE_STORAGE_KEY_V4 = "okcode:desktop-preview:v4";
 
 const VALID_PRESETS = new Set<string>([
@@ -88,7 +89,7 @@ function clampCustomViewport(viewport: CustomViewport): CustomViewport {
 
 function createEmptyPersistedPreviewUiState(): PersistedPreviewUiState {
   return {
-    openByProjectId: {},
+    openByThreadId: {},
     dockByProjectId: {},
     sizeByProjectId: {},
     presetByProjectId: {},
@@ -113,8 +114,11 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
   }
 
   try {
-    // Try v5 first, fall back to v4 for migration
+    // Try v6 first, then older keys for migration.
     let raw = window.localStorage.getItem(PREVIEW_STATE_STORAGE_KEY);
+    if (!raw) {
+      raw = window.localStorage.getItem(PREVIEW_STATE_STORAGE_KEY_V5);
+    }
     if (!raw) {
       raw = window.localStorage.getItem(PREVIEW_STATE_STORAGE_KEY_V4);
     }
@@ -124,10 +128,10 @@ function readPersistedPreviewUiState(): PersistedPreviewUiState {
 
     const parsed = JSON.parse(raw) as Partial<PersistedPreviewUiState>;
     return {
-      openByProjectId:
-        parsed.openByProjectId && typeof parsed.openByProjectId === "object"
+      openByThreadId:
+        parsed.openByThreadId && typeof parsed.openByThreadId === "object"
           ? Object.fromEntries(
-              Object.entries(parsed.openByProjectId).filter(
+              Object.entries(parsed.openByThreadId).filter(
                 (entry): entry is [string, boolean] =>
                   typeof entry[0] === "string" && typeof entry[1] === "boolean",
               ),
@@ -224,7 +228,7 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
     window.localStorage.setItem(
       PREVIEW_STATE_STORAGE_KEY,
       JSON.stringify({
-        openByProjectId: state.openByProjectId,
+        openByThreadId: state.openByThreadId,
         dockByProjectId: state.dockByProjectId,
         sizeByProjectId: state.sizeByProjectId,
         presetByProjectId: state.presetByProjectId,
@@ -242,7 +246,7 @@ function persistPreviewUiState(state: PersistedPreviewUiState): void {
 
 function snapshotState(state: PreviewStateStore): PersistedPreviewUiState {
   return {
-    openByProjectId: state.openByProjectId,
+    openByThreadId: state.openByThreadId,
     dockByProjectId: state.dockByProjectId,
     sizeByProjectId: state.sizeByProjectId,
     presetByProjectId: state.presetByProjectId,
@@ -259,16 +263,16 @@ const initialState = readPersistedPreviewUiState();
 export const usePreviewStateStore = create<PreviewStateStore>((set, get) => ({
   ...initialState,
 
-  setProjectOpen: (projectId, open) => {
+  setThreadOpen: (threadId, open) => {
     set((state) => {
-      const nextOpenByProjectId = { ...state.openByProjectId, [projectId]: open };
-      persistPreviewUiState({ ...snapshotState(state), openByProjectId: nextOpenByProjectId });
-      return { openByProjectId: nextOpenByProjectId };
+      const nextOpenByThreadId = { ...state.openByThreadId, [threadId]: open };
+      persistPreviewUiState({ ...snapshotState(state), openByThreadId: nextOpenByThreadId });
+      return { openByThreadId: nextOpenByThreadId };
     });
   },
 
-  toggleProjectOpen: (projectId) => {
-    get().setProjectOpen(projectId, !(get().openByProjectId[projectId] ?? false));
+  toggleThreadOpen: (threadId) => {
+    get().setThreadOpen(threadId, !(get().openByThreadId[threadId] ?? false));
   },
 
   setProjectDock: (projectId, _dock) => {

--- a/docs/superpowers/plans/2026-04-20-thread-scoped-preview-open-state.md
+++ b/docs/superpowers/plans/2026-04-20-thread-scoped-preview-open-state.md
@@ -1,0 +1,56 @@
+# Thread-Scoped Preview Open State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make browser preview visibility follow the active thread instead of the project so switching threads does not auto-open preview unless that thread already had it open.
+
+**Architecture:** Keep preview configuration such as layout, size, and presets scoped to the project because those are workspace-level preferences. Move only the open/closed bit to thread scope and update selectors, mutators, and layout capture/apply paths to use `threadId`.
+
+**Tech Stack:** React, Zustand, TypeScript, Vitest, Bun
+
+---
+
+### Task 1: Lock the Bug Down With Tests
+
+**Files:**
+
+- Modify: `apps/web/src/previewStateStore.test.ts`
+
+- [ ] Add a failing store test proving preview open state is keyed by thread and does not bleed across sibling threads in the same project.
+- [ ] Add a failing store test proving persisted thread-open state is written under the new thread-scoped field.
+- [ ] Run: `bun run vitest apps/web/src/previewStateStore.test.ts`
+
+### Task 2: Move Preview Open State to Thread Scope
+
+**Files:**
+
+- Modify: `apps/web/src/previewStateStore.ts`
+
+- [ ] Replace project-scoped preview open state with thread-scoped state and update persistence shape.
+- [ ] Preserve project-scoped preview layout metadata and migrate older persisted data without carrying forward stale open state.
+- [ ] Run: `bun run vitest apps/web/src/previewStateStore.test.ts`
+
+### Task 3: Update Preview Consumers
+
+**Files:**
+
+- Modify: `apps/web/src/components/ChatView.tsx`
+- Modify: `apps/web/src/components/PreviewPanel.tsx`
+- Modify: `apps/web/src/hooks/useLayoutActions.ts`
+- Modify: `apps/web/src/lib/openUrlInAppBrowser.ts`
+- Modify: `apps/web/src/lib/openUrlInAppBrowser.test.ts`
+- Modify: `apps/web/src/components/GitActionsControl.tsx`
+
+- [ ] Update preview selectors and open/close callbacks to use the active `threadId`.
+- [ ] Keep preview layout capture/apply using project-scoped layout settings while using thread-scoped visibility.
+- [ ] Run focused tests for affected helpers.
+
+### Task 4: Verify Repo Gates
+
+**Files:**
+
+- Modify: any files from prior tasks only if verification exposes issues
+
+- [ ] Run: `bun fmt`
+- [ ] Run: `bun lint`
+- [ ] Run: `bun typecheck`


### PR DESCRIPTION
## Summary
- Scope preview open state to the active thread instead of the project, so preview visibility no longer leaks across threads.
- Add a dedicated streaming code preview card with live status, metadata, and copy support for assistant code fences.
- Refactor markdown code block rendering to support progressive highlighting, fallback rendering, and cleaner shared preview metadata.
- Update preview-related state persistence and tests for the new thread-scoped behavior.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Added and updated Vitest coverage for streaming code preview metadata, preview card rendering, message timeline rendering, and preview state persistence