### PR TITLE
Add diff previews for file attachments in chat

### DIFF
--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -64,6 +64,7 @@ import {
   ProjectionSnapshotQuery,
   type ProjectionSnapshotQueryShape,
 } from "./orchestration/Services/ProjectionSnapshotQuery";
+import { createAttachmentId } from "./attachmentStore";
 
 const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
 const asProviderItemId = (value: string): ProviderItemId => ProviderItemId.makeUnsafe(value);
@@ -685,6 +686,29 @@ describe("WebSocket Server", () => {
     expect(response.headers.get("content-type")).toContain("image/png");
     const bytes = Buffer.from(await response.arrayBuffer());
     expect(bytes).toEqual(Buffer.from("hello-attachment"));
+  });
+
+  it("serves persisted attachments by attachment id", async () => {
+    const baseDir = makeTempDir("okcode-state-attachment-id-");
+    const { attachmentsDir } = deriveServerPathsSync(baseDir, undefined);
+    const attachmentId = createAttachmentId("thread-preview");
+    if (!attachmentId) {
+      throw new Error("Failed to create a safe test attachment id.");
+    }
+    const attachmentPath = path.join(attachmentsDir, `${attachmentId}.patch`);
+    fs.mkdirSync(path.dirname(attachmentPath), { recursive: true });
+    fs.writeFileSync(attachmentPath, Buffer.from("diff --git a/a.ts b/a.ts\n"));
+
+    const { cwd } = makeWorkspaceFixture("project");
+    server = await createTestServer({ cwd, baseDir });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    const response = await fetch(`http://127.0.0.1:${port}/attachments/${attachmentId}`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/x-diff");
+    expect(await response.text()).toContain("diff --git");
   });
 
   it("serves persisted attachments for URL-encoded paths", async () => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -137,6 +137,26 @@ function isNewerSemver(a: string, b: string): boolean {
   return false;
 }
 
+function inferAttachmentContentType(filePath: string): string {
+  const mimeType = Mime.getType(filePath);
+  if (mimeType) {
+    return mimeType;
+  }
+
+  const normalizedPath = filePath.toLowerCase();
+  if (normalizedPath.endsWith(".patch") || normalizedPath.endsWith(".diff")) {
+    return "text/x-diff; charset=utf-8";
+  }
+  if (normalizedPath.endsWith(".md")) {
+    return "text/markdown; charset=utf-8";
+  }
+  if (normalizedPath.endsWith(".txt")) {
+    return "text/plain; charset=utf-8";
+  }
+
+  return "application/octet-stream";
+}
+
 /**
  * Remote address from the HTTP upgrade (`request.socket`). The `ws` library often does not
  * expose a reliable `socket.remoteAddress` when handling messages, so we capture it here.
@@ -717,7 +737,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
             return;
           }
 
-          const contentType = Mime.getType(filePath) ?? "application/octet-stream";
+          const contentType = inferAttachmentContentType(filePath);
           res.writeHead(200, {
             "Content-Type": contentType,
             "Cache-Control": "public, max-age=31536000, immutable",

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,4 +1,3 @@
-import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -18,7 +17,8 @@ import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { buildAcceptedDiffFileKey, filterAcceptedDiffFiles } from "../lib/diffPanelAcceptance";
 import { checkpointDiffQueryOptions } from "../lib/providerReactQuery";
-import { buildPatchCacheKey, resolveDiffThemeName } from "../lib/diffRendering";
+import { resolveDiffThemeName } from "../lib/diffRendering";
+import { parseRenderablePatch } from "../lib/renderablePatch";
 import { cn } from "../lib/utils";
 import { useStore } from "../store";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
@@ -94,42 +94,6 @@ const DIFF_PANEL_UNSAFE_CSS = `
   text-decoration-color: currentColor;
 }
 `;
-
-type RenderablePatch =
-  | { kind: "files"; files: FileDiffMetadata[] }
-  | { kind: "raw"; text: string; reason: string };
-
-function getRenderablePatch(
-  patch: string | undefined,
-  cacheScope = "diff-panel",
-): RenderablePatch | null {
-  if (!patch) return null;
-  const normalizedPatch = patch.trim();
-  if (normalizedPatch.length === 0) return null;
-
-  try {
-    const parsedPatches = parsePatchFiles(
-      normalizedPatch,
-      buildPatchCacheKey(normalizedPatch, cacheScope),
-    );
-    const files = parsedPatches.flatMap((parsedPatch) => parsedPatch.files);
-    if (files.length > 0) {
-      return { kind: "files", files };
-    }
-
-    return {
-      kind: "raw",
-      text: normalizedPatch,
-      reason: "Unsupported diff format. Showing raw patch.",
-    };
-  } catch {
-    return {
-      kind: "raw",
-      text: normalizedPatch,
-      reason: "Failed to parse patch. Showing raw patch.",
-    };
-  }
-}
 
 type FileDiffCategory = "all" | "added" | "modified" | "deleted" | "renamed";
 
@@ -256,7 +220,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         ? "Failed to load checkpoint diff."
         : null;
   const renderablePatch = useMemo(
-    () => getRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}`),
+    () => parseRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}`),
     [resolvedTheme, selectedPatch],
   );
   const renderableFiles = useMemo(() => {

--- a/apps/web/src/components/chat/AttachmentPreviewDialog.tsx
+++ b/apps/web/src/components/chat/AttachmentPreviewDialog.tsx
@@ -1,0 +1,227 @@
+import { FileDiff } from "@pierre/diffs/react";
+import { TurnId } from "@okcode/contracts";
+import { ExternalLinkIcon, LoaderCircleIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import type { ChatFileAttachment } from "../../types";
+import {
+  buildAttachmentPreviewModel,
+  buildAttachmentPreviewTreeFiles,
+  type AttachmentPreviewModel,
+} from "../../lib/attachmentPreview";
+import { resolveDiffThemeName } from "../../lib/diffRendering";
+import { ChangedFilesTree } from "./ChangedFilesTree";
+import { PR_REVIEW_DIFF_UNSAFE_CSS, resolveFileDiffPath } from "../pr-review/pr-review-utils";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../ui/dialog";
+
+interface AttachmentPreviewDialogProps {
+  attachment: ChatFileAttachment;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  resolvedTheme: "light" | "dark";
+}
+
+interface AttachmentPreviewState {
+  status: "idle" | "loading" | "ready" | "error";
+  preview: AttachmentPreviewModel | null;
+  error: string | null;
+}
+
+function emptyPreviewState(): AttachmentPreviewState {
+  return {
+    status: "idle",
+    preview: null,
+    error: null,
+  };
+}
+
+export function AttachmentPreviewDialog({
+  attachment,
+  open,
+  onOpenChange,
+  resolvedTheme,
+}: AttachmentPreviewDialogProps) {
+  const [state, setState] = useState<AttachmentPreviewState>(() => emptyPreviewState());
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setState(emptyPreviewState());
+      setSelectedFilePath(null);
+      return;
+    }
+    if (!attachment.url) {
+      setState({
+        status: "error",
+        preview: null,
+        error: "This attachment does not have a preview URL.",
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({
+      status: "loading",
+      preview: null,
+      error: null,
+    });
+
+    void fetch(attachment.url, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load attachment (${response.status}).`);
+        }
+        const text = await response.text();
+        if (controller.signal.aborted) return;
+        const preview = buildAttachmentPreviewModel({
+          name: attachment.name,
+          mimeType: attachment.mimeType,
+          text,
+        });
+        const firstDiffFilePath =
+          preview.kind === "diff" && preview.files[0]
+            ? resolveFileDiffPath(preview.files[0])
+            : null;
+        setState({
+          status: "ready",
+          preview,
+          error: null,
+        });
+        setSelectedFilePath(firstDiffFilePath);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setState({
+          status: "error",
+          preview: null,
+          error: error instanceof Error ? error.message : "Failed to load attachment preview.",
+        });
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [attachment.mimeType, attachment.name, attachment.url, open]);
+
+  const diffFiles = useMemo(
+    () =>
+      state.preview?.kind === "diff" ? buildAttachmentPreviewTreeFiles(state.preview.files) : [],
+    [state.preview],
+  );
+  const selectedDiffFile = useMemo(() => {
+    if (state.preview?.kind !== "diff") {
+      return null;
+    }
+    if (state.preview.files.length === 0) {
+      return null;
+    }
+    return (
+      state.preview.files.find((fileDiff) => resolveFileDiffPath(fileDiff) === selectedFilePath) ??
+      state.preview.files[0] ??
+      null
+    );
+  }, [selectedFilePath, state.preview]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-6xl">
+        <DialogHeader>
+          <DialogTitle>{attachment.name}</DialogTitle>
+          <DialogDescription>
+            {attachment.mimeType} · {new Intl.NumberFormat().format(attachment.sizeBytes)} bytes
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="min-h-[28rem]">
+          {state.status === "loading" && (
+            <div className="flex h-full min-h-[22rem] items-center justify-center gap-2 text-sm text-muted-foreground">
+              <LoaderCircleIcon className="size-4 animate-spin" />
+              Loading attachment preview…
+            </div>
+          )}
+
+          {state.status === "error" && (
+            <div className="flex h-full min-h-[22rem] flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border/70 bg-muted/20 px-6 text-center">
+              <p className="max-w-md text-sm text-muted-foreground">{state.error}</p>
+              {attachment.url && (
+                <a
+                  href={attachment.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex h-8 items-center justify-center gap-2 rounded-lg border border-foreground/12 bg-card px-3 text-xs font-medium text-foreground shadow-[inset_0_1px_0_hsl(0_0%_100%/0.06)] transition-all duration-200 hover:border-primary/35 hover:bg-accent/80"
+                >
+                  <ExternalLinkIcon className="size-3.5" />
+                  Open raw attachment
+                </a>
+              )}
+            </div>
+          )}
+
+          {state.status === "ready" && state.preview?.kind === "text" && (
+            <div className="rounded-xl border border-border/70 bg-background/70">
+              <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap break-all p-4 font-mono text-[12px] leading-5 text-foreground/85">
+                {state.preview.text}
+              </pre>
+            </div>
+          )}
+
+          {state.status === "ready" && state.preview?.kind === "diff" && selectedDiffFile && (
+            <div className="grid min-h-[28rem] gap-4 lg:grid-cols-[18rem_minmax(0,1fr)]">
+              <div className="rounded-xl border border-border/70 bg-background/70 p-2">
+                <ChangedFilesTree
+                  turnId={TurnId.makeUnsafe(`attachment-${attachment.id}`)}
+                  files={diffFiles}
+                  allDirectoriesExpanded
+                  resolvedTheme={resolvedTheme}
+                  cwd={undefined}
+                  onSelectFile={setSelectedFilePath}
+                  selectedFilePath={resolveFileDiffPath(selectedDiffFile)}
+                />
+              </div>
+              <div className="overflow-hidden rounded-xl border border-border/70 bg-background/70">
+                <div className="border-b border-border/70 px-4 py-3">
+                  <p className="truncate font-mono text-xs text-muted-foreground">
+                    {resolveFileDiffPath(selectedDiffFile)}
+                  </p>
+                </div>
+                <div className="max-h-[70vh] overflow-auto p-2">
+                  <FileDiff
+                    fileDiff={selectedDiffFile}
+                    options={{
+                      diffStyle: "unified",
+                      lineDiffType: "none",
+                      overflow: "wrap",
+                      theme: resolveDiffThemeName(resolvedTheme),
+                      themeType: resolvedTheme,
+                      unsafeCSS: PR_REVIEW_DIFF_UNSAFE_CSS,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </DialogPanel>
+        <DialogFooter variant="bare" className="justify-end gap-2">
+          {attachment.url && (
+            <a
+              href={attachment.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-8 items-center justify-center gap-2 rounded-lg border border-foreground/12 bg-card px-3 text-xs font-medium text-foreground shadow-[inset_0_1px_0_hsl(0_0%_100%/0.06)] transition-all duration-200 hover:border-primary/35 hover:bg-accent/80"
+            >
+              <ExternalLinkIcon className="size-3.5" />
+              Open raw attachment
+            </a>
+          )}
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/chat/ChangedFilesTree.tsx
+++ b/apps/web/src/components/chat/ChangedFilesTree.tsx
@@ -22,8 +22,18 @@ export const ChangedFilesTree = memo(function ChangedFilesTree(props: {
   resolvedTheme: "light" | "dark";
   cwd: string | undefined;
   onOpenTurnDiff?: (turnId: TurnId, filePath?: string) => void;
+  onSelectFile?: (filePath: string) => void;
+  selectedFilePath?: string | undefined;
 }) {
-  const { files, allDirectoriesExpanded, resolvedTheme, cwd, onOpenTurnDiff } = props;
+  const {
+    files,
+    allDirectoriesExpanded,
+    resolvedTheme,
+    cwd,
+    onOpenTurnDiff,
+    onSelectFile,
+    selectedFilePath,
+  } = props;
   const fileManagerName =
     typeof navigator !== "undefined" && isMacPlatform(navigator.platform)
       ? "Finder"
@@ -226,9 +236,16 @@ export const ChangedFilesTree = memo(function ChangedFilesTree(props: {
       <button
         key={`file:${node.path}`}
         type="button"
-        className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
+        className={cn(
+          "group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80",
+          selectedFilePath === node.path && "bg-background/90",
+        )}
         style={{ paddingLeft: `${leftPadding}px` }}
         onClick={() => {
+          if (onSelectFile) {
+            onSelectFile(node.path);
+            return;
+          }
           if (onOpenTurnDiff) {
             onOpenTurnDiff(props.turnId, node.path);
             return;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -16,7 +16,7 @@ import {
 } from "@tanstack/react-virtual";
 import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
 import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX } from "../../chat-scroll";
-import { type TurnDiffSummary } from "../../types";
+import { type ChatMessage, type TurnDiffSummary } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import ChatMarkdown from "../ChatMarkdown";
 import {
@@ -43,6 +43,7 @@ import { estimateTimelineMessageHeight } from "../timelineHeight";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
+import { AttachmentPreviewDialog } from "./AttachmentPreviewDialog";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { InlineDiffBlock } from "./InlineDiffBlock";
 import { MessageCopyButton } from "./MessageCopyButton";
@@ -461,34 +462,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   </div>
                 )}
                 {userFiles.length > 0 && (
-                  <div className="mb-2 flex max-w-[420px] flex-wrap gap-2">
-                    {userFiles.map((attachment) => {
-                      const content = (
-                        <>
-                          <PaperclipIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                          <span className="truncate">{attachment.name}</span>
-                        </>
-                      );
-                      return attachment.url ? (
-                        <a
-                          key={attachment.id}
-                          href={attachment.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs transition-colors hover:bg-background"
-                        >
-                          {content}
-                        </a>
-                      ) : (
-                        <div
-                          key={attachment.id}
-                          className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs"
-                        >
-                          {content}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <MessageFileAttachments attachments={userFiles} resolvedTheme={resolvedTheme} />
                 )}
                 {(displayedUserMessage.visibleText.trim().length > 0 ||
                   terminalContexts.length > 0) && (
@@ -737,6 +711,85 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     </div>
   );
 });
+
+type TimelineFileAttachment = Extract<
+  NonNullable<ChatMessage["attachments"]>[number],
+  { type: "file" }
+>;
+
+function canPreviewFileAttachment(attachment: TimelineFileAttachment): boolean {
+  return Boolean(attachment.url);
+}
+
+function MessageFileAttachments(props: {
+  attachments: ReadonlyArray<TimelineFileAttachment>;
+  resolvedTheme: "light" | "dark";
+}) {
+  const [previewAttachmentId, setPreviewAttachmentId] = useState<string | null>(null);
+  const previewAttachment =
+    props.attachments.find((attachment) => attachment.id === previewAttachmentId) ?? null;
+
+  return (
+    <>
+      <div className="mb-2 flex max-w-[420px] flex-wrap gap-2">
+        {props.attachments.map((attachment) => {
+          const previewable = canPreviewFileAttachment(attachment) && Boolean(attachment.url);
+          const content = (
+            <>
+              <PaperclipIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{attachment.name}</span>
+              {previewable && <EyeIcon className="size-3.5 shrink-0 text-muted-foreground/80" />}
+            </>
+          );
+
+          if (previewable) {
+            return (
+              <button
+                key={attachment.id}
+                type="button"
+                className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs transition-colors hover:bg-background"
+                onClick={() => setPreviewAttachmentId(attachment.id)}
+              >
+                {content}
+              </button>
+            );
+          }
+
+          return attachment.url ? (
+            <a
+              key={attachment.id}
+              href={attachment.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs transition-colors hover:bg-background"
+            >
+              {content}
+            </a>
+          ) : (
+            <div
+              key={attachment.id}
+              className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs"
+            >
+              {content}
+            </div>
+          );
+        })}
+      </div>
+      {previewAttachment && (
+        <AttachmentPreviewDialog
+          attachment={previewAttachment}
+          open
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) {
+              setPreviewAttachmentId(null);
+            }
+          }}
+          resolvedTheme={props.resolvedTheme}
+        />
+      )}
+    </>
+  );
+}
 
 function EmptyTimelineGuidance({
   shortcutGuides,

--- a/apps/web/src/components/pr-review/pr-review-utils.tsx
+++ b/apps/web/src/components/pr-review/pr-review-utils.tsx
@@ -1,4 +1,4 @@
-import { parsePatchFiles, setLanguageOverride, type SupportedLanguages } from "@pierre/diffs";
+import { setLanguageOverride, type SupportedLanguages } from "@pierre/diffs";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import type {
   GitHubUserPreview,
@@ -10,17 +10,19 @@ import type {
 import { Schema } from "effect";
 import { CircleDotIcon, GitMergeIcon, GitPullRequestIcon, XCircleIcon } from "lucide-react";
 import { openInPreferredEditor } from "~/editorPreferences";
-import { buildPatchCacheKey } from "~/lib/diffRendering";
+import {
+  parseRenderablePatch,
+  resolveFileDiffPath,
+  summarizeFileDiffStats,
+} from "~/lib/renderablePatch";
 import { ensureNativeApi } from "~/nativeApi";
 import { inferLanguageIdForPath } from "~/vscode-icons";
+
+export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats };
 
 export type PullRequestState = "open" | "closed" | "merged";
 export type InspectorTab = "threads" | "workflow" | "people";
 export type RequestChangesButtonVariant = "default" | "destructive-outline" | "outline";
-
-export type RenderablePatch =
-  | { kind: "files"; files: FileDiffMetadata[] }
-  | { kind: "raw"; text: string; reason: string };
 
 export const TEXT_DRAFT_SCHEMA = Schema.String;
 export const REVIEWED_FILES_SCHEMA = Schema.Array(Schema.String);
@@ -143,27 +145,6 @@ export function labelStyle(hex: string) {
   return { backgroundColor: `#${hex}` };
 }
 
-export function summarizeFileDiffStats(fileDiff: FileDiffMetadata): {
-  additions: number;
-  deletions: number;
-} {
-  return fileDiff.hunks.reduce(
-    (summary, hunk) => ({
-      additions: summary.additions + hunk.additionLines,
-      deletions: summary.deletions + hunk.deletionLines,
-    }),
-    { additions: 0, deletions: 0 },
-  );
-}
-
-export function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
-  const raw = fileDiff.name ?? fileDiff.prevName ?? "";
-  if (raw.startsWith("a/") || raw.startsWith("b/")) {
-    return raw.slice(2);
-  }
-  return raw;
-}
-
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
   return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
 }
@@ -183,32 +164,6 @@ export function withInferredFileDiffLanguage(fileDiff: FileDiffMetadata): FileDi
     return fileDiff;
   }
   return setLanguageOverride(fileDiff, lang);
-}
-
-export function parseRenderablePatch(
-  patch: string | undefined,
-  scope = "pr-review",
-): RenderablePatch | null {
-  if (!patch || patch.trim().length === 0) return null;
-  const normalizedPatch = patch.trim();
-  try {
-    const parsed = parsePatchFiles(normalizedPatch, buildPatchCacheKey(normalizedPatch, scope));
-    const files = parsed.flatMap((entry) => entry.files);
-    if (files.length === 0) {
-      return {
-        kind: "raw",
-        text: normalizedPatch,
-        reason: "Unsupported diff format. Showing raw patch instead.",
-      };
-    }
-    return { kind: "files", files };
-  } catch {
-    return {
-      kind: "raw",
-      text: normalizedPatch,
-      reason: "Failed to parse patch. Showing raw patch instead.",
-    };
-  }
 }
 
 export function extractMentionQuery(

--- a/apps/web/src/lib/attachmentPreview.test.ts
+++ b/apps/web/src/lib/attachmentPreview.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAttachmentPreviewModel,
+  buildAttachmentPreviewTreeFiles,
+  isLikelyDiffAttachment,
+} from "./attachmentPreview";
+
+describe("isLikelyDiffAttachment", () => {
+  it("detects git patch attachments by file name", () => {
+    expect(
+      isLikelyDiffAttachment({
+        name: "changes.patch",
+        mimeType: "text/plain",
+        text: "plain text",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects unified diffs by content even without a patch extension", () => {
+    expect(
+      isLikelyDiffAttachment({
+        name: "notes.txt",
+        mimeType: "text/plain",
+        text: "diff --git a/apps/web/src/index.ts b/apps/web/src/index.ts\n",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("buildAttachmentPreviewModel", () => {
+  it("builds a diff preview for parseable patch attachments", () => {
+    const preview = buildAttachmentPreviewModel({
+      name: "changes.patch",
+      mimeType: "text/x-patch",
+      text: [
+        "diff --git a/apps/web/src/index.ts b/apps/web/src/index.ts",
+        "--- a/apps/web/src/index.ts",
+        "+++ b/apps/web/src/index.ts",
+        "@@ -1 +1 @@",
+        "-oldValue();",
+        "+newValue();",
+      ].join("\n"),
+    });
+
+    expect(preview.kind).toBe("diff");
+    if (preview.kind !== "diff") {
+      throw new Error("Expected a diff preview");
+    }
+
+    expect(preview.files).toHaveLength(1);
+    expect(preview.files[0] && buildAttachmentPreviewTreeFiles(preview.files)).toEqual([
+      {
+        path: "apps/web/src/index.ts",
+        additions: 1,
+        deletions: 1,
+      },
+    ]);
+  });
+
+  it("falls back to a text preview for non-diff attachments", () => {
+    const preview = buildAttachmentPreviewModel({
+      name: "README.md",
+      mimeType: "text/markdown",
+      text: "# Hello\n",
+    });
+
+    expect(preview).toEqual({
+      kind: "text",
+      text: "# Hello\n",
+      language: "markdown",
+    });
+  });
+});

--- a/apps/web/src/lib/attachmentPreview.ts
+++ b/apps/web/src/lib/attachmentPreview.ts
@@ -1,0 +1,76 @@
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+
+import type { TurnDiffFileChange } from "../types";
+import { inferLanguageIdForPath } from "../vscode-icons";
+import {
+  parseRenderablePatch,
+  resolveFileDiffPath,
+  summarizeFileDiffStats,
+} from "./renderablePatch";
+
+const DIFF_FILE_NAME_PATTERN = /\.(?:diff|patch)$/i;
+const DIFF_MIME_SUBSTRING_PATTERN = /(diff|patch)/i;
+const DIFF_CONTENT_PREFIXES = ["diff --git ", "Index: ", "--- ", "*** ", "Binary files "];
+
+export type AttachmentPreviewModel =
+  | {
+      kind: "diff";
+      text: string;
+      files: FileDiffMetadata[];
+    }
+  | {
+      kind: "text";
+      text: string;
+      language: string;
+    };
+
+export function isLikelyDiffAttachment(input: {
+  readonly name: string;
+  readonly mimeType: string;
+  readonly text: string;
+}): boolean {
+  if (DIFF_FILE_NAME_PATTERN.test(input.name)) {
+    return true;
+  }
+  if (DIFF_MIME_SUBSTRING_PATTERN.test(input.mimeType)) {
+    return true;
+  }
+  const trimmed = input.text.trimStart();
+  return DIFF_CONTENT_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+export function buildAttachmentPreviewTreeFiles(
+  files: ReadonlyArray<FileDiffMetadata>,
+): TurnDiffFileChange[] {
+  return files.map((fileDiff) => {
+    const stat = summarizeFileDiffStats(fileDiff);
+    return {
+      path: resolveFileDiffPath(fileDiff),
+      additions: stat.additions,
+      deletions: stat.deletions,
+    };
+  });
+}
+
+export function buildAttachmentPreviewModel(input: {
+  readonly name: string;
+  readonly mimeType: string;
+  readonly text: string;
+}): AttachmentPreviewModel {
+  if (isLikelyDiffAttachment(input)) {
+    const parsed = parseRenderablePatch(input.text, `attachment:${input.name}`);
+    if (parsed?.kind === "files") {
+      return {
+        kind: "diff",
+        text: input.text,
+        files: parsed.files,
+      };
+    }
+  }
+
+  return {
+    kind: "text",
+    text: input.text,
+    language: inferLanguageIdForPath(input.name) ?? "text",
+  };
+}

--- a/apps/web/src/lib/renderablePatch.ts
+++ b/apps/web/src/lib/renderablePatch.ts
@@ -1,0 +1,56 @@
+import { parsePatchFiles } from "@pierre/diffs";
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+
+import { buildPatchCacheKey } from "./diffRendering";
+
+export type RenderablePatch =
+  | { kind: "files"; files: FileDiffMetadata[] }
+  | { kind: "raw"; text: string; reason: string };
+
+export function parseRenderablePatch(
+  patch: string | undefined,
+  scope = "renderable-patch",
+): RenderablePatch | null {
+  if (!patch || patch.trim().length === 0) return null;
+  const normalizedPatch = patch.trim();
+
+  try {
+    const parsed = parsePatchFiles(normalizedPatch, buildPatchCacheKey(normalizedPatch, scope));
+    const files = parsed.flatMap((entry) => entry.files);
+    if (files.length === 0) {
+      return {
+        kind: "raw",
+        text: normalizedPatch,
+        reason: "Unsupported diff format. Showing raw patch instead.",
+      };
+    }
+    return { kind: "files", files };
+  } catch {
+    return {
+      kind: "raw",
+      text: normalizedPatch,
+      reason: "Failed to parse patch. Showing raw patch instead.",
+    };
+  }
+}
+
+export function summarizeFileDiffStats(fileDiff: FileDiffMetadata): {
+  additions: number;
+  deletions: number;
+} {
+  return fileDiff.hunks.reduce(
+    (summary, hunk) => ({
+      additions: summary.additions + hunk.additionLines,
+      deletions: summary.deletions + hunk.deletionLines,
+    }),
+    { additions: 0, deletions: 0 },
+  );
+}
+
+export function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
+  const raw = fileDiff.name ?? fileDiff.prevName ?? "";
+  if (raw.startsWith("a/") || raw.startsWith("b/")) {
+    return raw.slice(2);
+  }
+  return raw;
+}


### PR DESCRIPTION
## Summary
- Added in-app previews for chat file attachments, including diff rendering for patch-like uploads and text previews for plain files.
- Reused shared patch parsing and diff helpers in new `renderablePatch` and `attachmentPreview` modules to reduce duplication across chat and review UI.
- Updated the changed-files tree and attachment rendering so previewable files open a dedicated dialog with file selection and unified diff display.
- Improved attachment serving on the server to infer more precise content types for `.patch`, `.diff`, and text-based files.

## Testing
- `bun run test apps/web/src/lib/attachmentPreview.test.ts`
- `bun run test apps/server/src/wsServer.test.ts`
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`