### PR TITLE
Auto-scroll chat and hide empty diffs tab

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -606,6 +606,7 @@ export default function ChatView({
     LastInvokedScriptByProjectSchema,
   );
   const messagesScrollRef = useRef<HTMLDivElement>(null);
+  const messagesBottomRef = useRef<HTMLDivElement>(null);
   const [messagesScrollElement, setMessagesScrollElement] = useState<HTMLDivElement | null>(null);
   const shouldAutoScrollRef = useRef(true);
   const lastKnownScrollTopRef = useRef(0);
@@ -2318,9 +2319,13 @@ export default function ChatView({
   const messageCount = timelineMessages.length;
   const scrollMessagesToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const scrollContainer = messagesScrollRef.current;
-    if (!scrollContainer) return;
-    scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
-    lastKnownScrollTopRef.current = scrollContainer.scrollTop;
+    const bottomAnchor = messagesBottomRef.current;
+    if (!scrollContainer && !bottomAnchor) return;
+    bottomAnchor?.scrollIntoView({ block: "end", behavior });
+    scrollContainer?.scrollTo({ top: scrollContainer.scrollHeight, behavior });
+    if (scrollContainer) {
+      lastKnownScrollTopRef.current = scrollContainer.scrollTop;
+    }
     shouldAutoScrollRef.current = true;
   }, []);
   const cancelPendingStickToBottom = useCallback(() => {
@@ -5095,6 +5100,7 @@ export default function ChatView({
                   onOpenSettings={() => void navigate({ to: "/settings" })}
                   onOpenTurnDiff={handleOpenTurnDiff}
                 />
+                <div ref={messagesBottomRef} aria-hidden="true" className="h-px w-full" />
               </div>
 
               {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}


### PR DESCRIPTION
## Summary
- Keep chat views anchored to the latest message using a bottom anchor fallback, which improves scroll-to-end reliability.
- Normalize diff/highlight language ids through a shared mapping so common VS Code and file-based aliases resolve correctly in Shiki.
- Hide the Diffs tab when a thread has no diff content and avoid forcing the right panel open when switching tabs programmatically.
- Update the Capacitor local notifications patch script for the Capacitor v8 Swift API.
- Add and adjust tests for language normalization, diff language inference, and right panel tab behavior.

## Testing
- Not run (not requested).
- Added unit coverage for `resolveFileDiffLanguage` alias normalization.
- Updated right panel store coverage for inactive tab switching without opening the panel.
- Adjusted PR review utility coverage to expect normalized diff language ids.