### PR TITLE
Fix duplicate exports in pr-review-utils breaking web build

### DIFF
--- a/apps/web/src/components/pr-review/pr-review-utils.tsx
+++ b/apps/web/src/components/pr-review/pr-review-utils.tsx
@@ -21,10 +21,6 @@ import { normalizeLanguageIdForHighlighting } from "~/lib/languageIds";
 
 export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats };
 
-export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats };
-
-export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats };
-
 export type PullRequestState = "open" | "closed" | "merged";
 export type InspectorTab = "threads" | "workflow" | "people";
 export type RequestChangesButtonVariant = "default" | "destructive-outline" | "outline";


### PR DESCRIPTION
## Summary
- Removes two duplicated `export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats }` lines in `apps/web/src/components/pr-review/pr-review-utils.tsx`
- These duplicate re-exports caused 3 Vite/Rolldown `PARSE_ERROR: Duplicated export` errors, failing the `@okcode/web` build on Vercel

## Test plan
- [ ] Verify Vercel deployment build succeeds without `PARSE_ERROR` warnings
- [ ] Confirm PR review functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)