### PR TITLE
Use auth token for OpenClaw gateway signatures

### DIFF
--- a/apps/server/src/provider/Layers/OpenClawGatewayClient.ts
+++ b/apps/server/src/provider/Layers/OpenClawGatewayClient.ts
@@ -445,7 +445,7 @@ function buildConnectParams(input: {
             deviceToken: input.auth.value,
           }
         : undefined;
-  const signatureToken = input.auth.kind === "deviceToken" ? input.auth.value : undefined;
+  const signatureToken = input.auth.kind !== "none" ? input.auth.value : undefined;
   return {
     minProtocol: OPENCLAW_PROTOCOL_VERSION,
     maxProtocol: OPENCLAW_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary
- Update OpenClaw gateway connection params so request signatures use any available auth token, not only device tokens.
- Keep unauthenticated sessions unchanged by omitting the signature token when no auth is present.

## Testing
- Not run (PR title/body generation only).
- Review diff to confirm `signatureToken` now covers both device and non-device auth modes.