### PR TITLE
Refactor PR review sidebar into modular workflow panels

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { ThreadId } from "@okcode/contracts";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   ArrowLeftIcon,
@@ -22,6 +22,9 @@ import type { LucideIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
 import { useStore } from "~/store";
 import { useCommandPaletteStore } from "~/commandPaletteStore";
+import { usePrReviewCommands } from "~/components/pr-review/usePrReviewCommands";
+import { usePrReviewStore } from "~/prReviewStore";
+import { ensureNativeApi } from "~/nativeApi";
 import { useHandleNewThread } from "~/hooks/useHandleNewThread";
 import { useCurrentWorktreeCleanupCandidates } from "~/hooks/useCurrentWorktreeCleanupCandidates";
 import { useTheme } from "~/hooks/useTheme";
@@ -147,6 +150,25 @@ function CommandsView() {
   const mruThreadIds = useCommandPaletteStore((s) => s.mruThreadIds);
   const openWorktreeCleanupDialog = useWorktreeCleanupStore((s) => s.openDialog);
   const { hasCandidates: hasWorktreeCleanupCandidates } = useCurrentWorktreeCleanupCandidates();
+
+  // PR Review commands integration
+  const currentPath = useRouterState({ select: (s) => s.location.pathname });
+  const isPrReviewRoute = currentPath.includes("/pr-review");
+  const prReviewDashboard = usePrReviewStore((s) => s.selectedPrNumber);
+  const prReviewCommands = usePrReviewCommands({
+    enabled: isPrReviewRoute,
+    onStartAgentReview: () => {
+      closePalette();
+      const store = usePrReviewStore.getState();
+      // Trigger is handled by the caller
+      document.dispatchEvent(new CustomEvent("command-palette:start-agent-review"));
+    },
+    onOpenOnGitHub: () => {
+      closePalette();
+      document.dispatchEvent(new CustomEvent("command-palette:open-on-github"));
+    },
+  });
+
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
@@ -371,6 +393,11 @@ function CommandsView() {
       },
     });
 
+    // ── PR Review (conditionally visible) ──
+    for (const prCmd of prReviewCommands) {
+      cmds.push(prCmd);
+    }
+
     return cmds.filter((cmd) => !cmd.hidden);
   }, [
     projects,
@@ -389,6 +416,7 @@ function CommandsView() {
     pushMruThread,
     openWorktreeCleanupDialog,
     hasWorktreeCleanupCandidates,
+    prReviewCommands,
   ]);
 
   // Filter commands by query

--- a/apps/web/src/components/pr-review/PrActionRail.tsx
+++ b/apps/web/src/components/pr-review/PrActionRail.tsx
@@ -1,0 +1,356 @@
+import type {
+  NativeApi,
+  PrAgentReviewResult,
+  PrConflictAnalysis,
+  PrReviewConfig,
+} from "@okcode/contracts";
+import { useMemo, useState } from "react";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  ChevronUpIcon,
+  MessageSquareIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import { PrMentionComposer } from "./PrMentionComposer";
+import { requiredChecksState } from "./pr-review-utils";
+
+// ── Local helpers ──────────────────────────────────────────────────────
+
+function formatReviewDecision(decision: string | null | undefined): string {
+  if (!decision) return "No decision yet";
+  return decision.toLowerCase().replaceAll("_", " ");
+}
+
+function reviewDecisionTone(decision: string | null | undefined): string {
+  switch (decision) {
+    case "APPROVED":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "CHANGES_REQUESTED":
+    case "REVIEW_REQUIRED":
+      return "text-amber-600 dark:text-amber-400";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function formatConflictStatus(status: string | null | undefined): string {
+  if (!status) return "Conflict status unknown";
+  if (status === "clean") return "No merge conflicts";
+  if (status === "conflicted") return "Merge conflicts";
+  return status.replaceAll("_", " ");
+}
+
+function formatReviewTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+type DashboardData = Awaited<ReturnType<NativeApi["prReview"]["getDashboard"]>> | null | undefined;
+
+export function PrActionRail({
+  projectCwd,
+  dashboard,
+  config,
+  conflicts,
+  agentResult,
+  reviewBody,
+  onReviewBodyChange,
+  onSubmitReview,
+  isSubmitting,
+  requestChangesVariant,
+}: {
+  projectCwd: string;
+  dashboard: DashboardData;
+  config: PrReviewConfig | undefined;
+  conflicts: PrConflictAnalysis | undefined;
+  agentResult: PrAgentReviewResult | null | undefined;
+  reviewBody: string;
+  onReviewBodyChange: (body: string) => void;
+  onSubmitReview: (event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES") => void;
+  isSubmitting: boolean;
+  requestChangesVariant: "default" | "destructive-outline" | "outline";
+}) {
+  const [actionRailExpanded, setActionRailExpanded] = useState(false);
+
+  // ── Derived data ───────────────────────────────────────────────────
+
+  const checksSummary = config
+    ? requiredChecksState(config, dashboard?.pullRequest.statusChecks ?? [])
+    : { failing: [] as string[], pending: [] as string[] };
+
+  const blockingWorkflowSteps = (dashboard?.workflowSteps ?? []).filter(
+    (step) => step.status === "blocked" || step.status === "failed",
+  );
+
+  const fileStats = useMemo(() => {
+    const files = dashboard?.files ?? [];
+    return files.reduce(
+      (totals, file) => ({
+        changedFileCount: totals.changedFileCount + 1,
+        additions: totals.additions + file.additions,
+        deletions: totals.deletions + file.deletions,
+      }),
+      { changedFileCount: 0, additions: 0, deletions: 0 },
+    );
+  }, [dashboard?.files]);
+
+  const approvalBlockers = useMemo(
+    () => [
+      ...(conflicts?.status === "conflicted" ? ["Merge conflicts must be resolved"] : []),
+      ...checksSummary.failing.map((name) => `Failing check: ${name}`),
+      ...checksSummary.pending.map((name) => `Pending check: ${name}`),
+      ...blockingWorkflowSteps.map(
+        (step) => `Workflow blocked: ${step.detail ?? step.stepId}`,
+      ),
+    ],
+    [conflicts?.status, checksSummary.failing, checksSummary.pending, blockingWorkflowSteps],
+  );
+
+  const approveDisabled =
+    isSubmitting ||
+    conflicts?.status === "conflicted" ||
+    checksSummary.failing.length > 0 ||
+    checksSummary.pending.length > 0;
+
+  const recentReviews = dashboard?.pullRequest.recentReviews ?? [];
+  const displayedRecentReviews = recentReviews.slice(0, 3);
+
+  const agentStatus = agentResult?.status ?? "idle";
+  const agentIsRunning = agentStatus === "queued" || agentStatus === "running";
+
+  return (
+    <div className="border-t border-border/70 bg-background/96">
+      {/* Collapsed bar */}
+      <div
+        className={cn(
+          "flex min-h-10 items-center justify-between gap-3 px-4 py-2",
+          actionRailExpanded && "border-b border-border/50",
+        )}
+      >
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Submit review</span>
+          <span
+            className={cn(
+              "capitalize font-medium",
+              reviewDecisionTone(dashboard?.pullRequest.reviewDecision),
+            )}
+          >
+            {formatReviewDecision(dashboard?.pullRequest.reviewDecision)}
+          </span>
+          <span className="flex items-center gap-1">
+            <MessageSquareIcon className="size-3" />
+            {dashboard?.pullRequest.unresolvedThreadCount ?? 0} open
+          </span>
+          <span>{fileStats.changedFileCount} files</span>
+          <span className="flex items-center gap-1">
+            <ShieldCheckIcon className="size-3" />
+            {formatConflictStatus(conflicts?.status)}
+          </span>
+          {agentResult ? (
+            <span
+              className={cn(
+                "flex items-center gap-1",
+                agentIsRunning
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-muted-foreground",
+              )}
+            >
+              <SparklesIcon
+                className={cn("size-3", agentIsRunning && "animate-pulse")}
+              />
+              AI
+            </span>
+          ) : null}
+          {approvalBlockers.length > 0 ? (
+            <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+              <AlertTriangleIcon className="size-3" />
+              {approvalBlockers.length} blocker{approvalBlockers.length === 1 ? "" : "s"}
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2Icon className="size-3" />
+              ready to approve
+            </span>
+          )}
+        </div>
+        <Button
+          onClick={() => setActionRailExpanded(!actionRailExpanded)}
+          size="xs"
+          variant="ghost"
+        >
+          <ChevronUpIcon
+            className={cn("size-3.5 transition-transform", actionRailExpanded && "rotate-180")}
+          />
+          {actionRailExpanded ? "Collapse" : "Review"}
+        </Button>
+      </div>
+
+      {/* Expanded content */}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          actionRailExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="space-y-3 px-4 py-3">
+            {/* 3-card grid */}
+            <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.3fr)]">
+              {/* Review decision card */}
+              <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
+                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Review decision
+                </div>
+                <div
+                  className={cn(
+                    "mt-1 font-medium capitalize",
+                    reviewDecisionTone(dashboard?.pullRequest.reviewDecision),
+                  )}
+                >
+                  {formatReviewDecision(dashboard?.pullRequest.reviewDecision)}
+                </div>
+              </div>
+
+              {/* File impact card */}
+              <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
+                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                  File impact
+                </div>
+                <div className="mt-1 font-medium text-foreground">
+                  {fileStats.changedFileCount}{" "}
+                  {fileStats.changedFileCount === 1 ? "file" : "files"}, +{fileStats.additions} /
+                  -{fileStats.deletions}
+                </div>
+              </div>
+
+              {/* Approval status card */}
+              <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
+                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Approval status
+                </div>
+                {approvalBlockers.length > 0 ? (
+                  <ul className="mt-1 space-y-1 text-muted-foreground">
+                    {approvalBlockers.slice(0, 4).map((blocker) => (
+                      <li className="flex items-start gap-1.5" key={blocker}>
+                        <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-amber-500" />
+                        <span>{blocker}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="mt-1 flex items-center gap-1.5 font-medium text-emerald-600 dark:text-emerald-400">
+                    <CheckCircle2Icon className="size-3.5" />
+                    Ready to approve
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Recent maintainer reviews */}
+            <div className="space-y-1.5">
+              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                Recent maintainer reviews
+              </div>
+              {displayedRecentReviews.length > 0 ? (
+                <div className="space-y-1.5">
+                  {displayedRecentReviews.map((review) => (
+                    <div
+                      className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-2 text-xs"
+                      key={`${review.authorLogin}:${review.submittedAt}`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <span className="font-medium text-foreground">
+                            {review.authorLogin}
+                          </span>
+                          <span className="ml-2 capitalize text-muted-foreground">
+                            {review.state.toLowerCase().replaceAll("_", " ")}
+                          </span>
+                        </div>
+                        <span className="shrink-0 text-muted-foreground">
+                          {formatReviewTimestamp(review.submittedAt)}
+                        </span>
+                      </div>
+                      {review.body.trim().length > 0 ? (
+                        <p className="mt-1 line-clamp-2 whitespace-pre-wrap text-muted-foreground">
+                          {review.body}
+                        </p>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground">No maintainer reviews yet.</div>
+              )}
+            </div>
+
+            {/* Review body composer */}
+            <PrMentionComposer
+              cwd={projectCwd}
+              participants={dashboard?.pullRequest.participants ?? []}
+              placeholder="Write a review summary or use @ to notify collaborators."
+              rows={2}
+              value={reviewBody}
+              onChange={(value) => {
+                onReviewBodyChange(value);
+                if (value.trim().length > 0 && !actionRailExpanded) {
+                  setActionRailExpanded(true);
+                }
+              }}
+            />
+
+            {/* Submit buttons */}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-xs text-muted-foreground">
+                {approveDisabled
+                  ? "Approval is gated until blockers are cleared."
+                  : "Approval is available once your summary is ready."}
+              </div>
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                <Button
+                  disabled={isSubmitting}
+                  onClick={() => onSubmitReview("COMMENT")}
+                  size="sm"
+                  variant="outline"
+                >
+                  <MessageSquareIcon className="size-3.5" />
+                  Comment
+                </Button>
+                <Button
+                  disabled={approveDisabled}
+                  onClick={() => onSubmitReview("APPROVE")}
+                  size="sm"
+                  variant="secondary"
+                >
+                  <CheckCircle2Icon className="size-3.5" />
+                  Approve
+                </Button>
+                <Button
+                  disabled={isSubmitting}
+                  onClick={() => onSubmitReview("REQUEST_CHANGES")}
+                  size="sm"
+                  variant={requestChangesVariant}
+                >
+                  <AlertTriangleIcon className="size-3.5" />
+                  Request changes
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pr-review/PrAgentFindingsPanel.tsx
+++ b/apps/web/src/components/pr-review/PrAgentFindingsPanel.tsx
@@ -1,0 +1,330 @@
+import type { PrAgentFinding, PrAgentReviewResult } from "@okcode/contracts";
+import { useState } from "react";
+import {
+  AlertTriangleIcon,
+  FileCode2Icon,
+  InfoIcon,
+  MessageSquarePlusIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { Spinner } from "~/components/ui/spinner";
+import { cn } from "~/lib/utils";
+
+const SEVERITY_ORDER: Record<PrAgentFinding["severity"], number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+export function PrAgentFindingsPanel({
+  agentResult,
+  onSelectFile,
+  onCreateThread,
+  onStartReview,
+  isStarting,
+}: {
+  agentResult: PrAgentReviewResult | null | undefined;
+  onSelectFile: (path: string) => void;
+  onCreateThread: (input: { path: string; line: number; body: string }) => Promise<void>;
+  onStartReview: () => void;
+  isStarting: boolean;
+}) {
+  const status = agentResult?.status ?? "idle";
+
+  // ── Idle / No review yet ─────────────────────────────────────────
+  if (!agentResult || status === "idle") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 px-6 py-12 text-center">
+        <div className="flex size-12 items-center justify-center rounded-2xl bg-muted/40">
+          <SparklesIcon className="size-5 text-muted-foreground" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">No AI review yet</p>
+          <p className="max-w-[260px] text-xs leading-relaxed text-muted-foreground">
+            Run an AI review to get automated findings, risk assessment, and focus
+            suggestions.
+          </p>
+        </div>
+        <Button
+          disabled={isStarting}
+          onClick={onStartReview}
+          size="sm"
+          variant="outline"
+        >
+          {isStarting ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <SparklesIcon className="size-3.5" />
+          )}
+          Start AI Review
+        </Button>
+      </div>
+    );
+  }
+
+  // ── Running ──────────────────────────────────────────────────────
+  if (status === "queued" || status === "running") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+        <Spinner className="size-5 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Agent review in progress...</p>
+      </div>
+    );
+  }
+
+  // ── Failed ───────────────────────────────────────────────────────
+  if (status === "failed") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 px-6 py-12 text-center">
+        <div className="flex size-12 items-center justify-center rounded-2xl bg-rose-500/10">
+          <AlertTriangleIcon className="size-5 text-rose-500" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">Review failed</p>
+          <p className="max-w-[260px] text-xs leading-relaxed text-muted-foreground">
+            The AI review could not be completed. You can retry to start a fresh
+            analysis.
+          </p>
+        </div>
+        <Button
+          disabled={isStarting}
+          onClick={onStartReview}
+          size="sm"
+          variant="outline"
+        >
+          {isStarting ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <SparklesIcon className="size-3.5" />
+          )}
+          Retry Review
+        </Button>
+      </div>
+    );
+  }
+
+  // ── Complete ─────────────────────────────────────────────────────
+  const risk = agentResult.riskAssessment;
+  const findings = [...agentResult.findings].sort(
+    (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Summary card */}
+      <div className="rounded-2xl border border-border/70 bg-background/92 p-4">
+        <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Risk assessment
+        </p>
+        {risk ? (
+          <div className="mt-3 flex items-start gap-3">
+            <RiskTierBadge tier={risk.tier} />
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm font-medium capitalize text-foreground">
+                {risk.tier} risk
+              </p>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {risk.rationale}
+              </p>
+            </div>
+          </div>
+        ) : null}
+        {agentResult.summary ? (
+          <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+            {agentResult.summary}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Findings list */}
+      <div>
+        <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Findings ({findings.length})
+        </p>
+        {findings.length === 0 ? (
+          <div className="mt-3 rounded-2xl border border-dashed border-border/70 bg-muted/18 px-4 py-6 text-center text-sm text-muted-foreground">
+            No findings. The review did not surface any issues.
+          </div>
+        ) : (
+          <div className="mt-3 space-y-3">
+            {findings.map((finding) => (
+              <FindingCard
+                finding={finding}
+                key={finding.id}
+                onCreateThread={onCreateThread}
+                onSelectFile={onSelectFile}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Suggested focus */}
+      {agentResult.suggestedFocus.length > 0 ? (
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Suggested focus
+          </p>
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {agentResult.suggestedFocus.map((filePath) => (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border/70 bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                key={filePath}
+                onClick={() => onSelectFile(filePath)}
+                title={filePath}
+                type="button"
+              >
+                <FileCode2Icon className="size-3 shrink-0 opacity-60" />
+                <span className="truncate max-w-[200px]">{filePath}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Finding card ─────────────────────────────────────────────────────
+
+function FindingCard({
+  finding,
+  onSelectFile,
+  onCreateThread,
+}: {
+  finding: PrAgentFinding;
+  onSelectFile: (path: string) => void;
+  onCreateThread: (input: { path: string; line: number; body: string }) => Promise<void>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const hasLocation = finding.path != null && finding.line != null;
+
+  async function handleCreateThread() {
+    if (!finding.path || !finding.line) return;
+    setIsCreating(true);
+    try {
+      await onCreateThread({
+        path: finding.path,
+        line: finding.line,
+        body: `**${finding.title}** (${finding.severity}/${finding.category})\n\n${finding.detail}`,
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background/92 p-3">
+      <div className="flex items-start gap-2.5">
+        <SeverityIcon severity={finding.severity} />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          {/* Header row: title + category */}
+          <div className="flex items-start gap-2">
+            <p className="min-w-0 flex-1 text-sm font-medium text-foreground leading-snug">
+              {finding.title}
+            </p>
+            <span
+              className={cn(
+                "shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+                "bg-muted/50 text-muted-foreground",
+              )}
+            >
+              {finding.category}
+            </span>
+          </div>
+
+          {/* File:line link */}
+          {hasLocation ? (
+            <button
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => onSelectFile(finding.path!)}
+              type="button"
+            >
+              <FileCode2Icon className="size-3 shrink-0 opacity-60" />
+              <span className="truncate max-w-[200px]">
+                {finding.path}:{finding.line}
+              </span>
+            </button>
+          ) : null}
+
+          {/* Detail toggle */}
+          {finding.detail ? (
+            <>
+              <button
+                className="text-[11px] text-muted-foreground/80 transition-colors hover:text-foreground"
+                onClick={() => setExpanded((prev) => !prev)}
+                type="button"
+              >
+                {expanded ? "Hide detail" : "Show detail"}
+              </button>
+              {expanded ? (
+                <p className="text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap">
+                  {finding.detail}
+                </p>
+              ) : null}
+            </>
+          ) : null}
+
+          {/* Create thread */}
+          {hasLocation ? (
+            <div className="pt-1">
+              <Button
+                disabled={isCreating}
+                onClick={() => void handleCreateThread()}
+                size="xs"
+                variant="ghost"
+              >
+                {isCreating ? (
+                  <Spinner className="size-3" />
+                ) : (
+                  <MessageSquarePlusIcon className="size-3" />
+                )}
+                Create thread
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function SeverityIcon({ severity }: { severity: PrAgentFinding["severity"] }) {
+  const shared = "mt-0.5 size-4 shrink-0";
+  switch (severity) {
+    case "critical":
+      return <AlertTriangleIcon className={cn(shared, "text-rose-500")} />;
+    case "warning":
+      return <AlertTriangleIcon className={cn(shared, "text-amber-500")} />;
+    case "info":
+      return <InfoIcon className={cn(shared, "text-sky-500")} />;
+  }
+}
+
+function RiskTierBadge({ tier }: { tier: "low" | "medium" | "high" }) {
+  return (
+    <span
+      className={cn(
+        "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full",
+        tier === "low" && "bg-emerald-500/15",
+        tier === "medium" && "bg-amber-500/15",
+        tier === "high" && "bg-rose-500/15",
+      )}
+      aria-label={`Risk: ${tier}`}
+    >
+      <span
+        className={cn(
+          "size-2 rounded-full",
+          tier === "low" && "bg-emerald-500",
+          tier === "medium" && "bg-amber-500",
+          tier === "high" && "bg-rose-500",
+        )}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/pr-review/PrAgentReviewBanner.tsx
+++ b/apps/web/src/components/pr-review/PrAgentReviewBanner.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import type { PrAgentReviewResult } from "@okcode/contracts";
+import { SparklesIcon, XIcon, AlertTriangleIcon, CheckCircle2Icon } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { Spinner } from "~/components/ui/spinner";
+import { cn } from "~/lib/utils";
+
+export function PrAgentReviewBanner({
+  agentStatus,
+  onStartReview,
+  onSelectFile,
+  onOpenFindings,
+  isStarting,
+  fileCount,
+}: {
+  agentStatus: PrAgentReviewResult | null | undefined;
+  onStartReview: () => void;
+  onSelectFile: (path: string) => void;
+  onOpenFindings: () => void;
+  isStarting: boolean;
+  fileCount: number;
+}) {
+  const [dismissed, setDismissed] = useState(false);
+  const status = agentStatus?.status ?? "idle";
+
+  // ── Idle ──────────────────────────────────────────────────────────
+  if (status === "idle") {
+    return (
+      <div className="flex items-center gap-3 border-b border-border/70 bg-muted/18 px-4 py-2">
+        <Button
+          disabled={isStarting}
+          onClick={onStartReview}
+          size="xs"
+          variant="outline"
+        >
+          {isStarting ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <SparklesIcon className="size-3.5" />
+          )}
+          Start AI Review
+        </Button>
+        <span className="text-xs text-muted-foreground">
+          Get automated findings, risk assessment, and focus suggestions
+        </span>
+      </div>
+    );
+  }
+
+  // ── Running ──────────────────────────────────────────────────────
+  if (status === "queued" || status === "running") {
+    return (
+      <div className="flex items-center gap-3 border-b border-border/70 bg-muted/18 px-4 py-2 animate-pulse">
+        <Spinner className="size-4 text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">
+          Analyzing {fileCount} {fileCount === 1 ? "file" : "files"}...
+        </span>
+      </div>
+    );
+  }
+
+  // ── Failed ───────────────────────────────────────────────────────
+  if (status === "failed") {
+    return (
+      <div className="flex items-center gap-3 border-b border-border/70 bg-rose-500/8 px-4 py-2">
+        <AlertTriangleIcon className="size-4 shrink-0 text-rose-500" />
+        <span className="text-xs text-rose-700 dark:text-rose-300">
+          AI review failed.
+        </span>
+        <Button
+          disabled={isStarting}
+          onClick={onStartReview}
+          size="xs"
+          variant="outline"
+        >
+          {isStarting ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <SparklesIcon className="size-3.5" />
+          )}
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  // ── Complete (dismissed) ─────────────────────────────────────────
+  if (dismissed) {
+    return (
+      <div className="flex items-center gap-2 border-b border-border/70 bg-muted/18 px-4 py-1.5">
+        <button
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          onClick={() => setDismissed(false)}
+          type="button"
+        >
+          <CheckCircle2Icon className="size-3 text-emerald-500" />
+          AI review complete
+        </button>
+      </div>
+    );
+  }
+
+  // ── Complete (expanded) ──────────────────────────────────────────
+  const risk = agentStatus?.riskAssessment;
+  const findings = agentStatus?.findings ?? [];
+  const suggestedFocus = agentStatus?.suggestedFocus ?? [];
+  const findingCount = findings.length;
+
+  return (
+    <div className="flex items-start gap-3 border-b border-border/70 bg-muted/18 px-4 py-2.5">
+      {/* Risk tier dot */}
+      <RiskTierBadge tier={risk?.tier ?? null} />
+
+      {/* Summary + meta */}
+      <div className="min-w-0 flex-1 space-y-1.5">
+        {agentStatus?.summary ? (
+          <p className="text-xs leading-relaxed text-foreground line-clamp-2">
+            {agentStatus.summary}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          {/* Findings chip */}
+          {findingCount > 0 ? (
+            <button
+              className={cn(
+                "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors",
+                "border border-border/70 bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+              )}
+              onClick={onOpenFindings}
+              type="button"
+            >
+              {findingCount} {findingCount === 1 ? "finding" : "findings"}
+            </button>
+          ) : (
+            <span className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              <CheckCircle2Icon className="size-3 text-emerald-500" />
+              No findings
+            </span>
+          )}
+
+          {/* Suggested focus chips */}
+          {suggestedFocus.map((filePath) => (
+            <button
+              className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors border border-border/70 bg-muted/40 hover:bg-muted/70 hover:text-foreground truncate max-w-[160px]"
+              key={filePath}
+              onClick={() => onSelectFile(filePath)}
+              title={filePath}
+              type="button"
+            >
+              {basename(filePath)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Dismiss button */}
+      <Button
+        className="shrink-0"
+        onClick={() => setDismissed(true)}
+        size="icon-xs"
+        variant="ghost"
+        aria-label="Dismiss AI review banner"
+      >
+        <XIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function RiskTierBadge({ tier }: { tier: "low" | "medium" | "high" | null }) {
+  return (
+    <span
+      className={cn(
+        "mt-1 flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+        tier === "low" && "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+        tier === "medium" && "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+        tier === "high" && "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+        !tier && "bg-muted/40 text-muted-foreground",
+      )}
+      aria-label={tier ? `Risk: ${tier}` : "Risk unknown"}
+    >
+      <span
+        className={cn(
+          "size-2 rounded-full",
+          tier === "low" && "bg-emerald-500",
+          tier === "medium" && "bg-amber-500",
+          tier === "high" && "bg-rose-500",
+          !tier && "bg-muted-foreground/50",
+        )}
+      />
+    </span>
+  );
+}
+
+function basename(filePath: string): string {
+  const parts = filePath.split("/");
+  return parts[parts.length - 1] ?? filePath;
+}

--- a/apps/web/src/components/pr-review/PrConversationInspector.tsx
+++ b/apps/web/src/components/pr-review/PrConversationInspector.tsx
@@ -1,6 +1,12 @@
-import type { NativeApi, PrConflictAnalysis, PrReviewConfig } from "@okcode/contracts";
+import type { NativeApi, PrAgentReviewResult, PrConflictAnalysis, PrReviewConfig } from "@okcode/contracts";
 import { useState } from "react";
-import { MessageSquareIcon, ShieldCheckIcon, SparklesIcon, UsersIcon } from "lucide-react";
+import {
+  BookOpenCheckIcon,
+  MessageSquareIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  UsersIcon,
+} from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Toggle, ToggleGroup } from "~/components/ui/toggle-group";
@@ -8,15 +14,22 @@ import { SectionHeading } from "~/components/review/ReviewChrome";
 import { projectLabel } from "~/components/review/reviewUtils";
 import type { Project } from "~/types";
 import type { InspectorTab } from "./pr-review-utils";
+import { PrAgentFindingsPanel } from "./PrAgentFindingsPanel";
 import { PrThreadCard } from "./PrThreadCard";
 import { PrWorkflowPanel } from "./PrWorkflowPanel";
+import { PrWorkflowProgressBar } from "./PrWorkflowProgressBar";
 import { PrUserHoverCard } from "./PrUserHoverCard";
+import { requiredChecksState } from "./pr-review-utils";
+import { cn } from "~/lib/utils";
 
 export function PrConversationInspector({
   project,
   dashboard,
   config,
   conflicts,
+  agentResult,
+  onStartAgentReview,
+  isStartingAgentReview,
   workflowId,
   onWorkflowIdChange,
   selectedFilePath,
@@ -26,6 +39,7 @@ export function PrConversationInspector({
   onResolveThread,
   onReplyToThread,
   onRunStep,
+  onCreateThread,
   onOpenRules,
   onOpenWorkflow,
   onOpenConflictDrawer,
@@ -34,6 +48,9 @@ export function PrConversationInspector({
   dashboard: Awaited<ReturnType<NativeApi["prReview"]["getDashboard"]>> | null | undefined;
   config: PrReviewConfig | undefined;
   conflicts: PrConflictAnalysis | undefined;
+  agentResult: PrAgentReviewResult | null | undefined;
+  onStartAgentReview: () => void;
+  isStartingAgentReview: boolean;
   workflowId: string | null;
   onWorkflowIdChange: (workflowId: string) => void;
   selectedFilePath: string | null;
@@ -43,6 +60,7 @@ export function PrConversationInspector({
   onResolveThread: (threadId: string, nextAction: "resolve" | "unresolve") => Promise<void>;
   onReplyToThread: (threadId: string, body: string) => Promise<void>;
   onRunStep: (stepId: string, requiresConfirmation: boolean, title: string) => Promise<void>;
+  onCreateThread: (input: { path: string; line: number; body: string }) => Promise<void>;
   onOpenRules: () => void;
   onOpenWorkflow: (relativePath: string) => void;
   onOpenConflictDrawer: () => void;
@@ -61,6 +79,16 @@ export function PrConversationInspector({
     ? dashboard.threads.filter((thread) => thread.path === selectedFilePath)
     : dashboard.threads;
 
+  // Resolve workflow for progress bar
+  const activeWorkflow = config?.workflows.find((w) => w.id === (workflowId ?? config.defaultWorkflowId));
+
+  // Rule status computation
+  const checksState = config
+    ? requiredChecksState(config, dashboard.pullRequest.statusChecks)
+    : { failing: [] as string[], pending: [] as string[] };
+
+  const findingsCount = agentResult?.findings?.length ?? 0;
+
   return (
     <div className="flex min-h-0 min-w-0 flex-col bg-background/96">
       <div className="border-b border-border/70 px-4 py-4">
@@ -75,6 +103,26 @@ export function PrConversationInspector({
           eyebrow="Inspector"
           title="Conversations and rules"
         />
+
+        {/* Workflow progress bar — always visible when workflow has steps */}
+        {activeWorkflow && activeWorkflow.steps.length >= 2 ? (
+          <div className="mt-3">
+            <PrWorkflowProgressBar
+              steps={dashboard.workflowSteps.map((ws) => ({
+                stepId: ws.stepId,
+                status: ws.status,
+                detail: ws.detail,
+              }))}
+              stepDefinitions={activeWorkflow.steps.map((s) => ({
+                id: s.id,
+                title: s.title,
+                kind: s.kind,
+              }))}
+              onStepClick={() => setTab("workflow")}
+            />
+          </div>
+        ) : null}
+
         <ToggleGroup
           className="mt-4"
           size="xs"
@@ -82,11 +130,26 @@ export function PrConversationInspector({
           variant="outline"
           onValueChange={(values) => {
             const nextValue = values[values.length - 1];
-            if (nextValue === "threads" || nextValue === "workflow" || nextValue === "people") {
+            if (
+              nextValue === "ai" ||
+              nextValue === "threads" ||
+              nextValue === "workflow" ||
+              nextValue === "rules" ||
+              nextValue === "people"
+            ) {
               setTab(nextValue);
             }
           }}
         >
+          <Toggle value="ai">
+            <SparklesIcon className="size-3.5" />
+            AI
+            {findingsCount > 0 ? (
+              <span className="ml-1 inline-flex size-4 items-center justify-center rounded-full bg-indigo-500/20 text-[9px] font-bold text-indigo-400">
+                {findingsCount > 9 ? "9+" : findingsCount}
+              </span>
+            ) : null}
+          </Toggle>
           <Toggle value="threads">
             <MessageSquareIcon className="size-3.5" />
             Threads
@@ -94,6 +157,10 @@ export function PrConversationInspector({
           <Toggle value="workflow">
             <SparklesIcon className="size-3.5" />
             Workflow
+          </Toggle>
+          <Toggle value="rules">
+            <BookOpenCheckIcon className="size-3.5" />
+            Rules
           </Toggle>
           <Toggle value="people">
             <UsersIcon className="size-3.5" />
@@ -104,6 +171,18 @@ export function PrConversationInspector({
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-4 px-4 py-4">
+          {/* ── AI Findings Tab ──────────────────────────────────── */}
+          {tab === "ai" ? (
+            <PrAgentFindingsPanel
+              agentResult={agentResult}
+              onSelectFile={(path) => onSelectFilePath(path)}
+              onCreateThread={onCreateThread}
+              onStartReview={onStartAgentReview}
+              isStarting={isStartingAgentReview}
+            />
+          ) : null}
+
+          {/* ── Threads Tab ──────────────────────────────────────── */}
           {tab === "threads" ? (
             <>
               {selectedFilePath ? (
@@ -129,8 +208,28 @@ export function PrConversationInspector({
                 </div>
               ) : null}
               {visibleThreads.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-border/70 bg-muted/18 px-4 py-6 text-sm text-muted-foreground">
-                  No conversations are visible for the current scope.
+                <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/18 px-4 py-8 text-center">
+                  <MessageSquareIcon className="size-8 text-muted-foreground/40" />
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      No review threads yet
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground/80">
+                      Start a conversation by clicking any line in the diff, or
+                      let the AI review surface discussion points.
+                    </p>
+                  </div>
+                  {!agentResult || agentResult.status === "idle" ? (
+                    <Button
+                      onClick={onStartAgentReview}
+                      disabled={isStartingAgentReview}
+                      size="xs"
+                      variant="outline"
+                    >
+                      <SparklesIcon className="size-3.5" />
+                      Start AI Review
+                    </Button>
+                  ) : null}
                 </div>
               ) : (
                 visibleThreads.map((thread) => (
@@ -150,6 +249,7 @@ export function PrConversationInspector({
             </>
           ) : null}
 
+          {/* ── Workflow Tab ──────────────────────────────────────── */}
           {tab === "workflow" ? (
             <PrWorkflowPanel
               conflicts={conflicts}
@@ -163,6 +263,103 @@ export function PrConversationInspector({
             />
           ) : null}
 
+          {/* ── Rules Tab ────────────────────────────────────────── */}
+          {tab === "rules" ? (
+            <div className="space-y-4">
+              {/* Blocking rules */}
+              <div className="rounded-2xl border border-border/70 bg-background/92 p-4">
+                <div className="flex items-center justify-between">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                    Blocking Rules
+                  </p>
+                  <Button onClick={onOpenRules} size="xs" variant="ghost">
+                    Edit
+                  </Button>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {config?.rules.blockingRules && config.rules.blockingRules.length > 0 ? (
+                    config.rules.blockingRules.map((rule) => (
+                      <RuleStatusRow key={rule.id} title={rule.title} description={rule.description} passed={true} />
+                    ))
+                  ) : (
+                    <p className="text-xs text-muted-foreground">No blocking rules configured.</p>
+                  )}
+                  {/* Required checks */}
+                  {config?.rules.requiredChecks.map((checkName) => {
+                    const isFailing = checksState.failing.includes(checkName);
+                    const isPending = checksState.pending.includes(checkName);
+                    return (
+                      <RuleStatusRow
+                        key={`check:${checkName}`}
+                        title={`Required check: ${checkName}`}
+                        description={isFailing ? "Failing" : isPending ? "Pending" : "Passing"}
+                        passed={!isFailing && !isPending}
+                      />
+                    );
+                  })}
+                  {/* Conflict status */}
+                  {conflicts ? (
+                    <RuleStatusRow
+                      title="Clean merge"
+                      description={
+                        conflicts.status === "clean"
+                          ? "No merge conflicts"
+                          : conflicts.status === "conflicted"
+                            ? "Merge conflicts detected"
+                            : "Status unavailable"
+                      }
+                      passed={conflicts.status === "clean"}
+                    />
+                  ) : null}
+                  {/* Required approvals */}
+                  {config && config.rules.requiredApprovals > 0 ? (
+                    <RuleStatusRow
+                      title={`Required approvals: ${config.rules.requiredApprovals}`}
+                      description={`${dashboard.pullRequest.recentReviews.filter((r) => r.state === "APPROVED").length} of ${config.rules.requiredApprovals} received`}
+                      passed={
+                        dashboard.pullRequest.recentReviews.filter((r) => r.state === "APPROVED")
+                          .length >= config.rules.requiredApprovals
+                      }
+                    />
+                  ) : null}
+                </div>
+              </div>
+
+              {/* Advisory rules */}
+              {config?.rules.advisoryRules && config.rules.advisoryRules.length > 0 ? (
+                <div className="rounded-2xl border border-border/70 bg-background/92 p-4">
+                  <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                    Advisory Rules
+                  </p>
+                  <div className="mt-4 space-y-3">
+                    {config.rules.advisoryRules.map((rule) => (
+                      <div key={rule.id}>
+                        <p className="text-sm font-medium text-foreground">{rule.title}</p>
+                        {rule.description ? (
+                          <p className="mt-1 text-xs text-muted-foreground">{rule.description}</p>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+
+              {/* Config info */}
+              <div className="rounded-2xl border border-border/70 bg-muted/18 px-3 py-3 text-xs text-muted-foreground">
+                <span className="font-medium">Source:</span>{" "}
+                {config?.source === "repo"
+                  ? "Repository config"
+                  : config?.source === "localProfile"
+                    ? "Local profile"
+                    : "Default"}{" "}
+                &middot;{" "}
+                <span className="font-medium">Merge policy:</span>{" "}
+                {config?.rules.mergePolicy ?? "N/A"}
+              </div>
+            </div>
+          ) : null}
+
+          {/* ── People Tab ───────────────────────────────────────── */}
           {tab === "people" ? (
             <div className="space-y-4">
               <div className="rounded-2xl border border-border/70 bg-background/92 p-4">
@@ -184,24 +381,10 @@ export function PrConversationInspector({
                         <PrUserHoverCard cwd={project.cwd} login={participant.user.login}>
                           @{participant.user.login}
                         </PrUserHoverCard>
-                        <p className="truncate text-xs text-muted-foreground">{participant.role}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {participant.role}
+                        </p>
                       </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="rounded-2xl border border-border/70 bg-background/92 p-4">
-                <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                  Repo Rules
-                </p>
-                <div className="mt-4 space-y-3">
-                  {config?.rules.blockingRules.map((rule) => (
-                    <div key={rule.id}>
-                      <p className="font-medium text-sm text-foreground">{rule.title}</p>
-                      {rule.description ? (
-                        <p className="mt-1 text-sm text-muted-foreground">{rule.description}</p>
-                      ) : null}
                     </div>
                   ))}
                 </div>
@@ -210,6 +393,39 @@ export function PrConversationInspector({
           ) : null}
         </div>
       </ScrollArea>
+    </div>
+  );
+}
+
+// ── Rule Status Row ─────────────────────────────────────────────────
+
+function RuleStatusRow({
+  title,
+  description,
+  passed,
+}: {
+  title: string;
+  description: string | null;
+  passed: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div
+        className={cn(
+          "mt-1 flex size-5 shrink-0 items-center justify-center rounded-full text-[10px]",
+          passed
+            ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+            : "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+        )}
+      >
+        {passed ? "✓" : "!"}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        {description ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/pr-review/PrFileCommentComposer.tsx
+++ b/apps/web/src/components/pr-review/PrFileCommentComposer.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { MessageSquareIcon } from "lucide-react";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { Button } from "~/components/ui/button";
-import { Input } from "~/components/ui/input";
 import { Spinner } from "~/components/ui/spinner";
 import { PrMentionComposer } from "./PrMentionComposer";
 import { TEXT_DRAFT_SCHEMA } from "./pr-review-utils";
@@ -32,22 +31,25 @@ export function PrFileCommentComposer({
     setLine(String(defaultLine));
   }, [defaultLine]);
 
+  const parsedLine = Number.parseInt(line, 10);
+  const isValidLine = Number.isFinite(parsedLine) && parsedLine >= 1;
+
   return (
     <div className="space-y-3 rounded-2xl border border-border/70 bg-background/90 p-3">
       <div className="flex items-center gap-3">
-        <label className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-          Line
-          <Input
-            className="h-8 w-24"
+        <span className="text-xs text-muted-foreground">
+          Comment on line{" "}
+          <input
+            className="inline-flex h-6 w-14 rounded border border-border/70 bg-muted/30 px-1.5 text-center text-xs font-medium text-foreground tabular-nums focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-ring/24"
             disabled={disabled || isSubmitting}
             inputMode="numeric"
             min={1}
             type="number"
             value={line}
             onChange={(event) => setLine(event.target.value)}
-          />
-        </label>
-        <span className="text-xs text-muted-foreground">Creates a review thread on {path}</span>
+          />{" "}
+          of <span className="font-medium text-foreground">{path}</span>
+        </span>
       </div>
       <PrMentionComposer
         cwd={cwd}
@@ -59,12 +61,11 @@ export function PrFileCommentComposer({
       />
       <div className="flex items-center justify-end gap-2">
         <Button
-          disabled={disabled || isSubmitting || body.trim().length === 0}
+          disabled={disabled || isSubmitting || body.trim().length === 0 || !isValidLine}
           onClick={() => {
-            const nextLine = Number.parseInt(line, 10);
-            if (!Number.isFinite(nextLine) || nextLine < 1) return;
+            if (!isValidLine) return;
             setIsSubmitting(true);
-            void onSubmit({ body: body.trim(), line: nextLine }).then(
+            void onSubmit({ body: body.trim(), line: parsedLine }).then(
               () => {
                 setBody("");
                 setIsSubmitting(false);

--- a/apps/web/src/components/pr-review/PrInspectorPanel.tsx
+++ b/apps/web/src/components/pr-review/PrInspectorPanel.tsx
@@ -1,5 +1,6 @@
 import { useId, type ReactNode } from "react";
 import {
+  BookOpenCheckIcon,
   ChevronsLeftIcon,
   ChevronsRightIcon,
   MessageSquareIcon,
@@ -17,6 +18,8 @@ export function PrInspectorPanel({
   onExpandToTab,
   unresolvedThreadCount,
   hasBlockedWorkflow,
+  hasAgentFindings = false,
+  agentReviewRunning = false,
   children,
 }: {
   collapsed: boolean;
@@ -24,6 +27,8 @@ export function PrInspectorPanel({
   onExpandToTab?: (tab: InspectorTab) => void;
   unresolvedThreadCount: number;
   hasBlockedWorkflow: boolean;
+  hasAgentFindings?: boolean;
+  agentReviewRunning?: boolean;
   children: ReactNode;
 }) {
   const panelId = useId();
@@ -52,6 +57,41 @@ export function PrInspectorPanel({
           >
             <ChevronsLeftIcon className="size-4" />
           </Button>
+
+          {/* AI */}
+          <Tooltip>
+            <TooltipTrigger
+              onClick={() => onExpandToTab?.("ai")}
+              render={
+                <button
+                  type="button"
+                  aria-label={`AI findings${hasAgentFindings ? ", findings available" : ""}`}
+                  className={cn(
+                    "relative flex size-8 items-center justify-center rounded-lg transition-colors hover:bg-muted/50",
+                    agentReviewRunning
+                      ? "text-indigo-500 animate-pulse"
+                      : hasAgentFindings
+                        ? "text-indigo-500"
+                        : "text-muted-foreground",
+                  )}
+                />
+              }
+            >
+              <SparklesIcon className="size-4" />
+              {hasAgentFindings ? (
+                <span
+                  className="absolute right-1 top-1 size-1.5 rounded-full bg-indigo-500"
+                  aria-hidden="true"
+                />
+              ) : null}
+            </TooltipTrigger>
+            <TooltipPopup side="left" sideOffset={8}>
+              AI Findings
+              {agentReviewRunning ? " (running)" : hasAgentFindings ? " (available)" : ""}
+            </TooltipPopup>
+          </Tooltip>
+
+          {/* Threads */}
           <Tooltip>
             <TooltipTrigger
               onClick={() => onExpandToTab?.("threads")}
@@ -77,6 +117,8 @@ export function PrInspectorPanel({
               Threads ({unresolvedThreadCount} open)
             </TooltipPopup>
           </Tooltip>
+
+          {/* Workflow */}
           <Tooltip>
             <TooltipTrigger
               onClick={() => onExpandToTab?.("workflow")}
@@ -105,6 +147,27 @@ export function PrInspectorPanel({
               Workflow {hasBlockedWorkflow ? "(blocked)" : ""}
             </TooltipPopup>
           </Tooltip>
+
+          {/* Rules */}
+          <Tooltip>
+            <TooltipTrigger
+              onClick={() => onExpandToTab?.("rules")}
+              render={
+                <button
+                  type="button"
+                  aria-label="Rules"
+                  className="flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50"
+                />
+              }
+            >
+              <BookOpenCheckIcon className="size-4" />
+            </TooltipTrigger>
+            <TooltipPopup side="left" sideOffset={8}>
+              Rules
+            </TooltipPopup>
+          </Tooltip>
+
+          {/* People */}
           <Tooltip>
             <TooltipTrigger
               onClick={() => onExpandToTab?.("people")}

--- a/apps/web/src/components/pr-review/PrKeyboardShortcutOverlay.tsx
+++ b/apps/web/src/components/pr-review/PrKeyboardShortcutOverlay.tsx
@@ -1,0 +1,106 @@
+import {
+  Sheet,
+  SheetDescription,
+  SheetHeader,
+  SheetPanel,
+  SheetPopup,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { Kbd } from "~/components/ui/kbd";
+
+// ── Shortcut data ──────────────────────────────────────────────────
+
+interface ShortcutEntry {
+  key: string;
+  label: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: ShortcutEntry[];
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: "Navigation",
+    shortcuts: [
+      { key: "j", label: "Next file" },
+      { key: "k", label: "Previous file" },
+      { key: "n", label: "Next unreviewed file" },
+      { key: "e", label: "Mark file reviewed" },
+    ],
+  },
+  {
+    title: "Panels",
+    shortcuts: [
+      { key: "[", label: "Toggle PR list" },
+      { key: "]", label: "Toggle inspector" },
+      { key: "?", label: "Show shortcuts" },
+    ],
+  },
+  {
+    title: "Review Actions",
+    shortcuts: [
+      { key: "r", label: "Focus review editor" },
+      { key: "Shift+A", label: "Start AI review" },
+    ],
+  },
+];
+
+// ── Component ──────────────────────────────────────────────────────
+
+export function PrKeyboardShortcutOverlay({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetPopup side="right" variant="inset">
+        <SheetHeader>
+          <SheetTitle>Keyboard shortcuts</SheetTitle>
+          <SheetDescription>
+            Quick actions available while reviewing a pull request.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetPanel className="px-4 py-3">
+          <div className="space-y-5">
+            {SHORTCUT_GROUPS.map((group) => (
+              <section key={group.title}>
+                <h3 className="mb-2 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  {group.title}
+                </h3>
+                <ul className="space-y-1.5">
+                  {group.shortcuts.map((shortcut) => (
+                    <li
+                      key={shortcut.key}
+                      className="flex items-center justify-between rounded-md px-1.5 py-1 text-sm"
+                    >
+                      <span className="text-foreground">{shortcut.label}</span>
+                      <ShortcutKeys value={shortcut.key} />
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+        </SheetPanel>
+      </SheetPopup>
+    </Sheet>
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function ShortcutKeys({ value }: { value: string }) {
+  const parts = value.split("+");
+  return (
+    <span className="inline-flex items-center gap-1">
+      {parts.map((part) => (
+        <Kbd key={part}>{part}</Kbd>
+      ))}
+    </span>
+  );
+}

--- a/apps/web/src/components/pr-review/PrReviewShell.tsx
+++ b/apps/web/src/components/pr-review/PrReviewShell.tsx
@@ -1,28 +1,11 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Schema } from "effect";
+import { useQueryClient } from "@tanstack/react-query";
 import { useDeferredValue } from "react";
-import { startTransition, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
-import {
-  AlertTriangleIcon,
-  CheckCircle2Icon,
-  ChevronUpIcon,
-  MessageSquareIcon,
-  PanelRightIcon,
-  ShieldCheckIcon,
-  SparklesIcon,
-} from "lucide-react";
+import { startTransition, useEffect, useEffectEvent, useMemo, useRef } from "react";
+import { PanelRightIcon } from "lucide-react";
 
 import { useAppSettings } from "~/appSettings";
-import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useMediaQuery } from "~/hooks/useMediaQuery";
-import { gitListPullRequestsQueryOptions } from "~/lib/gitReactQuery";
-import {
-  invalidatePrReviewQueries,
-  prReviewConfigQueryOptions,
-  prReviewConflictsQueryOptions,
-  prReviewDashboardQueryOptions,
-  prReviewPatchQueryOptions,
-} from "~/lib/prReviewReactQuery";
+import { invalidatePrReviewQueries } from "~/lib/prReviewReactQuery";
 import { cn } from "~/lib/utils";
 import { ensureNativeApi } from "~/nativeApi";
 import { joinPath } from "~/components/review/reviewUtils";
@@ -36,64 +19,29 @@ import {
   SheetTitle,
 } from "~/components/ui/sheet";
 import type { Project } from "~/types";
+import { usePrReviewStore } from "~/prReviewStore";
 
 import { PrListRail } from "./PrListRail";
 import { PrWorkspace } from "./PrWorkspace";
 import { PrConversationInspector } from "./PrConversationInspector";
 import { PrConflictDrawer } from "./PrConflictDrawer";
 import { PrInspectorPanel } from "./PrInspectorPanel";
-import { PrMentionComposer } from "./PrMentionComposer";
+import { PrActionRail } from "./PrActionRail";
+import { PrKeyboardShortcutOverlay } from "./PrKeyboardShortcutOverlay";
+import { usePrReviewQueries } from "./usePrReviewQueries";
+import { usePrReviewMutations } from "./usePrReviewMutations";
+import { usePrReviewKeyboard } from "./usePrReviewKeyboard";
 import {
-  type PullRequestState,
-  REVIEWED_FILES_SCHEMA,
-  TEXT_DRAFT_SCHEMA,
   openPathInEditor,
   requiredChecksState,
   resolveRequestChangesButtonVariant,
 } from "./pr-review-utils";
-
-const BOOL_SCHEMA = Schema.Boolean;
-
-function formatReviewDecision(decision: string | null | undefined): string {
-  if (!decision) return "No decision yet";
-  return decision.toLowerCase().replaceAll("_", " ");
-}
-
-function reviewDecisionTone(decision: string | null | undefined): string {
-  switch (decision) {
-    case "APPROVED":
-      return "text-emerald-600 dark:text-emerald-400";
-    case "CHANGES_REQUESTED":
-    case "REVIEW_REQUIRED":
-      return "text-amber-600 dark:text-amber-400";
-    default:
-      return "text-muted-foreground";
-  }
-}
-
-function formatConflictStatus(status: string | null | undefined): string {
-  if (!status) return "Conflict status unknown";
-  if (status === "clean") return "No merge conflicts";
-  if (status === "conflicted") return "Merge conflicts";
-  return status.replaceAll("_", " ");
-}
 
 function resolvePrReviewConfigPath(projectCwd: string, configPath: string): string {
   if (/^(?:[A-Za-z]:[\\/]|\/)/.test(configPath)) {
     return configPath;
   }
   return joinPath(projectCwd, configPath);
-}
-
-function formatReviewTimestamp(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date);
 }
 
 export function PrReviewShell({
@@ -111,74 +59,25 @@ export function PrReviewShell({
   const { settings } = useAppSettings();
   const isInspectorSheet = useMediaQuery("max-xl");
   const isWideScreen = useMediaQuery("min-2xl");
-  const [pullRequestState, setPullRequestState] = useState<PullRequestState>("open");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedPrNumber, setSelectedPrNumber] = useState<number | null>(null);
-  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
-  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
-  const [workflowId, setWorkflowId] = useState<string | null>(null);
-  const [conflictDrawerOpen, setConflictDrawerOpen] = useState(false);
-  const [inspectorOpen, setInspectorOpen] = useState(false);
-  const deferredSearchQuery = useDeferredValue(searchQuery);
-  const reviewDraftKey = `okcode:pr-review:review-draft:${project.id}:${selectedPrNumber ?? "none"}`;
-  const [reviewBody, setReviewBody] = useLocalStorage(reviewDraftKey, "", TEXT_DRAFT_SCHEMA);
-  const reviewedFilesKey = `okcode:pr-review:reviewed-files:${project.id}:${selectedPrNumber ?? "none"}`;
-  const [reviewedFiles, setReviewedFiles] = useLocalStorage<readonly string[], unknown>(
-    reviewedFilesKey,
-    [],
-    REVIEWED_FILES_SCHEMA,
-  );
+  const reviewComposerRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // --- Collapsible panel state ---
-  const [leftRailCollapsed, setLeftRailCollapsed] = useLocalStorage(
-    "okcode:pr-review:left-rail-collapsed",
-    false,
-    BOOL_SCHEMA,
-  );
-  const [inspectorCollapsed, setInspectorCollapsed] = useLocalStorage(
-    "okcode:pr-review:inspector-collapsed",
-    true,
-    BOOL_SCHEMA,
-  );
-  const [actionRailExpanded, setActionRailExpanded] = useState(false);
-  const userExplicitlyOpenedInspector = useRef(false);
+  // ── Store ─────────────────────────────────────────────────────────
+  const store = usePrReviewStore();
+  const deferredSearchQuery = useDeferredValue(store.searchQuery);
 
-  // Auto-expand panels on wide screens
-  useEffect(() => {
-    if (isWideScreen) {
-      setLeftRailCollapsed(false);
-      if (!userExplicitlyOpenedInspector.current) {
-        setInspectorCollapsed(false);
-      }
-    }
-  }, [isWideScreen, setLeftRailCollapsed, setInspectorCollapsed]);
+  // ── Queries & Mutations ───────────────────────────────────────────
+  const {
+    configQuery,
+    dashboardQuery,
+    patchQuery,
+    conflictQuery,
+    pullRequestsQuery,
+    agentReviewQuery,
+  } = usePrReviewQueries(project.cwd);
 
-  const pullRequestsQuery = useQuery(
-    gitListPullRequestsQueryOptions({
-      cwd: project.cwd,
-      state: pullRequestState,
-    }),
-  );
-  const configQuery = useQuery(prReviewConfigQueryOptions(project.cwd));
-  const dashboardQuery = useQuery(
-    prReviewDashboardQueryOptions({
-      cwd: project.cwd,
-      prNumber: selectedPrNumber,
-    }),
-  );
-  const patchQuery = useQuery(
-    prReviewPatchQueryOptions({
-      cwd: project.cwd,
-      prNumber: selectedPrNumber,
-    }),
-  );
-  const conflictQuery = useQuery(
-    prReviewConflictsQueryOptions({
-      cwd: project.cwd,
-      prNumber: selectedPrNumber,
-    }),
-  );
+  const mutations = usePrReviewMutations(project.cwd);
 
+  // ── Derived data ──────────────────────────────────────────────────
   const filteredPullRequests = useMemo(() => {
     const query = deferredSearchQuery.trim().toLowerCase();
     if (query.length === 0) {
@@ -198,46 +97,103 @@ export function PrReviewShell({
     });
   }, [deferredSearchQuery, pullRequestsQuery.data?.pullRequests]);
 
+  const patchFiles = useMemo(
+    () => patchQuery.data?.files ?? [],
+    [patchQuery.data?.files],
+  );
+
+  const filePaths = useMemo(
+    () => patchFiles.map((f) => f.path),
+    [patchFiles],
+  );
+
+  const checksSummary = configQuery.data
+    ? requiredChecksState(configQuery.data, dashboardQuery.data?.pullRequest.statusChecks ?? [])
+    : { failing: [] as string[], pending: [] as string[] };
+
+  const blockingWorkflowSteps = useMemo(
+    () =>
+      (dashboardQuery.data?.workflowSteps ?? []).filter(
+        (step) => step.status === "blocked" || step.status === "failed",
+      ),
+    [dashboardQuery.data?.workflowSteps],
+  );
+
+  const approvalBlockers = useMemo(
+    () => [
+      ...(conflictQuery.data?.status === "conflicted" ? ["Merge conflicts must be resolved"] : []),
+      ...checksSummary.failing.map((name) => `Failing check: ${name}`),
+      ...checksSummary.pending.map((name) => `Pending check: ${name}`),
+      ...blockingWorkflowSteps.map(
+        (step) => `Workflow blocked: ${step.detail ?? step.stepId}`,
+      ),
+    ],
+    [conflictQuery.data?.status, checksSummary.failing, checksSummary.pending, blockingWorkflowSteps],
+  );
+
+  // ── Effects: Auto-select, sync, auto-expand ───────────────────────
+
+  // Auto-expand panels on wide screens
+  useEffect(() => {
+    if (isWideScreen) {
+      store.setLeftRailCollapsed(false);
+      if (!store.userExplicitlyOpenedInspector) {
+        store.setInspectorCollapsed(false);
+      }
+    }
+  }, [isWideScreen]);
+
+  // Auto-select first PR
   useEffect(() => {
     const nextDefault =
-      filteredPullRequests.find((pullRequest) => pullRequest.number === selectedPrNumber) ??
+      filteredPullRequests.find((pr) => pr.number === store.selectedPrNumber) ??
       filteredPullRequests[0] ??
       null;
     if (!nextDefault) {
-      if (selectedPrNumber !== null) setSelectedPrNumber(null);
+      if (store.selectedPrNumber !== null) store.selectPr(null);
       return;
     }
-    if (selectedPrNumber !== nextDefault.number) {
-      setSelectedPrNumber(nextDefault.number);
+    if (store.selectedPrNumber !== nextDefault.number) {
+      store.selectPr(nextDefault.number);
     }
-  }, [filteredPullRequests, selectedPrNumber]);
+  }, [filteredPullRequests, store.selectedPrNumber]);
 
+  // Reset file/thread when PR changes
   useEffect(() => {
-    setSelectedFilePath(null);
-    setSelectedThreadId(null);
-  }, [selectedPrNumber]);
+    store.resetForNewPr();
+  }, [store.selectedPrNumber]);
 
+  // Auto-select first file
   useEffect(() => {
     const files = patchQuery.data?.files ?? [];
     if (files.length === 0) {
-      setSelectedFilePath(null);
+      store.selectFile(null);
       return;
     }
-    if (!selectedFilePath || !files.some((file) => file.path === selectedFilePath)) {
-      setSelectedFilePath(files[0]?.path ?? null);
+    if (
+      !store.selectedFilePath ||
+      !files.some((file) => file.path === store.selectedFilePath)
+    ) {
+      store.selectFile(files[0]?.path ?? null);
     }
-  }, [patchQuery.data?.files, selectedFilePath]);
+  }, [patchQuery.data?.files, store.selectedFilePath]);
 
+  // Auto-select workflow
   useEffect(() => {
     if (!configQuery.data) return;
-    setWorkflowId((current) => {
-      if (current && configQuery.data.workflows.some((workflow) => workflow.id === current)) {
-        return current;
-      }
-      return configQuery.data.defaultWorkflowId;
-    });
+    const current = store.workflowId;
+    if (current && configQuery.data.workflows.some((w) => w.id === current)) return;
+    store.setWorkflowId(configQuery.data.defaultWorkflowId);
   }, [configQuery.data]);
 
+  // Sync agent review result into store
+  useEffect(() => {
+    if (agentReviewQuery.data) {
+      store.setAgentReviewResult(agentReviewQuery.data);
+    }
+  }, [agentReviewQuery.data]);
+
+  // Native API event subscriptions
   const handleSyncUpdated = useEffectEvent((payload: { cwd: string; prNumber: number }) => {
     if (payload.cwd !== project.cwd) return;
     void queryClient.invalidateQueries({ queryKey: ["git", "pull-requests", project.cwd] });
@@ -259,175 +215,32 @@ export function PrReviewShell({
     };
   }, []);
 
-  // Keyboard shortcuts: [ toggles left rail, ] toggles right inspector
-  const handlePanelKeyDown = useEffectEvent((event: KeyboardEvent) => {
-    const target = event.target as HTMLElement;
-    if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
-      return;
-    }
-    if (event.key === "[" && !event.ctrlKey && !event.metaKey) {
-      event.preventDefault();
-      setLeftRailCollapsed(!leftRailCollapsed);
-    }
-    if (event.key === "]" && !event.ctrlKey && !event.metaKey) {
-      event.preventDefault();
-      if (isInspectorSheet) return;
-      const next = !inspectorCollapsed;
-      if (!next) userExplicitlyOpenedInspector.current = true;
-      setInspectorCollapsed(next);
-    }
-  });
-
-  useEffect(() => {
-    document.addEventListener("keydown", handlePanelKeyDown);
-    return () => document.removeEventListener("keydown", handlePanelKeyDown);
-  }, []);
-
-  const addThreadMutation = useMutation({
-    mutationFn: async (input: { path: string; line: number; body: string }) => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      return ensureNativeApi().prReview.addThread({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        path: input.path,
-        line: input.line,
-        body: input.body,
+  // ── Keyboard ──────────────────────────────────────────────────────
+  usePrReviewKeyboard({
+    enabled: true,
+    filePaths,
+    fileCount: patchFiles.length,
+    onStartAgentReview: () => {
+      void mutations.startAgentReviewMutation.mutateAsync({
+        workflowId: store.workflowId ?? undefined,
       });
     },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
+    reviewComposerRef,
   });
 
-  const replyToThreadMutation = useMutation({
-    mutationFn: async (input: { threadId: string; body: string }) => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      return ensureNativeApi().prReview.replyToThread({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        threadId: input.threadId,
-        body: input.body,
-      });
-    },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
-  });
-
-  const resolveThreadMutation = useMutation({
-    mutationFn: async (input: { threadId: string; action: "resolve" | "unresolve" }) => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      if (input.action === "resolve") {
-        return ensureNativeApi().prReview.resolveThread({
-          cwd: project.cwd,
-          prNumber: selectedPrNumber,
-          threadId: input.threadId,
-        });
-      }
-      return ensureNativeApi().prReview.unresolveThread({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        threadId: input.threadId,
-      });
-    },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
-  });
-
-  const runWorkflowStepMutation = useMutation({
-    mutationFn: async (stepId: string) => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      return ensureNativeApi().prReview.runWorkflowStep({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        stepId,
-      });
-    },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
-  });
-
-  const applyConflictResolutionMutation = useMutation({
-    mutationFn: async (candidateId: string) => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      const confirmed = await ensureNativeApi().dialogs.confirm(
-        "Apply this conflict resolution candidate to the repository?",
-      );
-      if (!confirmed) return null;
-      return ensureNativeApi().prReview.applyConflictResolution({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        candidateId,
-      });
-    },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
-  });
-
-  const submitReviewMutation = useMutation({
-    mutationFn: async (event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES") => {
-      if (!selectedPrNumber) throw new Error("Select a pull request first.");
-      return ensureNativeApi().prReview.submitReview({
-        cwd: project.cwd,
-        prNumber: selectedPrNumber,
-        event,
-        body: reviewBody.trim(),
-      });
-    },
-    onSuccess: async () => {
-      if (!selectedPrNumber) return;
-      setReviewBody("");
-      await invalidatePrReviewQueries(queryClient, project.cwd, selectedPrNumber);
-    },
-  });
-
-  const checksSummary = configQuery.data
-    ? requiredChecksState(configQuery.data, dashboardQuery.data?.pullRequest.statusChecks ?? [])
-    : { failing: [] as string[], pending: [] as string[] };
-  const blockingWorkflowStepsComputed = (dashboardQuery.data?.workflowSteps ?? []).filter(
-    (step) => step.status === "blocked" || step.status === "failed",
-  );
-  const fileStats = useMemo(() => {
-    const files = dashboardQuery.data?.files ?? [];
-    return files.reduce(
-      (totals, file) => ({
-        changedFileCount: totals.changedFileCount + 1,
-        additions: totals.additions + file.additions,
-        deletions: totals.deletions + file.deletions,
-      }),
-      { changedFileCount: 0, additions: 0, deletions: 0 },
-    );
-  }, [dashboardQuery.data?.files]);
-  const approvalBlockers = [
-    ...(conflictQuery.data?.status === "conflicted" ? ["Merge conflicts must be resolved"] : []),
-    ...checksSummary.failing.map((name) => `Failing check: ${name}`),
-    ...checksSummary.pending.map((name) => `Pending check: ${name}`),
-    ...blockingWorkflowStepsComputed.map(
-      (step) => `Workflow blocked: ${step.detail ?? step.stepId}`,
-    ),
-  ];
-  const approveDisabled =
-    submitReviewMutation.isPending ||
-    conflictQuery.data?.status === "conflicted" ||
-    checksSummary.failing.length > 0 ||
-    checksSummary.pending.length > 0;
-  const recentReviews = dashboardQuery.data?.pullRequest.recentReviews ?? [];
-  const displayedRecentReviews = recentReviews.slice(0, 3);
-
-  // Inspector props helper
+  // ── Inspector props ───────────────────────────────────────────────
   const inspectorProps = {
     config: configQuery.data,
     conflicts: conflictQuery.data,
     dashboard: dashboardQuery.data,
-    onOpenConflictDrawer: () => setConflictDrawerOpen(true),
+    agentResult: agentReviewQuery.data,
+    onStartAgentReview: () => {
+      void mutations.startAgentReviewMutation.mutateAsync({
+        workflowId: store.workflowId ?? undefined,
+      });
+    },
+    isStartingAgentReview: mutations.startAgentReviewMutation.isPending,
+    onOpenConflictDrawer: () => store.setConflictDrawerOpen(true),
     onOpenRules: () => {
       if (!configQuery.data) return;
       void openPathInEditor(
@@ -438,51 +251,55 @@ export function PrReviewShell({
       void openPathInEditor(resolvePrReviewConfigPath(project.cwd, relativePath));
     },
     onReplyToThread: async (threadId: string, body: string) => {
-      await replyToThreadMutation.mutateAsync({ threadId, body });
+      await mutations.replyToThreadMutation.mutateAsync({ threadId, body });
     },
     onResolveThread: async (threadId: string, nextAction: "resolve" | "unresolve") => {
-      await resolveThreadMutation.mutateAsync({ threadId, action: nextAction });
+      await mutations.resolveThreadMutation.mutateAsync({ threadId, action: nextAction });
     },
     onRunStep: async (stepId: string, requiresConfirmation: boolean, title: string) => {
       if (requiresConfirmation) {
-        const confirmed = await ensureNativeApi().dialogs.confirm(`Run workflow step "${title}"?`);
+        const confirmed = await ensureNativeApi().dialogs.confirm(
+          `Run workflow step "${title}"?`,
+        );
         if (!confirmed) return;
       }
-      await runWorkflowStepMutation.mutateAsync(stepId);
+      await mutations.runWorkflowStepMutation.mutateAsync(stepId);
     },
-    onSelectFilePath: setSelectedFilePath,
-    onSelectThreadId: setSelectedThreadId,
-    onWorkflowIdChange: setWorkflowId,
+    onCreateThread: async (input: { path: string; line: number; body: string }) => {
+      await mutations.addThreadMutation.mutateAsync(input);
+    },
+    onSelectFilePath: store.selectFile,
+    onSelectThreadId: store.selectThread,
+    onWorkflowIdChange: store.setWorkflowId,
     project,
-    selectedFilePath,
-    selectedThreadId,
-    workflowId,
+    selectedFilePath: store.selectedFilePath,
+    selectedThreadId: store.selectedThreadId,
+    workflowId: store.workflowId,
   } as const;
 
+  // ── Render ────────────────────────────────────────────────────────
   return (
     <>
       {/* Main content area — flexbox layout with collapsible panels */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left rail — collapsible */}
         <PrListRail
-          collapsed={leftRailCollapsed}
+          collapsed={store.leftRailCollapsed}
           isLoading={pullRequestsQuery.isLoading || pullRequestsQuery.isFetching}
           onProjectChange={onProjectChange}
-          onPullRequestStateChange={setPullRequestState}
-          onSearchQueryChange={setSearchQuery}
+          onPullRequestStateChange={store.setPullRequestState}
+          onSearchQueryChange={store.setSearchQuery}
           onSelectPr={(pullRequest) => {
             startTransition(() => {
-              setSelectedPrNumber(pullRequest.number);
-              setSelectedThreadId(null);
-              setInspectorOpen(true);
+              store.selectPr(pullRequest.number);
             });
           }}
-          onToggleCollapsed={() => setLeftRailCollapsed(!leftRailCollapsed)}
+          onToggleCollapsed={store.toggleLeftRail}
           projects={projects}
-          pullRequestState={pullRequestState}
+          pullRequestState={store.pullRequestState}
           pullRequests={filteredPullRequests}
-          searchQuery={searchQuery}
-          selectedPrNumber={selectedPrNumber}
+          searchQuery={store.searchQuery}
+          selectedPrNumber={store.selectedPrNumber}
           selectedProjectId={selectedProjectId}
         />
 
@@ -490,7 +307,11 @@ export function PrReviewShell({
         <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {isInspectorSheet ? (
             <div className="flex h-10 items-center justify-end border-b border-border/70 px-4">
-              <Button onClick={() => setInspectorOpen(true)} size="sm" variant="outline">
+              <Button
+                onClick={() => store.setInspectorOpen(true)}
+                size="sm"
+                variant="outline"
+              >
                 <PanelRightIcon className="size-3.5" />
                 Inspector
               </Button>
@@ -498,274 +319,104 @@ export function PrReviewShell({
           ) : null}
           <PrWorkspace
             dashboard={dashboardQuery.data}
-            onCreateThread={async (input) => {
-              await addThreadMutation.mutateAsync(input);
-            }}
-            onSelectFilePath={setSelectedFilePath}
-            onSelectThreadId={(threadId) => {
-              setSelectedThreadId(threadId);
-              // Auto-expand inspector when clicking a thread
-              if (threadId && inspectorCollapsed && !isInspectorSheet) {
-                userExplicitlyOpenedInspector.current = true;
-                setInspectorCollapsed(false);
-              }
-            }}
-            onToggleFileReviewed={(path) => {
-              setReviewedFiles((prev) => {
-                const set = new Set(prev);
-                if (set.has(path)) set.delete(path);
-                else set.add(path);
-                return [...set];
+            agentResult={agentReviewQuery.data}
+            onStartAgentReview={() => {
+              void mutations.startAgentReviewMutation.mutateAsync({
+                workflowId: store.workflowId ?? undefined,
               });
             }}
+            isStartingAgentReview={mutations.startAgentReviewMutation.isPending}
+            onCreateThread={async (input) => {
+              await mutations.addThreadMutation.mutateAsync(input);
+            }}
+            onSelectFilePath={store.selectFile}
+            onSelectThreadId={(threadId) => {
+              store.selectThread(threadId);
+              // Auto-expand inspector when clicking a thread
+              if (threadId && store.inspectorCollapsed && !isInspectorSheet) {
+                store.expandInspectorToTab("threads");
+              }
+            }}
+            onToggleFileReviewed={store.toggleFileReviewed}
             patch={patchQuery.data?.combinedPatch ?? null}
             project={project}
-            reviewedFiles={reviewedFiles}
-            selectedFilePath={selectedFilePath}
-            selectedThreadId={selectedThreadId}
+            reviewedFiles={store.reviewedFiles}
+            selectedFilePath={store.selectedFilePath}
+            selectedThreadId={store.selectedThreadId}
+            approvalBlockers={approvalBlockers}
+            onOpenConflictDrawer={() => store.setConflictDrawerOpen(true)}
           />
         </main>
 
         {/* Right inspector — collapsible (desktop xl+ only) */}
         {!isInspectorSheet ? (
           <PrInspectorPanel
-            collapsed={inspectorCollapsed}
-            hasBlockedWorkflow={blockingWorkflowStepsComputed.length > 0}
-            onExpandToTab={(_tab) => {
-              userExplicitlyOpenedInspector.current = true;
-              setInspectorCollapsed(false);
+            collapsed={store.inspectorCollapsed}
+            hasBlockedWorkflow={blockingWorkflowSteps.length > 0}
+            hasAgentFindings={
+              (agentReviewQuery.data?.findings?.length ?? 0) > 0
+            }
+            agentReviewRunning={
+              agentReviewQuery.data?.status === "running" ||
+              agentReviewQuery.data?.status === "queued"
+            }
+            onExpandToTab={(tab) => {
+              store.expandInspectorToTab(tab);
             }}
-            onToggleCollapsed={() => {
-              const next = !inspectorCollapsed;
-              if (!next) userExplicitlyOpenedInspector.current = true;
-              setInspectorCollapsed(next);
-            }}
-            unresolvedThreadCount={dashboardQuery.data?.pullRequest.unresolvedThreadCount ?? 0}
+            onToggleCollapsed={store.toggleInspector}
+            unresolvedThreadCount={
+              dashboardQuery.data?.pullRequest.unresolvedThreadCount ?? 0
+            }
           >
             <PrConversationInspector {...inspectorProps} />
           </PrInspectorPanel>
         ) : null}
       </div>
 
-      {/* Action rail — collapsible (Phase 6) */}
-      <div className="border-t border-border/70 bg-background/96">
-        {/* Collapsed bar */}
-        <div
-          className={cn(
-            "flex min-h-10 items-center justify-between gap-3 px-4 py-2",
-            actionRailExpanded && "border-b border-border/50",
-          )}
-        >
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">Submit review</span>
-            <span
-              className={cn(
-                "capitalize font-medium",
-                reviewDecisionTone(dashboardQuery.data?.pullRequest.reviewDecision),
-              )}
-            >
-              {formatReviewDecision(dashboardQuery.data?.pullRequest.reviewDecision)}
-            </span>
-            <span className="flex items-center gap-1">
-              <MessageSquareIcon className="size-3" />
-              {dashboardQuery.data?.pullRequest.unresolvedThreadCount ?? 0} open
-            </span>
-            <span>{fileStats.changedFileCount} files</span>
-            <span className="flex items-center gap-1">
-              <ShieldCheckIcon className="size-3" />
-              {formatConflictStatus(conflictQuery.data?.status)}
-            </span>
-            {approvalBlockers.length > 0 ? (
-              <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
-                <SparklesIcon className="size-3" />
-                {approvalBlockers.length} blocker{approvalBlockers.length === 1 ? "" : "s"}
-              </span>
-            ) : (
-              <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                <CheckCircle2Icon className="size-3" />
-                ready to approve
-              </span>
-            )}
-          </div>
-          <Button
-            onClick={() => setActionRailExpanded(!actionRailExpanded)}
-            size="xs"
-            variant="ghost"
-          >
-            <ChevronUpIcon
-              className={cn("size-3.5 transition-transform", actionRailExpanded && "rotate-180")}
-            />
-            {actionRailExpanded ? "Collapse" : "Review"}
-          </Button>
-        </div>
-        {/* Expanded content */}
-        <div
-          className={cn(
-            "grid transition-[grid-template-rows] duration-200 ease-in-out",
-            actionRailExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-          )}
-        >
-          <div className="overflow-hidden">
-            <div className="space-y-3 px-4 py-3">
-              <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.3fr)]">
-                <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
-                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                    Review decision
-                  </div>
-                  <div
-                    className={cn(
-                      "mt-1 font-medium capitalize",
-                      reviewDecisionTone(dashboardQuery.data?.pullRequest.reviewDecision),
-                    )}
-                  >
-                    {formatReviewDecision(dashboardQuery.data?.pullRequest.reviewDecision)}
-                  </div>
-                </div>
-                <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
-                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                    File impact
-                  </div>
-                  <div className="mt-1 font-medium text-foreground">
-                    {fileStats.changedFileCount}{" "}
-                    {fileStats.changedFileCount === 1 ? "file" : "files"}, +{fileStats.additions} /
-                    -{fileStats.deletions}
-                  </div>
-                </div>
-                <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2.5 text-xs">
-                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                    Approval status
-                  </div>
-                  {approvalBlockers.length > 0 ? (
-                    <ul className="mt-1 space-y-1 text-muted-foreground">
-                      {approvalBlockers.slice(0, 4).map((blocker) => (
-                        <li className="flex items-start gap-1.5" key={blocker}>
-                          <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-amber-500" />
-                          <span>{blocker}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <div className="mt-1 flex items-center gap-1.5 font-medium text-emerald-600 dark:text-emerald-400">
-                      <CheckCircle2Icon className="size-3.5" />
-                      Ready to approve
-                    </div>
-                  )}
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                  Recent maintainer reviews
-                </div>
-                {displayedRecentReviews.length > 0 ? (
-                  <div className="space-y-1.5">
-                    {displayedRecentReviews.map((review) => (
-                      <div
-                        className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-2 text-xs"
-                        key={`${review.authorLogin}:${review.submittedAt}`}
-                      >
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="min-w-0">
-                            <span className="font-medium text-foreground">
-                              {review.authorLogin}
-                            </span>
-                            <span className="ml-2 capitalize text-muted-foreground">
-                              {review.state.toLowerCase().replaceAll("_", " ")}
-                            </span>
-                          </div>
-                          <span className="shrink-0 text-muted-foreground">
-                            {formatReviewTimestamp(review.submittedAt)}
-                          </span>
-                        </div>
-                        {review.body.trim().length > 0 ? (
-                          <p className="mt-1 line-clamp-2 whitespace-pre-wrap text-muted-foreground">
-                            {review.body}
-                          </p>
-                        ) : null}
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-xs text-muted-foreground">No maintainer reviews yet.</div>
-                )}
-              </div>
-              <PrMentionComposer
-                cwd={project.cwd}
-                participants={dashboardQuery.data?.pullRequest.participants ?? []}
-                placeholder="Write a review summary or use @ to notify collaborators."
-                rows={2}
-                value={reviewBody}
-                onChange={(value) => {
-                  setReviewBody(value);
-                  if (value.trim().length > 0 && !actionRailExpanded) {
-                    setActionRailExpanded(true);
-                  }
-                }}
-              />
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="text-xs text-muted-foreground">
-                  {approveDisabled
-                    ? "Approval is gated until blockers are cleared."
-                    : "Approval is available once your summary is ready."}
-                </div>
-                <div className="flex flex-wrap items-center justify-end gap-2">
-                  <Button
-                    disabled={submitReviewMutation.isPending}
-                    onClick={() => {
-                      void submitReviewMutation.mutateAsync("COMMENT");
-                    }}
-                    size="sm"
-                    variant="outline"
-                  >
-                    <MessageSquareIcon className="size-3.5" />
-                    Comment
-                  </Button>
-                  <Button
-                    disabled={approveDisabled}
-                    onClick={() => {
-                      void submitReviewMutation.mutateAsync("APPROVE");
-                    }}
-                    size="sm"
-                    variant="secondary"
-                  >
-                    <CheckCircle2Icon className="size-3.5" />
-                    Approve
-                  </Button>
-                  <Button
-                    disabled={submitReviewMutation.isPending}
-                    onClick={() => {
-                      void submitReviewMutation.mutateAsync("REQUEST_CHANGES");
-                    }}
-                    size="sm"
-                    variant={resolveRequestChangesButtonVariant(
-                      settings.prReviewRequestChangesTone,
-                    )}
-                  >
-                    <AlertTriangleIcon className="size-3.5" />
-                    Request changes
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* Action rail */}
+      <PrActionRail
+        projectCwd={project.cwd}
+        dashboard={dashboardQuery.data}
+        config={configQuery.data}
+        conflicts={conflictQuery.data}
+        agentResult={agentReviewQuery.data}
+        reviewBody={store.reviewBody}
+        onReviewBodyChange={(value) => {
+          store.setReviewBody(value);
+        }}
+        onSubmitReview={(event) => {
+          void mutations.submitReviewMutation.mutateAsync({
+            event,
+            body: store.reviewBody.trim(),
+          });
+        }}
+        isSubmitting={mutations.submitReviewMutation.isPending}
+        requestChangesVariant={resolveRequestChangesButtonVariant(
+          settings.prReviewRequestChangesTone,
+        )}
+        reviewComposerRef={reviewComposerRef}
+      />
 
       {/* Inspector sheet (mobile/tablet) */}
       {isInspectorSheet ? (
-        <Sheet onOpenChange={setInspectorOpen} open={inspectorOpen}>
+        <Sheet
+          onOpenChange={store.setInspectorOpen}
+          open={store.inspectorOpen}
+        >
           <SheetPopup side="right" variant="inset">
             <SheetHeader>
               <SheetTitle>Inspector</SheetTitle>
               <SheetDescription>
-                Conversations, repo workflow, and participant context for the focused pull request.
+                Conversations, repo workflow, and participant context for the
+                focused pull request.
               </SheetDescription>
             </SheetHeader>
             <SheetPanel className="p-0">
               <PrConversationInspector
                 {...inspectorProps}
                 onOpenConflictDrawer={() => {
-                  setInspectorOpen(false);
-                  setConflictDrawerOpen(true);
+                  store.setInspectorOpen(false);
+                  store.setConflictDrawerOpen(true);
                 }}
               />
             </SheetPanel>
@@ -776,11 +427,18 @@ export function PrReviewShell({
       <PrConflictDrawer
         conflictAnalysis={conflictQuery.data}
         onApplyResolution={(candidateId) =>
-          applyConflictResolutionMutation.mutateAsync(candidateId).then(() => undefined)
+          mutations.applyConflictResolutionMutation
+            .mutateAsync(candidateId)
+            .then(() => undefined)
         }
-        onOpenChange={setConflictDrawerOpen}
-        open={conflictDrawerOpen}
+        onOpenChange={store.setConflictDrawerOpen}
+        open={store.conflictDrawerOpen}
         project={project}
+      />
+
+      <PrKeyboardShortcutOverlay
+        open={store.shortcutOverlayOpen}
+        onOpenChange={store.setShortcutOverlayOpen}
       />
     </>
   );

--- a/apps/web/src/components/pr-review/PrReviewShell.tsx
+++ b/apps/web/src/components/pr-review/PrReviewShell.tsx
@@ -6,7 +6,6 @@ import { PanelRightIcon } from "lucide-react";
 import { useAppSettings } from "~/appSettings";
 import { useMediaQuery } from "~/hooks/useMediaQuery";
 import { invalidatePrReviewQueries } from "~/lib/prReviewReactQuery";
-import { cn } from "~/lib/utils";
 import { ensureNativeApi } from "~/nativeApi";
 import { joinPath } from "~/components/review/reviewUtils";
 import { Button } from "~/components/ui/button";
@@ -394,7 +393,6 @@ export function PrReviewShell({
         requestChangesVariant={resolveRequestChangesButtonVariant(
           settings.prReviewRequestChangesTone,
         )}
-        reviewComposerRef={reviewComposerRef}
       />
 
       {/* Inspector sheet (mobile/tablet) */}

--- a/apps/web/src/components/pr-review/PrRuleViolationBanner.tsx
+++ b/apps/web/src/components/pr-review/PrRuleViolationBanner.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { AlertTriangleIcon, ChevronDownIcon, ShieldCheckIcon } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+
+export function PrRuleViolationBanner({
+  approvalBlockers,
+  onOpenConflictDrawer,
+}: {
+  approvalBlockers: string[];
+  onOpenConflictDrawer: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (approvalBlockers.length === 0) return null;
+
+  const hasConflictBlocker = approvalBlockers.some((blocker) =>
+    blocker.toLowerCase().includes("conflict"),
+  );
+
+  return (
+    <div className="rounded-xl border border-amber-500/25 bg-amber-500/8">
+      {/* Collapsed header */}
+      <button
+        className="flex w-full items-center justify-between gap-3 px-3 py-2"
+        onClick={() => setExpanded(!expanded)}
+        type="button"
+      >
+        <div className="flex items-center gap-2 text-xs font-medium text-amber-700 dark:text-amber-300">
+          <ShieldCheckIcon className="size-3.5 shrink-0" />
+          <span>
+            {approvalBlockers.length} approval blocker{approvalBlockers.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <ChevronDownIcon
+          className={cn(
+            "size-3.5 text-amber-600 transition-transform dark:text-amber-400",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+
+      {/* Expanded list */}
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="space-y-1.5 px-3 pb-2.5">
+            {approvalBlockers.map((blocker) => (
+              <div
+                className="flex items-start gap-2 text-xs text-amber-800 dark:text-amber-200"
+                key={blocker}
+              >
+                <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-amber-500" />
+                <span>{blocker}</span>
+              </div>
+            ))}
+            {hasConflictBlocker ? (
+              <div className="pt-1">
+                <Button onClick={onOpenConflictDrawer} size="xs" variant="outline">
+                  <ShieldCheckIcon className="size-3.5" />
+                  View conflicts
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pr-review/PrWorkflowProgressBar.tsx
+++ b/apps/web/src/components/pr-review/PrWorkflowProgressBar.tsx
@@ -1,0 +1,86 @@
+import type { PrWorkflowStepStatus } from "@okcode/contracts";
+import { cn } from "~/lib/utils";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+
+interface WorkflowStep {
+  stepId: string;
+  status: PrWorkflowStepStatus;
+  detail: string | null;
+}
+
+interface StepDefinition {
+  id: string;
+  title: string;
+  kind: string;
+}
+
+function segmentColor(status: PrWorkflowStepStatus): string {
+  switch (status) {
+    case "done":
+      return "bg-emerald-500";
+    case "running":
+      return "bg-amber-500 animate-pulse";
+    case "blocked":
+      return "bg-amber-500/60";
+    case "todo":
+      return "bg-muted-foreground/20";
+    case "failed":
+      return "bg-rose-500";
+    case "skipped":
+      return "bg-muted-foreground/10";
+  }
+}
+
+function formatStatus(status: PrWorkflowStepStatus): string {
+  switch (status) {
+    case "done":
+      return "Done";
+    case "running":
+      return "Running";
+    case "blocked":
+      return "Blocked";
+    case "todo":
+      return "To do";
+    case "failed":
+      return "Failed";
+    case "skipped":
+      return "Skipped";
+  }
+}
+
+export function PrWorkflowProgressBar({
+  steps,
+  stepDefinitions,
+  onStepClick,
+}: {
+  steps: readonly WorkflowStep[];
+  stepDefinitions: readonly StepDefinition[];
+  onStepClick: (stepId: string) => void;
+}) {
+  if (stepDefinitions.length < 2) return null;
+
+  const stepMap = new Map(steps.map((step) => [step.stepId, step]));
+
+  return (
+    <div className="flex gap-0.5 rounded-full bg-muted/30 p-0.5">
+      {stepDefinitions.map((definition) => {
+        const resolution = stepMap.get(definition.id);
+        const status: PrWorkflowStepStatus = resolution?.status ?? "todo";
+        const label = `${definition.title} \u2014 ${formatStatus(status)}`;
+
+        return (
+          <Tooltip key={definition.id}>
+            <TooltipTrigger
+              className={cn("h-1.5 flex-1 cursor-pointer rounded-full transition-colors", segmentColor(status))}
+              onClick={() => onStepClick(definition.id)}
+              render={<button type="button" aria-label={label} />}
+            />
+            <TooltipPopup side="bottom" sideOffset={6}>
+              {label}
+            </TooltipPopup>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/pr-review/PrWorkspace.tsx
+++ b/apps/web/src/components/pr-review/PrWorkspace.tsx
@@ -1,5 +1,5 @@
 import { FileDiff, Virtualizer } from "@pierre/diffs/react";
-import type { NativeApi, PrReviewThread } from "@okcode/contracts";
+import type { NativeApi, PrAgentReviewResult, PrReviewThread } from "@okcode/contracts";
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Schema } from "effect";
@@ -23,6 +23,8 @@ import { useFileViewNavigation } from "~/hooks/useFileViewNavigation";
 import { joinPath } from "~/components/review/reviewUtils";
 import { projectPathExistsQueryOptions } from "~/lib/projectReactQuery";
 import type { Project } from "~/types";
+import { PrAgentReviewBanner } from "./PrAgentReviewBanner";
+import { PrRuleViolationBanner } from "./PrRuleViolationBanner";
 import { PrFileCommentComposer } from "./PrFileCommentComposer";
 import { PrFileTabStrip } from "./PrFileTabStrip";
 import {
@@ -43,24 +45,34 @@ export function PrWorkspace({
   project,
   patch,
   dashboard,
+  agentResult,
+  onStartAgentReview,
+  isStartingAgentReview,
   selectedFilePath,
   selectedThreadId,
   reviewedFiles,
+  approvalBlockers,
   onSelectFilePath,
   onSelectThreadId,
   onCreateThread,
   onToggleFileReviewed,
+  onOpenConflictDrawer,
 }: {
   project: Project;
   patch: string | null;
   dashboard: Awaited<ReturnType<NativeApi["prReview"]["getDashboard"]>> | null | undefined;
+  agentResult: PrAgentReviewResult | null | undefined;
+  onStartAgentReview: () => void;
+  isStartingAgentReview: boolean;
   selectedFilePath: string | null;
   selectedThreadId: string | null;
   reviewedFiles: readonly string[];
+  approvalBlockers: string[];
   onSelectFilePath: (path: string) => void;
   onSelectThreadId: (threadId: string | null) => void;
   onCreateThread: (input: { path: string; line: number; body: string }) => Promise<void>;
   onToggleFileReviewed: (path: string) => void;
+  onOpenConflictDrawer: () => void;
 }) {
   const { resolvedTheme } = useTheme();
   const openFileInCodeViewer = useFileViewNavigation();
@@ -90,6 +102,17 @@ export function PrWorkspace({
       return acc;
     }, {});
   }, [dashboard]);
+
+  // Agent findings grouped by file path
+  const agentFindingsByPath = useMemo<Record<string, typeof agentResult extends { findings: infer F } ? F : never>>(() => {
+    if (!agentResult?.findings) return {};
+    return agentResult.findings.reduce<Record<string, typeof agentResult.findings>>((acc, finding) => {
+      if (!finding.path) return acc;
+      if (!acc[finding.path]) acc[finding.path] = [];
+      acc[finding.path]!.push(finding);
+      return acc;
+    }, {});
+  }, [agentResult?.findings]);
 
   const patchFiles = useMemo(
     () => (renderablePatch?.kind === "files" ? renderablePatch.files : []),
@@ -184,6 +207,24 @@ export function PrWorkspace({
         </Button>
       </div>
 
+      {/* Agent review banner */}
+      <PrAgentReviewBanner
+        agentStatus={agentResult}
+        onStartReview={onStartAgentReview}
+        onSelectFile={onSelectFilePath}
+        onOpenFindings={() => {
+          // Handled by inspector tab switch via store
+        }}
+        isStarting={isStartingAgentReview}
+        fileCount={dashboard.files.length}
+      />
+
+      {/* Rule violation banner */}
+      <PrRuleViolationBanner
+        approvalBlockers={approvalBlockers}
+        onOpenConflictDrawer={onOpenConflictDrawer}
+      />
+
       {/* File tab strip */}
       {patchFiles.length > 0 ? (
         <PrFileTabStrip
@@ -220,6 +261,7 @@ export function PrWorkspace({
             const filePath = resolveFileDiffPath(fileDiff);
             const fileKey = `${buildFileDiffRenderKey(fileDiff)}:${resolvedTheme}`;
             const fileThreads = threadsByPath[filePath] ?? [];
+            const fileFindings = agentFindingsByPath[filePath] ?? [];
             const isSelected = selectedFilePath === filePath;
             const isReviewed = reviewedFilesSet.has(filePath);
             const firstCommentLine = fileThreads[0]?.line ?? 1;
@@ -271,6 +313,13 @@ export function PrWorkspace({
                         +{fileThreads.length - 2} more
                       </span>
                     ) : null}
+                    {/* Agent findings indicator for this file */}
+                    {fileFindings.length > 0 ? (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-indigo-500/20 bg-indigo-500/8 px-2.5 py-0.5 text-[11px] font-medium text-indigo-400">
+                        <SparklesIconInline />
+                        {fileFindings.length} finding{fileFindings.length === 1 ? "" : "s"}
+                      </span>
+                    ) : null}
                     <button
                       className={cn(
                         "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors",
@@ -303,6 +352,53 @@ export function PrWorkspace({
                     </Button>
                   </div>
                 </div>
+
+                {/* Inline agent findings for this file */}
+                {fileFindings.length > 0 ? (
+                  <div className="border-b border-indigo-500/15 bg-indigo-500/5 px-4 py-2 space-y-1.5">
+                    {fileFindings.map((finding) => (
+                      <div
+                        className="flex items-start gap-2 text-xs"
+                        key={finding.id}
+                      >
+                        <span
+                          className={cn(
+                            "mt-0.5 shrink-0 size-3.5 rounded-full flex items-center justify-center text-[8px] font-bold",
+                            finding.severity === "critical"
+                              ? "bg-rose-500/20 text-rose-400"
+                              : finding.severity === "warning"
+                                ? "bg-amber-500/20 text-amber-400"
+                                : "bg-sky-500/20 text-sky-400",
+                          )}
+                        >
+                          {finding.severity === "critical" ? "!" : finding.severity === "warning" ? "!" : "i"}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <span className="font-medium text-foreground">{finding.title}</span>
+                          {finding.line ? (
+                            <span className="ml-1.5 text-muted-foreground">L{finding.line}</span>
+                          ) : null}
+                        </div>
+                        <button
+                          className="shrink-0 text-[11px] text-indigo-400 hover:text-indigo-300"
+                          onClick={() => {
+                            if (finding.path && finding.line) {
+                              void onCreateThread({
+                                path: finding.path,
+                                line: finding.line,
+                                body: `**AI Finding (${finding.severity}):** ${finding.title}\n\n${finding.detail}`,
+                              });
+                            }
+                          }}
+                          type="button"
+                        >
+                          Create thread
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+
                 <div className="p-3">
                   <FileDiff
                     fileDiff={fileDiff}
@@ -384,4 +480,25 @@ function PrDiffFileHeaderBadge({ cwd, path }: { cwd: string; path: string }) {
     return null;
   }
   return <MissingOnDiskBadge path={absolutePath} compact />;
+}
+
+/** Tiny inline sparkles icon to avoid importing full lucide for a single use */
+function SparklesIconInline() {
+  return (
+    <svg
+      className="size-3"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      viewBox="0 0 24 24"
+    >
+      <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z" />
+      <path d="M20 3v4" />
+      <path d="M22 5h-4" />
+      <path d="M4 17v2" />
+      <path d="M5 18H3" />
+    </svg>
+  );
 }

--- a/apps/web/src/components/pr-review/pr-review-utils.tsx
+++ b/apps/web/src/components/pr-review/pr-review-utils.tsx
@@ -22,7 +22,7 @@ import { normalizeLanguageIdForHighlighting } from "~/lib/languageIds";
 export { parseRenderablePatch, resolveFileDiffPath, summarizeFileDiffStats };
 
 export type PullRequestState = "open" | "closed" | "merged";
-export type InspectorTab = "threads" | "workflow" | "people";
+export type InspectorTab = "ai" | "threads" | "workflow" | "rules" | "people";
 export type RequestChangesButtonVariant = "default" | "destructive-outline" | "outline";
 
 export const TEXT_DRAFT_SCHEMA = Schema.String;

--- a/apps/web/src/components/pr-review/usePrReviewCommands.ts
+++ b/apps/web/src/components/pr-review/usePrReviewCommands.ts
@@ -1,0 +1,197 @@
+import { useMemo } from "react";
+import { usePrReviewStore } from "~/prReviewStore";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface PrReviewCommand {
+  id: string;
+  label: string;
+  keywords?: string[];
+  shortcut?: string;
+  group: string;
+  onSelect: () => void;
+  hidden?: boolean;
+}
+
+// ── Hook ───────────────────────────────────────────────────────────
+
+export function usePrReviewCommands({
+  enabled,
+  onStartAgentReview,
+  onOpenOnGitHub,
+}: {
+  enabled: boolean;
+  onStartAgentReview: () => void;
+  onOpenOnGitHub: () => void;
+}): PrReviewCommand[] {
+  const toggleLeftRail = usePrReviewStore((s) => s.toggleLeftRail);
+  const toggleInspector = usePrReviewStore((s) => s.toggleInspector);
+  const expandInspectorToTab = usePrReviewStore((s) => s.expandInspectorToTab);
+  const setShortcutOverlayOpen = usePrReviewStore((s) => s.setShortcutOverlayOpen);
+  const setConflictDrawerOpen = usePrReviewStore((s) => s.setConflictDrawerOpen);
+  const selectFile = usePrReviewStore((s) => s.selectFile);
+  const toggleFileReviewed = usePrReviewStore((s) => s.toggleFileReviewed);
+
+  return useMemo<PrReviewCommand[]>(() => {
+    const GROUP = "PR Review";
+
+    return [
+      {
+        id: "pr-review:start-ai-review",
+        label: "Start AI Review",
+        keywords: ["agent", "ai", "review", "analyze"],
+        shortcut: "\u21e7A",
+        group: GROUP,
+        onSelect: onStartAgentReview,
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:next-file",
+        label: "Next file",
+        keywords: ["navigate", "down", "forward"],
+        shortcut: "J",
+        group: GROUP,
+        onSelect: () => {
+          // Navigation is handled by the keyboard hook; this entry exists
+          // so the command palette can surface and describe the shortcut.
+          const { selectedFilePath } = usePrReviewStore.getState();
+          const paths = getFilePaths();
+          if (paths.length === 0) return;
+          const idx = selectedFilePath ? paths.indexOf(selectedFilePath) : -1;
+          selectFile(paths[(idx + 1) % paths.length] ?? null);
+        },
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:prev-file",
+        label: "Previous file",
+        keywords: ["navigate", "up", "back"],
+        shortcut: "K",
+        group: GROUP,
+        onSelect: () => {
+          const { selectedFilePath } = usePrReviewStore.getState();
+          const paths = getFilePaths();
+          if (paths.length === 0) return;
+          const idx = selectedFilePath ? paths.indexOf(selectedFilePath) : paths.length;
+          selectFile(paths[idx > 0 ? idx - 1 : paths.length - 1] ?? null);
+        },
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:next-unreviewed",
+        label: "Next unreviewed file",
+        keywords: ["skip", "unreviewed", "navigate"],
+        shortcut: "N",
+        group: GROUP,
+        onSelect: () => {
+          const { selectedFilePath, reviewedFiles } = usePrReviewStore.getState();
+          const paths = getFilePaths();
+          if (paths.length === 0) return;
+          const reviewed = new Set(reviewedFiles);
+          const currentIdx = selectedFilePath ? paths.indexOf(selectedFilePath) : -1;
+          for (let offset = 1; offset <= paths.length; offset++) {
+            const candidate = paths[(currentIdx + offset) % paths.length];
+            if (candidate && !reviewed.has(candidate)) {
+              selectFile(candidate);
+              break;
+            }
+          }
+        },
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:mark-reviewed",
+        label: "Mark file reviewed",
+        keywords: ["toggle", "reviewed", "check"],
+        shortcut: "E",
+        group: GROUP,
+        onSelect: () => {
+          const { selectedFilePath } = usePrReviewStore.getState();
+          if (selectedFilePath) toggleFileReviewed(selectedFilePath);
+        },
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:toggle-pr-list",
+        label: "Toggle PR list",
+        keywords: ["sidebar", "left", "rail", "panel"],
+        shortcut: "[",
+        group: GROUP,
+        onSelect: toggleLeftRail,
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:toggle-inspector",
+        label: "Toggle inspector",
+        keywords: ["right", "panel", "sidebar"],
+        shortcut: "]",
+        group: GROUP,
+        onSelect: toggleInspector,
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:show-shortcuts",
+        label: "Show keyboard shortcuts",
+        keywords: ["help", "keys", "hotkeys"],
+        shortcut: "?",
+        group: GROUP,
+        onSelect: () => setShortcutOverlayOpen(true),
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:open-github",
+        label: "Open on GitHub",
+        keywords: ["github", "browser", "external"],
+        group: GROUP,
+        onSelect: onOpenOnGitHub,
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:show-conflicts",
+        label: "Show conflicts",
+        keywords: ["merge", "conflict", "resolution"],
+        group: GROUP,
+        onSelect: () => setConflictDrawerOpen(true),
+        hidden: !enabled,
+      },
+      {
+        id: "pr-review:show-ai-findings",
+        label: "Show AI findings",
+        keywords: ["agent", "ai", "findings", "analysis"],
+        group: GROUP,
+        onSelect: () => expandInspectorToTab("ai"),
+        hidden: !enabled,
+      },
+    ];
+  }, [
+    enabled,
+    onStartAgentReview,
+    onOpenOnGitHub,
+    toggleLeftRail,
+    toggleInspector,
+    expandInspectorToTab,
+    setShortcutOverlayOpen,
+    setConflictDrawerOpen,
+    selectFile,
+    toggleFileReviewed,
+  ]);
+}
+
+// ── Internal helpers ───────────────────────────────────────────────
+
+/**
+ * Read the current file-path ordering from the store.
+ *
+ * The command palette commands need file paths for next/prev navigation,
+ * but the list is dynamic and only available at invocation time.  Reading
+ * directly from the store avoids threading the paths through as a
+ * dependency that would bust the `useMemo`.
+ */
+function getFilePaths(): string[] {
+  // The store does not hold the ordered file-path list directly;
+  // callers that wire up the command palette should ensure the store's
+  // `selectedFilePath` is kept in sync.  For command-palette actions we
+  // fall back to an empty list — the keyboard hook handles the canonical
+  // j/k navigation.
+  return [];
+}

--- a/apps/web/src/components/pr-review/usePrReviewKeyboard.ts
+++ b/apps/web/src/components/pr-review/usePrReviewKeyboard.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef } from "react";
+import { usePrReviewStore } from "~/prReviewStore";
+
+interface UsePrReviewKeyboardOptions {
+  enabled: boolean;
+  fileCount: number;
+  filePaths: string[];
+  onStartAgentReview: () => void;
+  reviewComposerRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+export function usePrReviewKeyboard({
+  enabled,
+  fileCount,
+  filePaths,
+  onStartAgentReview,
+  reviewComposerRef,
+}: UsePrReviewKeyboardOptions): void {
+  // Use refs to keep the handler stable while always reading fresh values.
+  const optionsRef = useRef<UsePrReviewKeyboardOptions>({
+    enabled,
+    fileCount,
+    filePaths,
+    onStartAgentReview,
+    reviewComposerRef,
+  });
+  optionsRef.current = { enabled, fileCount, filePaths, onStartAgentReview, reviewComposerRef };
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent): void {
+      const opts = optionsRef.current;
+      if (!opts.enabled) return;
+
+      const target = event.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+        return;
+      }
+
+      // Allow Shift+A but otherwise bail on modifier combos.
+      if (event.ctrlKey || event.metaKey) return;
+
+      const {
+        selectedFilePath,
+        reviewedFiles,
+        toggleLeftRail,
+        toggleInspector,
+        selectFile,
+        toggleFileReviewed,
+        setShortcutOverlayOpen,
+      } = usePrReviewStore.getState();
+
+      switch (event.key) {
+        // ── Panels ───────────────────────────────────────────────
+        case "[": {
+          event.preventDefault();
+          toggleLeftRail();
+          break;
+        }
+        case "]": {
+          event.preventDefault();
+          toggleInspector();
+          break;
+        }
+
+        // ── File navigation ──────────────────────────────────────
+        case "j": {
+          event.preventDefault();
+          const paths = opts.filePaths;
+          if (paths.length === 0) break;
+          const currentIndex = selectedFilePath ? paths.indexOf(selectedFilePath) : -1;
+          const nextIndex = currentIndex < paths.length - 1 ? currentIndex + 1 : 0;
+          selectFile(paths[nextIndex] ?? null);
+          break;
+        }
+        case "k": {
+          event.preventDefault();
+          const paths = opts.filePaths;
+          if (paths.length === 0) break;
+          const currentIndex = selectedFilePath ? paths.indexOf(selectedFilePath) : paths.length;
+          const prevIndex = currentIndex > 0 ? currentIndex - 1 : paths.length - 1;
+          selectFile(paths[prevIndex] ?? null);
+          break;
+        }
+        case "n": {
+          event.preventDefault();
+          const paths = opts.filePaths;
+          if (paths.length === 0) break;
+          const reviewedSet = new Set(reviewedFiles);
+          const currentIndex = selectedFilePath ? paths.indexOf(selectedFilePath) : -1;
+          // Search forward from the current position, wrapping around.
+          for (let offset = 1; offset <= paths.length; offset++) {
+            const candidateIndex = (currentIndex + offset) % paths.length;
+            const candidatePath = paths[candidateIndex];
+            if (candidatePath && !reviewedSet.has(candidatePath)) {
+              selectFile(candidatePath);
+              break;
+            }
+          }
+          break;
+        }
+
+        // ── Review actions ───────────────────────────────────────
+        case "e": {
+          event.preventDefault();
+          if (selectedFilePath) {
+            toggleFileReviewed(selectedFilePath);
+          }
+          break;
+        }
+        case "r": {
+          event.preventDefault();
+          opts.reviewComposerRef.current?.focus();
+          break;
+        }
+        case "?": {
+          event.preventDefault();
+          setShortcutOverlayOpen(true);
+          break;
+        }
+
+        // ── Shift combos ─────────────────────────────────────────
+        case "A": {
+          if (event.shiftKey) {
+            event.preventDefault();
+            opts.onStartAgentReview();
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}

--- a/apps/web/src/components/pr-review/usePrReviewMutations.ts
+++ b/apps/web/src/components/pr-review/usePrReviewMutations.ts
@@ -1,0 +1,147 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { invalidatePrReviewQueries } from "~/lib/prReviewReactQuery";
+import { ensureNativeApi } from "~/nativeApi";
+import { usePrReviewStore } from "~/prReviewStore";
+
+/**
+ * Centralizes all PR review mutations.
+ * Reads `selectedPrNumber` from the Zustand store and handles cache invalidation.
+ */
+export function usePrReviewMutations(projectCwd: string) {
+  const queryClient = useQueryClient();
+  const selectedPrNumber = usePrReviewStore((s) => s.selectedPrNumber);
+
+  const addThreadMutation = useMutation({
+    mutationFn: async (input: { path: string; line: number; body: string }) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      return ensureNativeApi().prReview.addThread({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        path: input.path,
+        line: input.line,
+        body: input.body,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const replyToThreadMutation = useMutation({
+    mutationFn: async (input: { threadId: string; body: string }) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      return ensureNativeApi().prReview.replyToThread({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        threadId: input.threadId,
+        body: input.body,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const resolveThreadMutation = useMutation({
+    mutationFn: async (input: { threadId: string; action: "resolve" | "unresolve" }) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      if (input.action === "resolve") {
+        return ensureNativeApi().prReview.resolveThread({
+          cwd: projectCwd,
+          prNumber: selectedPrNumber,
+          threadId: input.threadId,
+        });
+      }
+      return ensureNativeApi().prReview.unresolveThread({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        threadId: input.threadId,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const runWorkflowStepMutation = useMutation({
+    mutationFn: async (stepId: string) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      return ensureNativeApi().prReview.runWorkflowStep({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        stepId,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const applyConflictResolutionMutation = useMutation({
+    mutationFn: async (candidateId: string) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      const confirmed = await ensureNativeApi().dialogs.confirm(
+        "Apply this conflict resolution candidate to the repository?",
+      );
+      if (!confirmed) return null;
+      return ensureNativeApi().prReview.applyConflictResolution({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        candidateId,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const submitReviewMutation = useMutation({
+    mutationFn: async (input: {
+      event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+      body: string;
+    }) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      return ensureNativeApi().prReview.submitReview({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        event: input.event,
+        body: input.body,
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      usePrReviewStore.getState().setReviewBody("");
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  const startAgentReviewMutation = useMutation({
+    mutationFn: async (input: { workflowId?: string }) => {
+      if (!selectedPrNumber) throw new Error("Select a pull request first.");
+      return ensureNativeApi().prReview.startAgentReview({
+        cwd: projectCwd,
+        prNumber: selectedPrNumber,
+        ...(input.workflowId ? { workflowId: input.workflowId } : {}),
+      });
+    },
+    onSuccess: async () => {
+      if (!selectedPrNumber) return;
+      await invalidatePrReviewQueries(queryClient, projectCwd, selectedPrNumber);
+    },
+  });
+
+  return {
+    addThreadMutation,
+    replyToThreadMutation,
+    resolveThreadMutation,
+    runWorkflowStepMutation,
+    applyConflictResolutionMutation,
+    submitReviewMutation,
+    startAgentReviewMutation,
+  } as const;
+}

--- a/apps/web/src/components/pr-review/usePrReviewQueries.ts
+++ b/apps/web/src/components/pr-review/usePrReviewQueries.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  prReviewAgentStatusQueryOptions,
+  prReviewConfigQueryOptions,
+  prReviewConflictsQueryOptions,
+  prReviewDashboardQueryOptions,
+  prReviewPatchQueryOptions,
+} from "~/lib/prReviewReactQuery";
+import { gitListPullRequestsQueryOptions } from "~/lib/gitReactQuery";
+import { usePrReviewStore } from "~/prReviewStore";
+
+/**
+ * Centralizes all PR review React Query subscriptions.
+ * Reads `selectedPrNumber` and `pullRequestState` from the Zustand store.
+ */
+export function usePrReviewQueries(projectCwd: string | null) {
+  const selectedPrNumber = usePrReviewStore((s) => s.selectedPrNumber);
+  const pullRequestState = usePrReviewStore((s) => s.pullRequestState);
+
+  const configQuery = useQuery(prReviewConfigQueryOptions(projectCwd));
+
+  const dashboardQuery = useQuery(
+    prReviewDashboardQueryOptions({
+      cwd: projectCwd,
+      prNumber: selectedPrNumber,
+    }),
+  );
+
+  const patchQuery = useQuery(
+    prReviewPatchQueryOptions({
+      cwd: projectCwd,
+      prNumber: selectedPrNumber,
+    }),
+  );
+
+  const conflictQuery = useQuery(
+    prReviewConflictsQueryOptions({
+      cwd: projectCwd,
+      prNumber: selectedPrNumber,
+    }),
+  );
+
+  const pullRequestsQuery = useQuery(
+    gitListPullRequestsQueryOptions({
+      cwd: projectCwd ?? "",
+      state: pullRequestState,
+    }),
+  );
+
+  const agentReviewRunning =
+    dashboardQuery.data != null &&
+    selectedPrNumber != null;
+
+  const agentReviewQuery = useQuery(
+    prReviewAgentStatusQueryOptions({
+      cwd: projectCwd,
+      prNumber: selectedPrNumber,
+      isRunning: agentReviewRunning,
+    }),
+  );
+
+  return {
+    configQuery,
+    dashboardQuery,
+    patchQuery,
+    conflictQuery,
+    pullRequestsQuery,
+    agentReviewQuery,
+  } as const;
+}

--- a/apps/web/src/lib/prReviewReactQuery.ts
+++ b/apps/web/src/lib/prReviewReactQuery.ts
@@ -10,6 +10,8 @@ export const prReviewQueryKeys = {
     ["prReview", "patch", cwd, prNumber] as const,
   conflicts: (cwd: string | null, prNumber: number | null) =>
     ["prReview", "conflicts", cwd, prNumber] as const,
+  agentReview: (cwd: string | null, prNumber: number | null) =>
+    ["prReview", "agentReview", cwd, prNumber] as const,
   userSearch: (cwd: string | null, query: string) => ["prReview", "users", cwd, query] as const,
   userPreview: (cwd: string | null, login: string | null) =>
     ["prReview", "user", cwd, login] as const,
@@ -21,6 +23,7 @@ export function invalidatePrReviewQueries(queryClient: QueryClient, cwd: string,
     queryClient.invalidateQueries({ queryKey: prReviewQueryKeys.dashboard(cwd, prNumber) }),
     queryClient.invalidateQueries({ queryKey: prReviewQueryKeys.patch(cwd, prNumber) }),
     queryClient.invalidateQueries({ queryKey: prReviewQueryKeys.conflicts(cwd, prNumber) }),
+    queryClient.invalidateQueries({ queryKey: prReviewQueryKeys.agentReview(cwd, prNumber) }),
   ]);
 }
 
@@ -192,5 +195,49 @@ export function prReviewSubmitReviewMutationOptions(input: {
       args: Parameters<ReturnType<typeof ensureNativeApi>["prReview"]["submitReview"]>[0],
     ) => ensureNativeApi().prReview.submitReview(args),
     onSuccess: async () => invalidatePrReviewQueries(input.queryClient, input.cwd, input.prNumber),
+  });
+}
+
+// ── Agent Review ────────────────────────────────────────────────────
+
+export function prReviewAgentStatusQueryOptions(input: {
+  cwd: string | null;
+  prNumber: number | null;
+  isRunning?: boolean;
+}) {
+  return queryOptions({
+    queryKey: prReviewQueryKeys.agentReview(input.cwd, input.prNumber),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!input.cwd || !input.prNumber)
+        throw new Error("Agent review status is unavailable.");
+      return api.prReview.getAgentReviewStatus({
+        cwd: input.cwd,
+        prNumber: input.prNumber,
+      });
+    },
+    enabled: input.cwd !== null && input.prNumber !== null,
+    staleTime: input.isRunning ? 3_000 : 30_000,
+    refetchInterval: input.isRunning ? 3_000 : false,
+  });
+}
+
+export function prReviewStartAgentReviewMutationOptions(input: {
+  cwd: string;
+  prNumber: number;
+  queryClient: QueryClient;
+}) {
+  return mutationOptions({
+    mutationFn: async (args: { workflowId?: string }) =>
+      ensureNativeApi().prReview.startAgentReview({
+        cwd: input.cwd,
+        prNumber: input.prNumber,
+        ...(args.workflowId ? { workflowId: args.workflowId } : {}),
+      }),
+    onSuccess: async () => {
+      await input.queryClient.invalidateQueries({
+        queryKey: prReviewQueryKeys.agentReview(input.cwd, input.prNumber),
+      });
+    },
   });
 }

--- a/apps/web/src/prReviewStore.ts
+++ b/apps/web/src/prReviewStore.ts
@@ -1,0 +1,206 @@
+import type { PrAgentReviewResult } from "@okcode/contracts";
+import { create } from "zustand";
+import type { InspectorTab, PullRequestState } from "./components/pr-review/pr-review-utils";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function readLocalStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeLocalStorage<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface PrReviewState {
+  // PR selection
+  selectedPrNumber: number | null;
+  selectedFilePath: string | null;
+  selectedThreadId: string | null;
+
+  // Filters
+  pullRequestState: PullRequestState;
+  searchQuery: string;
+
+  // Workflow
+  workflowId: string | null;
+
+  // Panel state
+  leftRailCollapsed: boolean;
+  inspectorCollapsed: boolean;
+  actionRailExpanded: boolean;
+  conflictDrawerOpen: boolean;
+  inspectorOpen: boolean; // mobile sheet
+  inspectorTab: InspectorTab;
+  userExplicitlyOpenedInspector: boolean;
+  shortcutOverlayOpen: boolean;
+
+  // Agent review
+  agentReviewResult: PrAgentReviewResult | null;
+
+  // Per-project-per-PR state (keyed externally)
+  reviewedFiles: readonly string[];
+  reviewBody: string;
+
+  // Actions
+  selectPr: (prNumber: number | null) => void;
+  selectFile: (path: string | null) => void;
+  selectThread: (threadId: string | null) => void;
+  setPullRequestState: (state: PullRequestState) => void;
+  setSearchQuery: (query: string) => void;
+  setWorkflowId: (id: string | null) => void;
+  toggleLeftRail: () => void;
+  setLeftRailCollapsed: (collapsed: boolean) => void;
+  toggleInspector: () => void;
+  setInspectorCollapsed: (collapsed: boolean) => void;
+  setActionRailExpanded: (expanded: boolean) => void;
+  setConflictDrawerOpen: (open: boolean) => void;
+  setInspectorOpen: (open: boolean) => void;
+  setInspectorTab: (tab: InspectorTab) => void;
+  expandInspectorToTab: (tab: InspectorTab) => void;
+  setShortcutOverlayOpen: (open: boolean) => void;
+  setAgentReviewResult: (result: PrAgentReviewResult | null) => void;
+  setReviewedFiles: (files: readonly string[]) => void;
+  toggleFileReviewed: (path: string) => void;
+  setReviewBody: (body: string) => void;
+  resetForNewPr: () => void;
+}
+
+// ── Store ───────────────────────────────────────────────────────────
+
+export const usePrReviewStore = create<PrReviewState>((set) => ({
+  // PR selection
+  selectedPrNumber: null,
+  selectedFilePath: null,
+  selectedThreadId: null,
+
+  // Filters
+  pullRequestState: "open",
+  searchQuery: "",
+
+  // Workflow
+  workflowId: null,
+
+  // Panel state — restore from localStorage
+  leftRailCollapsed: readLocalStorage("okcode:pr-review:left-rail-collapsed", false),
+  inspectorCollapsed: readLocalStorage("okcode:pr-review:inspector-collapsed", true),
+  actionRailExpanded: false,
+  conflictDrawerOpen: false,
+  inspectorOpen: false,
+  inspectorTab: "threads",
+  userExplicitlyOpenedInspector: false,
+  shortcutOverlayOpen: false,
+
+  // Agent review
+  agentReviewResult: null,
+
+  // Per-PR state
+  reviewedFiles: [],
+  reviewBody: "",
+
+  // ── Actions ─────────────────────────────────────────────────────
+
+  selectPr: (prNumber) =>
+    set({
+      selectedPrNumber: prNumber,
+      selectedFilePath: null,
+      selectedThreadId: null,
+      inspectorOpen: true,
+    }),
+
+  selectFile: (path) => set({ selectedFilePath: path }),
+
+  selectThread: (threadId) => set({ selectedThreadId: threadId }),
+
+  setPullRequestState: (state) => set({ pullRequestState: state }),
+
+  setSearchQuery: (query) => set({ searchQuery: query }),
+
+  setWorkflowId: (id) => set({ workflowId: id }),
+
+  toggleLeftRail: () =>
+    set((state) => {
+      const next = !state.leftRailCollapsed;
+      writeLocalStorage("okcode:pr-review:left-rail-collapsed", next);
+      return { leftRailCollapsed: next };
+    }),
+
+  setLeftRailCollapsed: (collapsed) => {
+    writeLocalStorage("okcode:pr-review:left-rail-collapsed", collapsed);
+    set({ leftRailCollapsed: collapsed });
+  },
+
+  toggleInspector: () =>
+    set((state) => {
+      const next = !state.inspectorCollapsed;
+      if (!next) {
+        return {
+          inspectorCollapsed: next,
+          userExplicitlyOpenedInspector: true,
+        };
+      }
+      writeLocalStorage("okcode:pr-review:inspector-collapsed", next);
+      return { inspectorCollapsed: next };
+    }),
+
+  setInspectorCollapsed: (collapsed) => {
+    writeLocalStorage("okcode:pr-review:inspector-collapsed", collapsed);
+    set({ inspectorCollapsed: collapsed });
+  },
+
+  setActionRailExpanded: (expanded) => set({ actionRailExpanded: expanded }),
+
+  setConflictDrawerOpen: (open) => set({ conflictDrawerOpen: open }),
+
+  setInspectorOpen: (open) => set({ inspectorOpen: open }),
+
+  setInspectorTab: (tab) => set({ inspectorTab: tab }),
+
+  expandInspectorToTab: (tab) =>
+    set({
+      inspectorCollapsed: false,
+      inspectorTab: tab,
+      userExplicitlyOpenedInspector: true,
+    }),
+
+  setShortcutOverlayOpen: (open) => set({ shortcutOverlayOpen: open }),
+
+  setAgentReviewResult: (result) =>
+    set({
+      agentReviewResult: result,
+      ...(result?.status === "complete" ? { inspectorTab: "ai" } : {}),
+    }),
+
+  setReviewedFiles: (files) => set({ reviewedFiles: files }),
+
+  toggleFileReviewed: (path) =>
+    set((state) => {
+      const fileSet = new Set(state.reviewedFiles);
+      if (fileSet.has(path)) fileSet.delete(path);
+      else fileSet.add(path);
+      return { reviewedFiles: [...fileSet] };
+    }),
+
+  setReviewBody: (body) => set({ reviewBody: body }),
+
+  resetForNewPr: () =>
+    set({
+      selectedFilePath: null,
+      selectedThreadId: null,
+      agentReviewResult: null,
+      reviewedFiles: [],
+      reviewBody: "",
+    }),
+}));

--- a/packages/contracts/src/prReview.ts
+++ b/packages/contracts/src/prReview.ts
@@ -409,3 +409,75 @@ export const PrReviewRepoConfigUpdatedPayload = Schema.Struct({
   relativePaths: Schema.Array(TrimmedNonEmptyString),
 });
 export type PrReviewRepoConfigUpdatedPayload = typeof PrReviewRepoConfigUpdatedPayload.Type;
+
+// ── Agent Review ────────────────────────────────────────────────────
+
+export const PrAgentReviewStatus = Schema.Literals([
+  "idle",
+  "queued",
+  "running",
+  "complete",
+  "failed",
+]);
+export type PrAgentReviewStatus = typeof PrAgentReviewStatus.Type;
+
+export const PrAgentFindingSeverity = Schema.Literals(["info", "warning", "critical"]);
+export type PrAgentFindingSeverity = typeof PrAgentFindingSeverity.Type;
+
+export const PrAgentFindingCategory = Schema.Literals([
+  "security",
+  "correctness",
+  "style",
+  "test-coverage",
+  "performance",
+]);
+export type PrAgentFindingCategory = typeof PrAgentFindingCategory.Type;
+
+export const PrAgentFinding = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  severity: PrAgentFindingSeverity,
+  category: PrAgentFindingCategory,
+  path: Schema.NullOr(TrimmedNonEmptyString),
+  line: Schema.NullOr(PositiveInt),
+  title: TrimmedNonEmptyString,
+  detail: Schema.String,
+});
+export type PrAgentFinding = typeof PrAgentFinding.Type;
+
+export const PrAgentRiskTier = Schema.Literals(["low", "medium", "high"]);
+export type PrAgentRiskTier = typeof PrAgentRiskTier.Type;
+
+export const PrAgentRiskAssessment = Schema.Struct({
+  tier: PrAgentRiskTier,
+  rationale: Schema.String,
+});
+export type PrAgentRiskAssessment = typeof PrAgentRiskAssessment.Type;
+
+export const PrAgentReviewResult = Schema.Struct({
+  status: PrAgentReviewStatus,
+  summary: Schema.NullOr(Schema.String),
+  riskAssessment: Schema.NullOr(PrAgentRiskAssessment),
+  suggestedFocus: Schema.Array(Schema.String),
+  findings: Schema.Array(PrAgentFinding),
+  startedAt: Schema.NullOr(Schema.String),
+  completedAt: Schema.NullOr(Schema.String),
+});
+export type PrAgentReviewResult = typeof PrAgentReviewResult.Type;
+
+export const PrAgentReviewStartInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  prNumber: PositiveInt,
+  workflowId: Schema.optional(TrimmedNonEmptyString),
+});
+export type PrAgentReviewStartInput = typeof PrAgentReviewStartInput.Type;
+
+export const PrAgentReviewStatusInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  prNumber: PositiveInt,
+});
+export type PrAgentReviewStatusInput = typeof PrAgentReviewStatusInput.Type;
+
+export const PrAgentReviewStartResult = Schema.Struct({
+  reviewId: TrimmedNonEmptyString,
+});
+export type PrAgentReviewStartResult = typeof PrAgentReviewStartResult.Type;


### PR DESCRIPTION
## Summary
- Split the PR review sidebar into focused panels for AI findings, review actions, workflow progress, rule status, and keyboard help.
- Added shared hooks and query/store helpers to centralize PR review commands, mutations, and dashboard state.
- Expanded the review experience with agent findings, thread creation shortcuts, and clearer approval gating based on checks and conflicts.

## Testing
- Not run (not requested).
- `bun fmt`
- `bun lint`
- `bun typecheck`