### PR TITLE
Handle defensive ALTER TABLE defects in migrations

### DIFF
--- a/apps/server/src/persistence/Migrations/020_SmeConversationProviderAuth.ts
+++ b/apps/server/src/persistence/Migrations/020_SmeConversationProviderAuth.ts
@@ -7,12 +7,12 @@ export default Effect.gen(function* () {
   yield* sql`
     ALTER TABLE sme_conversations
     ADD COLUMN provider TEXT NOT NULL DEFAULT 'claudeAgent'
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   yield* sql`
     ALTER TABLE sme_conversations
     ADD COLUMN auth_method TEXT NOT NULL DEFAULT 'auto'
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   yield* sql`
     UPDATE sme_conversations

--- a/apps/server/src/persistence/Migrations/025_CanonicalizeModelSelections.ts
+++ b/apps/server/src/persistence/Migrations/025_CanonicalizeModelSelections.ts
@@ -7,12 +7,12 @@ export default Effect.gen(function* () {
   yield* sql`
     ALTER TABLE projection_projects
     ADD COLUMN default_model_selection TEXT
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   yield* sql`
     ALTER TABLE projection_threads
     ADD COLUMN model_selection TEXT
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   yield* sql`
     UPDATE projection_projects

--- a/apps/server/src/persistence/Migrations/025_ProjectionProjectIconPath.ts
+++ b/apps/server/src/persistence/Migrations/025_ProjectionProjectIconPath.ts
@@ -7,5 +7,5 @@ export default Effect.gen(function* () {
   yield* sql`
     ALTER TABLE projection_projects
     ADD COLUMN icon_path TEXT
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 });

--- a/apps/server/src/persistence/Migrations/027_CanonicalizeModelSelectionsBackfill.ts
+++ b/apps/server/src/persistence/Migrations/027_CanonicalizeModelSelectionsBackfill.ts
@@ -81,12 +81,12 @@ export default Effect.gen(function* () {
   yield* sql`
     ALTER TABLE projection_projects
     ADD COLUMN default_model_selection TEXT
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   yield* sql`
     ALTER TABLE projection_threads
     ADD COLUMN model_selection TEXT
-  `.pipe(Effect.catch(() => Effect.void));
+  `.pipe(Effect.catchCause(() => Effect.void));
 
   const projectRows = yield* sql<ProjectRow>`
     SELECT


### PR DESCRIPTION
## Summary

- `bun dev` crashes on first run on a fresh machine: migration 27 errors with `SQLiteError: duplicate column name: default_model_selection` and `turbo` exits non-zero, so the server never comes up.
- Migrations 020, 025, and 027 try to swallow "column already exists" errors on their defensive `ALTER TABLE ... ADD COLUMN` calls via `.pipe(Effect.catch(() => Effect.void))`, but `@effect/sql-sqlite-bun` throws the underlying `SQLiteError` from `db.query(sql)` *before* its internal `try/catch` (see `node_modules/@effect/sql-sqlite-bun/dist/SqliteClient.js:47`), so it surfaces as an Effect defect, not a failure. `Effect.catch` only handles failures, so the error escapes. On a fresh DB, migration 25 adds `default_model_selection`, then migration 27 re-adds it and crashes.
- Swap `Effect.catch` for `Effect.catchCause` in the four migrations using that pattern so both failures and defects are absorbed, which restores the intended "idempotent on replay" behavior.

## Test plan

- [x] Delete `~/.okcode/dev/state.sqlite*` and run `bun dev` — server now migrates cleanly, web comes up at http://localhost:5733/, bootstrap thread/project created, WS welcome fires.
- [x] `bun run fmt:check`, `bun run lint`, `bun --filter okcodes typecheck` all pass.