### PR TITLE
Add in-app folder picker for web and mobile clients

### DIFF
--- a/apps/server/src/fileSystemBrowser.test.ts
+++ b/apps/server/src/fileSystemBrowser.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, assert, describe, expect, it } from "vitest";
+
+import { browseFileSystemDirectory } from "./fileSystemBrowser";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  // On macOS /tmp resolves through a symlink to /private/tmp. The handler
+  // resolves symlinks in the returned path, so normalize expectations.
+  const resolved = fs.realpathSync(dir);
+  tempDirs.push(resolved);
+  return resolved;
+}
+
+describe("browseFileSystemDirectory", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("lists directories first, then files, each group alphabetically", async () => {
+    const root = makeTempDir("okcode-fsbrowse-sort-");
+    fs.mkdirSync(path.join(root, "zeta-dir"));
+    fs.mkdirSync(path.join(root, "alpha-dir"));
+    fs.writeFileSync(path.join(root, "b.txt"), "");
+    fs.writeFileSync(path.join(root, "a.txt"), "");
+
+    const result = await browseFileSystemDirectory({ path: root });
+
+    assert.deepEqual(
+      result.entries.map((e) => ({ name: e.name, kind: e.kind })),
+      [
+        { name: "alpha-dir", kind: "directory" },
+        { name: "zeta-dir", kind: "directory" },
+        { name: "a.txt", kind: "file" },
+        { name: "b.txt", kind: "file" },
+      ],
+    );
+    assert.equal(result.path, root);
+    assert.equal(result.parentPath, path.dirname(root));
+    assert.equal(result.partial, false);
+  });
+
+  it("filters dot-prefixed entries by default", async () => {
+    const root = makeTempDir("okcode-fsbrowse-hidden-");
+    fs.writeFileSync(path.join(root, "visible.txt"), "");
+    fs.writeFileSync(path.join(root, ".secret"), "");
+    fs.mkdirSync(path.join(root, ".hidden-dir"));
+
+    const result = await browseFileSystemDirectory({ path: root });
+    const names = result.entries.map((e) => e.name);
+
+    assert.deepEqual(names, ["visible.txt"]);
+  });
+
+  it("includes dot-prefixed entries when includeHidden is true", async () => {
+    const root = makeTempDir("okcode-fsbrowse-hidden-on-");
+    fs.writeFileSync(path.join(root, "visible.txt"), "");
+    fs.writeFileSync(path.join(root, ".secret"), "");
+    fs.mkdirSync(path.join(root, ".hidden-dir"));
+
+    const result = await browseFileSystemDirectory({ path: root, includeHidden: true });
+    const names = result.entries.map((e) => e.name).sort();
+
+    assert.deepEqual(names, [".hidden-dir", ".secret", "visible.txt"]);
+  });
+
+  it("rejects non-absolute paths", async () => {
+    await expect(browseFileSystemDirectory({ path: "relative/path" })).rejects.toThrow(
+      /must be absolute/,
+    );
+  });
+
+  it("rejects paths that are not directories", async () => {
+    const root = makeTempDir("okcode-fsbrowse-notdir-");
+    const file = path.join(root, "plain.txt");
+    fs.writeFileSync(file, "");
+
+    await expect(browseFileSystemDirectory({ path: file })).rejects.toThrow(/not a directory/);
+  });
+
+  it("flags partial and reports as file when a symlink target is unreadable", async () => {
+    const root = makeTempDir("okcode-fsbrowse-brokenlink-");
+    const missingTarget = path.join(root, "does-not-exist");
+    const link = path.join(root, "broken-link");
+    fs.symlinkSync(missingTarget, link);
+
+    const result = await browseFileSystemDirectory({ path: root });
+
+    assert.equal(result.partial, true);
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.entries[0]?.name, "broken-link");
+    assert.equal(result.entries[0]?.kind, "file");
+    assert.equal(result.entries[0]?.isSymlink, true);
+  });
+
+  it("resolves symlinks to directories as directory-kind entries", async () => {
+    const root = makeTempDir("okcode-fsbrowse-dirlink-");
+    const target = path.join(root, "real-dir");
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, path.join(root, "alias-dir"));
+
+    const result = await browseFileSystemDirectory({ path: root });
+
+    const alias = result.entries.find((e) => e.name === "alias-dir");
+    assert.ok(alias, "expected alias-dir entry");
+    assert.equal(alias.kind, "directory");
+    assert.equal(alias.isSymlink, true);
+    assert.equal(result.partial, false);
+  });
+
+  it("omits parentPath at the filesystem root", async () => {
+    const result = await browseFileSystemDirectory({ path: "/" });
+    assert.equal(result.path, "/");
+    assert.equal(result.parentPath, undefined);
+  });
+
+  it("defaults to the service user's home directory when path is omitted", async () => {
+    const result = await browseFileSystemDirectory({});
+    assert.equal(result.path, os.homedir());
+  });
+});

--- a/apps/server/src/fileSystemBrowser.ts
+++ b/apps/server/src/fileSystemBrowser.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type {
+  FileSystemEntry,
+  ProjectBrowseDirectoryInput,
+  ProjectBrowseDirectoryResult,
+} from "@okcode/contracts";
+
+/**
+ * Lists the immediate children of a directory on the machine running the OK
+ * Code server. Unlike `listWorkspaceDirectory`, this does not build a full
+ * project index — it is intended for interactive folder-picker UIs where the
+ * user navigates one level at a time.
+ *
+ * SECURITY POSTURE: This endpoint is reachable only through the authenticated
+ * WebSocket transport (the same auth-token gate as every other WS method), but
+ * within that gate it performs no path allowlisting. Any caller holding a
+ * valid token can enumerate any directory the server process can stat —
+ * effectively the entire filesystem of the user the server runs as. That is
+ * intentional: this is a filesystem picker, and constraining it would defeat
+ * the feature. Operators running the server with a shared or widely-distributed
+ * token should treat filesystem enumeration as within scope of that token.
+ */
+export async function browseFileSystemDirectory(
+  input: ProjectBrowseDirectoryInput,
+): Promise<ProjectBrowseDirectoryResult> {
+  const requested = input.path ?? homedir();
+  if (!path.isAbsolute(requested)) {
+    throw new Error(`path must be absolute, got: ${requested}`);
+  }
+
+  const resolved = path.resolve(requested);
+  const stat = await fs.stat(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error(`not a directory: ${resolved}`);
+  }
+
+  const dirents = await fs.readdir(resolved, { withFileTypes: true });
+  const includeHidden = input.includeHidden ?? false;
+  const entries: FileSystemEntry[] = [];
+  let partial = false;
+
+  for (const dirent of dirents) {
+    if (!includeHidden && dirent.name.startsWith(".")) {
+      continue;
+    }
+
+    let isSymlink = dirent.isSymbolicLink();
+    let isDirectory = dirent.isDirectory();
+    let isFile = dirent.isFile();
+
+    // Resolve symlink targets so the caller can navigate through them. If the
+    // target cannot be stat'd (broken link, permission denied) fall back to
+    // reporting the link itself as a file-kind entry and flag partial.
+    if (isSymlink) {
+      try {
+        const targetStat = await fs.stat(path.join(resolved, dirent.name));
+        isDirectory = targetStat.isDirectory();
+        isFile = targetStat.isFile();
+      } catch {
+        partial = true;
+        isDirectory = false;
+        isFile = true;
+      }
+    }
+
+    if (!isDirectory && !isFile) {
+      // Skip sockets, block devices, fifos — not meaningful for project picking.
+      continue;
+    }
+
+    entries.push({
+      name: dirent.name,
+      kind: isDirectory ? "directory" : "file",
+      isSymlink,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const parent = path.dirname(resolved);
+  // Omit parentPath at the filesystem root, where dirname returns the input.
+  return parent === resolved
+    ? { path: resolved, entries, partial }
+    : { path: resolved, parentPath: parent, entries, partial };
+}

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -57,6 +57,7 @@ import { pickFolderNative } from "./nativeFolderPicker.ts";
 import { GitManager } from "./git/Services/GitManager.ts";
 import { TerminalManager } from "./terminal/Services/Manager.ts";
 import { Keybindings } from "./keybindings";
+import { browseFileSystemDirectory } from "./fileSystemBrowser.ts";
 import {
   clearWorkspaceIndexCache,
   listWorkspaceDirectory,
@@ -1114,6 +1115,17 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           catch: (cause) =>
             new RouteRequestError({
               message: `Failed to list workspace directory: ${String(cause)}`,
+            }),
+        });
+      }
+
+      case WS_METHODS.projectsBrowseDirectory: {
+        const body = stripRequestTag(request.body);
+        return yield* Effect.tryPromise({
+          try: () => browseFileSystemDirectory(body),
+          catch: (cause) =>
+            new RouteRequestError({
+              message: `Failed to browse directory: ${String(cause)}`,
             }),
         });
       }

--- a/apps/web/src/components/ServerFolderPickerDialog.tsx
+++ b/apps/web/src/components/ServerFolderPickerDialog.tsx
@@ -1,0 +1,263 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  HomeIcon,
+  Loader2Icon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { readNativeApi } from "~/nativeApi";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+
+interface ServerFolderPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Initial path to show. When undefined, defaults to the service user's home. */
+  initialPath?: string;
+  onSelect: (path: string) => void;
+}
+
+/**
+ * In-app folder picker that browses the OK Code server's filesystem over
+ * WebSocket. Used in web/mobile mode (where no native OS folder picker is
+ * available on the server host) to let users add projects by navigating the
+ * remote filesystem.
+ */
+export function ServerFolderPickerDialog({
+  open,
+  onOpenChange,
+  initialPath,
+  onSelect,
+}: ServerFolderPickerDialogProps) {
+  const [currentPath, setCurrentPath] = useState<string | undefined>(initialPath);
+  const [pathInput, setPathInput] = useState<string>(initialPath ?? "");
+  const [selectedChild, setSelectedChild] = useState<string | null>(null);
+
+  // Reset when dialog opens so stale state from a previous session doesn't leak.
+  useEffect(() => {
+    if (open) {
+      setCurrentPath(initialPath);
+      setPathInput(initialPath ?? "");
+      setSelectedChild(null);
+    }
+  }, [open, initialPath]);
+
+  const browseQuery = useQuery({
+    queryKey: ["server-folder-picker", currentPath ?? "__home__"],
+    enabled: open,
+    queryFn: async () => {
+      const api = readNativeApi();
+      if (!api) {
+        throw new Error("okcode API unavailable");
+      }
+      return api.projects.browseDirectory(currentPath === undefined ? {} : { path: currentPath });
+    },
+    staleTime: 2000,
+    retry: false,
+  });
+
+  // Keep pathInput in sync with the resolved server path (handles the case where
+  // we opened at `undefined` and the server resolves it to $HOME).
+  useEffect(() => {
+    if (browseQuery.data?.path && currentPath !== browseQuery.data.path) {
+      setCurrentPath(browseQuery.data.path);
+      setPathInput(browseQuery.data.path);
+    }
+  }, [browseQuery.data, currentPath]);
+
+  const navigateTo = useCallback((target: string) => {
+    setCurrentPath(target);
+    setPathInput(target);
+    setSelectedChild(null);
+  }, []);
+
+  const navigateUp = useCallback(() => {
+    if (browseQuery.data?.parentPath) {
+      navigateTo(browseQuery.data.parentPath);
+    }
+  }, [browseQuery.data?.parentPath, navigateTo]);
+
+  const navigateHome = useCallback(() => {
+    setCurrentPath(undefined);
+    setSelectedChild(null);
+  }, []);
+
+  const handlePathInputSubmit = useCallback(() => {
+    const trimmed = pathInput.trim();
+    if (trimmed.length === 0) return;
+    navigateTo(trimmed);
+  }, [navigateTo, pathInput]);
+
+  const directoryEntries = useMemo(
+    () => (browseQuery.data?.entries ?? []).filter((entry) => entry.kind === "directory"),
+    [browseQuery.data],
+  );
+  const fileEntries = useMemo(
+    () => (browseQuery.data?.entries ?? []).filter((entry) => entry.kind === "file"),
+    [browseQuery.data],
+  );
+
+  const pickPath = useMemo(() => {
+    if (selectedChild && browseQuery.data) {
+      return joinPath(browseQuery.data.path, selectedChild);
+    }
+    return browseQuery.data?.path;
+  }, [browseQuery.data, selectedChild]);
+
+  const handleSelect = useCallback(() => {
+    if (!pickPath) return;
+    onSelect(pickPath);
+    onOpenChange(false);
+  }, [onOpenChange, onSelect, pickPath]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup>
+        <DialogPanel className="w-[min(560px,95vw)]">
+          <DialogHeader>
+            <DialogTitle>Select project folder</DialogTitle>
+            <DialogDescription>
+              Browse the OK Code server&rsquo;s filesystem. Only directories you can read are shown.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="mt-3 flex gap-1.5">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={navigateUp}
+              disabled={!browseQuery.data?.parentPath}
+              aria-label="Up to parent directory"
+            >
+              <ArrowUpIcon className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={navigateHome}
+              aria-label="Go to home directory"
+            >
+              <HomeIcon className="size-4" />
+            </Button>
+            <Input
+              value={pathInput}
+              onChange={(event) => setPathInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handlePathInputSubmit();
+                }
+              }}
+              placeholder="/absolute/path"
+              className="flex-1 font-mono text-xs"
+              aria-label="Current path"
+            />
+          </div>
+
+          <div className="mt-3 h-[320px] overflow-auto rounded-md border border-border bg-secondary">
+            {browseQuery.isLoading ? (
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                <Loader2Icon className="size-4 animate-spin" />
+              </div>
+            ) : browseQuery.error ? (
+              <div className="p-3 text-xs text-red-500">
+                {browseQuery.error instanceof Error
+                  ? browseQuery.error.message
+                  : "Failed to list directory"}
+              </div>
+            ) : directoryEntries.length === 0 && fileEntries.length === 0 ? (
+              <div className="p-3 text-xs text-muted-foreground">(empty directory)</div>
+            ) : (
+              <ul className="divide-y divide-border/50">
+                {directoryEntries.map((entry) => {
+                  const isSelected = selectedChild === entry.name;
+                  return (
+                    <li key={`d:${entry.name}`}>
+                      <button
+                        type="button"
+                        className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
+                          isSelected ? "bg-accent" : ""
+                        }`}
+                        onClick={() => setSelectedChild(entry.name)}
+                        onDoubleClick={() => {
+                          if (browseQuery.data) {
+                            navigateTo(joinPath(browseQuery.data.path, entry.name));
+                          }
+                        }}
+                      >
+                        {isSelected ? (
+                          <FolderOpenIcon className="size-3.5 text-foreground/80" />
+                        ) : (
+                          <FolderIcon className="size-3.5 text-foreground/60" />
+                        )}
+                        <span className="flex-1 truncate font-mono">{entry.name}</span>
+                        {entry.isSymlink && (
+                          <span className="text-[10px] text-muted-foreground/80">link</span>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+                {fileEntries.map((entry) => (
+                  <li
+                    key={`f:${entry.name}`}
+                    className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground/70"
+                  >
+                    <span className="inline-block size-3.5" />
+                    <span className="flex-1 truncate font-mono">{entry.name}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {browseQuery.data?.partial && (
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Some entries were skipped (broken symlinks or permission denied).
+            </p>
+          )}
+
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSelect}
+              disabled={!pickPath}
+              title={pickPath ? `Use: ${pickPath}` : undefined}
+            >
+              <CheckIcon className="mr-1 size-4" />
+              {selectedChild ? "Select subfolder" : "Use this folder"}
+            </Button>
+          </DialogFooter>
+        </DialogPanel>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+/** Join a directory and a child name using the server's path conventions. */
+function joinPath(dir: string, child: string): string {
+  if (dir.endsWith("/") || dir.endsWith("\\")) {
+    return `${dir}${child}`;
+  }
+  // Preserve Windows separators if the parent used them.
+  const sep = dir.includes("\\") && !dir.includes("/") ? "\\" : "/";
+  return `${dir}${sep}${child}`;
+}

--- a/apps/web/src/components/ServerFolderPickerDialog.tsx
+++ b/apps/web/src/components/ServerFolderPickerDialog.tsx
@@ -8,7 +8,6 @@ import {
   FolderIcon,
   FolderOpenIcon,
   HomeIcon,
-  Loader2Icon,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -24,6 +23,8 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Input } from "./ui/input";
+import { ScrollArea } from "./ui/scroll-area";
+import { Spinner } from "./ui/spinner";
 
 interface ServerFolderPickerDialogProps {
   open: boolean;
@@ -50,7 +51,6 @@ export function ServerFolderPickerDialog({
   const [selectedChild, setSelectedChild] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
-  // Reset when dialog opens so stale state from a previous session doesn't leak.
   useEffect(() => {
     if (open) {
       setCurrentPath(initialPath);
@@ -73,8 +73,6 @@ export function ServerFolderPickerDialog({
     retry: false,
   });
 
-  // Keep pathInput in sync with the resolved server path (handles the case where
-  // we opened at `undefined` and the server resolves it to $HOME).
   useEffect(() => {
     if (browseQuery.data?.path && currentPath !== browseQuery.data.path) {
       setCurrentPath(browseQuery.data.path);
@@ -133,34 +131,33 @@ export function ServerFolderPickerDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogPopup>
-        <DialogPanel className="w-[min(560px,95vw)]">
-          <DialogHeader>
-            <DialogTitle>Select project folder</DialogTitle>
-            <DialogDescription>
-              Browse the OK Code server&rsquo;s filesystem. Only directories you can read are shown.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="mt-3 flex gap-1.5">
+      <DialogPopup className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Select project folder</DialogTitle>
+          <DialogDescription>
+            Browse the server&rsquo;s filesystem and pick a directory to open as a project.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-3">
+          <div className="flex gap-2">
             <Button
               type="button"
               variant="outline"
-              size="icon"
+              size="icon-sm"
               onClick={navigateUp}
               disabled={!browseQuery.data?.parentPath}
               aria-label="Up to parent directory"
             >
-              <ArrowUpIcon className="size-4" />
+              <ArrowUpIcon className="size-3.5" />
             </Button>
             <Button
               type="button"
               variant="outline"
-              size="icon"
+              size="icon-sm"
               onClick={navigateHome}
               aria-label="Go to home directory"
             >
-              <HomeIcon className="size-4" />
+              <HomeIcon className="size-3.5" />
             </Button>
             <Input
               value={pathInput}
@@ -177,12 +174,12 @@ export function ServerFolderPickerDialog({
             />
           </div>
 
-          <div className="mt-3 flex flex-col overflow-hidden rounded-md border border-border bg-secondary">
-            <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-2">
+          <div className="overflow-hidden rounded-xl border border-border/70 bg-muted/24">
+            <div className="flex items-center justify-between border-b border-border/50 bg-muted/30 px-3 py-2">
               <button
                 type="button"
                 onClick={toggleSort}
-                className="flex items-center gap-1.5 text-xs font-medium text-foreground/70 hover:text-foreground"
+                className="flex items-center gap-1.5 text-xs font-medium text-foreground/80 hover:text-foreground"
                 aria-label={`Sort by name ${sortDirection === "asc" ? "descending" : "ascending"}`}
               >
                 Name
@@ -192,22 +189,29 @@ export function ServerFolderPickerDialog({
                   <ArrowUpAZIcon className="size-3.5" />
                 )}
               </button>
+              {browseQuery.data?.partial ? (
+                <span className="text-[11px] text-muted-foreground">Some entries skipped</span>
+              ) : null}
             </div>
-            <div className="max-h-[320px] min-h-[80px] overflow-auto">
-              {browseQuery.isLoading ? (
-                <div className="flex min-h-[80px] items-center justify-center text-muted-foreground">
-                  <Loader2Icon className="size-4 animate-spin" />
-                </div>
-              ) : browseQuery.error ? (
-                <div className="p-3 text-xs text-red-500">
-                  {browseQuery.error instanceof Error
-                    ? browseQuery.error.message
-                    : "Failed to list directory"}
-                </div>
-              ) : sortedEntries.length === 0 ? (
-                <div className="p-3 text-xs text-muted-foreground">(empty directory)</div>
-              ) : (
-                <ul className="divide-y divide-border/50">
+
+            {browseQuery.isLoading ? (
+              <div className="flex items-center justify-center gap-2 py-10 text-xs text-muted-foreground">
+                <Spinner className="size-3.5" />
+                Loading...
+              </div>
+            ) : browseQuery.error ? (
+              <div className="px-3 py-6 text-xs text-destructive">
+                {browseQuery.error instanceof Error
+                  ? browseQuery.error.message
+                  : "Failed to list directory"}
+              </div>
+            ) : sortedEntries.length === 0 ? (
+              <div className="px-3 py-6 text-xs text-muted-foreground">
+                This directory is empty.
+              </div>
+            ) : (
+              <ScrollArea className="max-h-[280px]" scrollbarGutter>
+                <ul className="divide-y divide-border/40">
                   {sortedEntries.map((entry) => {
                     const isDirectory = entry.kind === "directory";
                     const isSelected = selectedChild === entry.name;
@@ -215,13 +219,13 @@ export function ServerFolderPickerDialog({
                       return (
                         <li
                           key={`f:${entry.name}`}
-                          className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground/70"
+                          className="flex items-center gap-2.5 px-3 py-1.5 text-xs text-muted-foreground/70"
                         >
                           <FileIcon className="size-3.5 shrink-0 text-muted-foreground/50" />
                           <span className="flex-1 truncate font-mono">{entry.name}</span>
-                          {entry.isSymlink && (
+                          {entry.isSymlink ? (
                             <span className="text-[10px] text-muted-foreground/80">link</span>
-                          )}
+                          ) : null}
                         </li>
                       );
                     }
@@ -229,8 +233,8 @@ export function ServerFolderPickerDialog({
                       <li key={`d:${entry.name}`}>
                         <button
                           type="button"
-                          className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
-                            isSelected ? "bg-accent" : ""
+                          className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent/60 ${
+                            isSelected ? "bg-accent/80" : ""
                           }`}
                           onClick={() => setSelectedChild(entry.name)}
                           onDoubleClick={() => {
@@ -245,39 +249,33 @@ export function ServerFolderPickerDialog({
                             <FolderIcon className="size-3.5 shrink-0 text-foreground/60" />
                           )}
                           <span className="flex-1 truncate font-mono">{entry.name}</span>
-                          {entry.isSymlink && (
+                          {entry.isSymlink ? (
                             <span className="text-[10px] text-muted-foreground/80">link</span>
-                          )}
+                          ) : null}
                         </button>
                       </li>
                     );
                   })}
                 </ul>
-              )}
-            </div>
+              </ScrollArea>
+            )}
           </div>
-
-          {browseQuery.data?.partial && (
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              Some entries were skipped (broken symlinks or permission denied).
-            </p>
-          )}
-
-          <DialogFooter className="mt-4">
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={handleSelect}
-              disabled={!pickPath}
-              title={pickPath ? `Use: ${pickPath}` : undefined}
-            >
-              <CheckIcon className="mr-1 size-4" />
-              {selectedChild ? "Select subfolder" : "Use this folder"}
-            </Button>
-          </DialogFooter>
         </DialogPanel>
+        <DialogFooter>
+          <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSelect}
+            disabled={!pickPath}
+            title={pickPath ? `Use: ${pickPath}` : undefined}
+          >
+            <CheckIcon className="size-3.5" />
+            {selectedChild ? "Select subfolder" : "Use this folder"}
+          </Button>
+        </DialogFooter>
       </DialogPopup>
     </Dialog>
   );

--- a/apps/web/src/components/ServerFolderPickerDialog.tsx
+++ b/apps/web/src/components/ServerFolderPickerDialog.tsx
@@ -172,30 +172,30 @@ export function ServerFolderPickerDialog({
                 }
               }}
               placeholder="/absolute/path"
-              className="flex-1 font-mono text-xs"
+              className="min-w-0 flex-1 font-mono text-xs"
               aria-label="Current path"
             />
           </div>
 
-          <div className="mt-3 flex h-[320px] flex-col overflow-hidden rounded-md border border-border bg-secondary">
-            <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-1.5">
+          <div className="mt-3 flex flex-col overflow-hidden rounded-md border border-border bg-secondary">
+            <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-2">
               <button
                 type="button"
                 onClick={toggleSort}
-                className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+                className="flex items-center gap-1.5 text-xs font-medium text-foreground/70 hover:text-foreground"
                 aria-label={`Sort by name ${sortDirection === "asc" ? "descending" : "ascending"}`}
               >
                 Name
                 {sortDirection === "asc" ? (
-                  <ArrowDownAZIcon className="size-3" />
+                  <ArrowDownAZIcon className="size-3.5" />
                 ) : (
-                  <ArrowUpAZIcon className="size-3" />
+                  <ArrowUpAZIcon className="size-3.5" />
                 )}
               </button>
             </div>
-            <div className="flex-1 overflow-auto">
+            <div className="max-h-[320px] min-h-[80px] overflow-auto">
               {browseQuery.isLoading ? (
-                <div className="flex h-full items-center justify-center text-muted-foreground">
+                <div className="flex min-h-[80px] items-center justify-center text-muted-foreground">
                   <Loader2Icon className="size-4 animate-spin" />
                 </div>
               ) : browseQuery.error ? (

--- a/apps/web/src/components/ServerFolderPickerDialog.tsx
+++ b/apps/web/src/components/ServerFolderPickerDialog.tsx
@@ -1,7 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
+  ArrowDownAZIcon,
+  ArrowUpAZIcon,
   ArrowUpIcon,
   CheckIcon,
+  FileIcon,
   FolderIcon,
   FolderOpenIcon,
   HomeIcon,
@@ -45,6 +48,7 @@ export function ServerFolderPickerDialog({
   const [currentPath, setCurrentPath] = useState<string | undefined>(initialPath);
   const [pathInput, setPathInput] = useState<string>(initialPath ?? "");
   const [selectedChild, setSelectedChild] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
   // Reset when dialog opens so stale state from a previous session doesn't leak.
   useEffect(() => {
@@ -101,14 +105,18 @@ export function ServerFolderPickerDialog({
     navigateTo(trimmed);
   }, [navigateTo, pathInput]);
 
-  const directoryEntries = useMemo(
-    () => (browseQuery.data?.entries ?? []).filter((entry) => entry.kind === "directory"),
-    [browseQuery.data],
-  );
-  const fileEntries = useMemo(
-    () => (browseQuery.data?.entries ?? []).filter((entry) => entry.kind === "file"),
-    [browseQuery.data],
-  );
+  // Default sort is case-insensitive alphabetical by filename, flat (no
+  // directory/file grouping). Clicking the column header toggles direction.
+  const sortedEntries = useMemo(() => {
+    const entries = [...(browseQuery.data?.entries ?? [])];
+    entries.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+    if (sortDirection === "desc") entries.reverse();
+    return entries;
+  }, [browseQuery.data, sortDirection]);
+
+  const toggleSort = useCallback(() => {
+    setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+  }, []);
 
   const pickPath = useMemo(() => {
     if (selectedChild && browseQuery.data) {
@@ -169,61 +177,84 @@ export function ServerFolderPickerDialog({
             />
           </div>
 
-          <div className="mt-3 h-[320px] overflow-auto rounded-md border border-border bg-secondary">
-            {browseQuery.isLoading ? (
-              <div className="flex h-full items-center justify-center text-muted-foreground">
-                <Loader2Icon className="size-4 animate-spin" />
-              </div>
-            ) : browseQuery.error ? (
-              <div className="p-3 text-xs text-red-500">
-                {browseQuery.error instanceof Error
-                  ? browseQuery.error.message
-                  : "Failed to list directory"}
-              </div>
-            ) : directoryEntries.length === 0 && fileEntries.length === 0 ? (
-              <div className="p-3 text-xs text-muted-foreground">(empty directory)</div>
-            ) : (
-              <ul className="divide-y divide-border/50">
-                {directoryEntries.map((entry) => {
-                  const isSelected = selectedChild === entry.name;
-                  return (
-                    <li key={`d:${entry.name}`}>
-                      <button
-                        type="button"
-                        className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
-                          isSelected ? "bg-accent" : ""
-                        }`}
-                        onClick={() => setSelectedChild(entry.name)}
-                        onDoubleClick={() => {
-                          if (browseQuery.data) {
-                            navigateTo(joinPath(browseQuery.data.path, entry.name));
-                          }
-                        }}
-                      >
-                        {isSelected ? (
-                          <FolderOpenIcon className="size-3.5 text-foreground/80" />
-                        ) : (
-                          <FolderIcon className="size-3.5 text-foreground/60" />
-                        )}
-                        <span className="flex-1 truncate font-mono">{entry.name}</span>
-                        {entry.isSymlink && (
-                          <span className="text-[10px] text-muted-foreground/80">link</span>
-                        )}
-                      </button>
-                    </li>
-                  );
-                })}
-                {fileEntries.map((entry) => (
-                  <li
-                    key={`f:${entry.name}`}
-                    className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground/70"
-                  >
-                    <span className="inline-block size-3.5" />
-                    <span className="flex-1 truncate font-mono">{entry.name}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
+          <div className="mt-3 flex h-[320px] flex-col overflow-hidden rounded-md border border-border bg-secondary">
+            <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-1.5">
+              <button
+                type="button"
+                onClick={toggleSort}
+                className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+                aria-label={`Sort by name ${sortDirection === "asc" ? "descending" : "ascending"}`}
+              >
+                Name
+                {sortDirection === "asc" ? (
+                  <ArrowDownAZIcon className="size-3" />
+                ) : (
+                  <ArrowUpAZIcon className="size-3" />
+                )}
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto">
+              {browseQuery.isLoading ? (
+                <div className="flex h-full items-center justify-center text-muted-foreground">
+                  <Loader2Icon className="size-4 animate-spin" />
+                </div>
+              ) : browseQuery.error ? (
+                <div className="p-3 text-xs text-red-500">
+                  {browseQuery.error instanceof Error
+                    ? browseQuery.error.message
+                    : "Failed to list directory"}
+                </div>
+              ) : sortedEntries.length === 0 ? (
+                <div className="p-3 text-xs text-muted-foreground">(empty directory)</div>
+              ) : (
+                <ul className="divide-y divide-border/50">
+                  {sortedEntries.map((entry) => {
+                    const isDirectory = entry.kind === "directory";
+                    const isSelected = selectedChild === entry.name;
+                    if (!isDirectory) {
+                      return (
+                        <li
+                          key={`f:${entry.name}`}
+                          className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground/70"
+                        >
+                          <FileIcon className="size-3.5 shrink-0 text-muted-foreground/50" />
+                          <span className="flex-1 truncate font-mono">{entry.name}</span>
+                          {entry.isSymlink && (
+                            <span className="text-[10px] text-muted-foreground/80">link</span>
+                          )}
+                        </li>
+                      );
+                    }
+                    return (
+                      <li key={`d:${entry.name}`}>
+                        <button
+                          type="button"
+                          className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
+                            isSelected ? "bg-accent" : ""
+                          }`}
+                          onClick={() => setSelectedChild(entry.name)}
+                          onDoubleClick={() => {
+                            if (browseQuery.data) {
+                              navigateTo(joinPath(browseQuery.data.path, entry.name));
+                            }
+                          }}
+                        >
+                          {isSelected ? (
+                            <FolderOpenIcon className="size-3.5 shrink-0 text-foreground/80" />
+                          ) : (
+                            <FolderIcon className="size-3.5 shrink-0 text-foreground/60" />
+                          )}
+                          <span className="flex-1 truncate font-mono">{entry.name}</span>
+                          {entry.isSymlink && (
+                            <span className="text-[10px] text-muted-foreground/80">link</span>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
           </div>
 
           {browseQuery.data?.partial && (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -59,6 +59,7 @@ import {
 } from "react";
 import { CloneRepositoryDialog } from "~/components/CloneRepositoryDialog";
 import { EditableThreadTitle } from "~/components/EditableThreadTitle";
+import { ServerFolderPickerDialog } from "~/components/ServerFolderPickerDialog";
 import { ProjectIconEditorDialog } from "~/components/ProjectIconEditorDialog";
 import { ProjectIcon } from "~/components/ProjectIcon";
 import { useClientMode } from "~/hooks/useClientMode";
@@ -598,6 +599,7 @@ export default function Sidebar() {
   const [addProjectError, setAddProjectError] = useState<string | null>(null);
   const [manualProjectPathEntry, setManualProjectPathEntry] = useState(false);
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
+  const [serverFolderPickerOpen, setServerFolderPickerOpen] = useState(false);
   const [projectIconDialogOpen, setProjectIconDialogOpen] = useState(false);
   const [projectIconDialogProjectId, setProjectIconDialogProjectId] = useState<ProjectId | null>(
     null,
@@ -950,21 +952,42 @@ export default function Sidebar() {
     if (!api || isPickingFolder) return;
     setIsPickingFolder(true);
     let pickedPath: string | null = null;
+    let pickerFailed = false;
     try {
       pickedPath = await api.dialogs.pickFolder();
     } catch (error) {
+      pickerFailed = true;
       toastManager.add({
         type: "error",
         title: "Could not open folder picker",
         description: error instanceof Error ? error.message : "An unexpected error occurred.",
       });
     }
+    setIsPickingFolder(false);
+
     if (pickedPath) {
       await addProjectFromPath(pickedPath);
-    } else if (!shouldBrowseForProjectImmediately) {
+      return;
+    }
+
+    // In browser/mobile mode the server-side native picker (osascript / zenity
+    // / kdialog) will return null on headless hosts — that's the normal remote
+    // case. Fall back to the in-app folder browser so users can still navigate
+    // the server's filesystem. Electron desktop users keep the native OS
+    // dialog flow and don't see this fallback.
+    if (!isElectron && !pickerFailed) {
+      setServerFolderPickerOpen(true);
+      return;
+    }
+
+    if (!shouldBrowseForProjectImmediately) {
       addProjectInputRef.current?.focus();
     }
-    setIsPickingFolder(false);
+  };
+
+  const handleServerFolderSelected = async (selectedPath: string) => {
+    setServerFolderPickerOpen(false);
+    await addProjectFromPath(selectedPath);
   };
 
   const handleStartAddProject = () => {
@@ -2529,6 +2552,12 @@ export default function Sidebar() {
         open={cloneDialogOpen}
         onOpenChange={setCloneDialogOpen}
         onCloned={handleCloneComplete}
+      />
+
+      <ServerFolderPickerDialog
+        open={serverFolderPickerOpen}
+        onOpenChange={setServerFolderPickerOpen}
+        onSelect={handleServerFolderSelected}
       />
     </>
   );

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -266,6 +266,7 @@ export function createWsNativeApi(): NativeApi {
     projects: {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       listDirectory: (input) => transport.request(WS_METHODS.projectsListDirectory, input),
+      browseDirectory: (input) => transport.request(WS_METHODS.projectsBrowseDirectory, input),
       writeFile: (input) => transport.request(WS_METHODS.projectsWriteFile, input),
       readFile: (input) => transport.request(WS_METHODS.projectsReadFile, input),
       deleteEntry: (input) => transport.request(WS_METHODS.projectsDeleteEntry, input),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -30,6 +30,8 @@ import type {
 import type {
   ProjectDeleteEntryInput,
   ProjectFileTreeChangedPayload,
+  ProjectBrowseDirectoryInput,
+  ProjectBrowseDirectoryResult,
   ProjectListDirectoryInput,
   ProjectListDirectoryResult,
   ProjectReadFileInput,
@@ -380,6 +382,7 @@ export interface NativeApi {
   projects: {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     listDirectory: (input: ProjectListDirectoryInput) => Promise<ProjectListDirectoryResult>;
+    browseDirectory: (input: ProjectBrowseDirectoryInput) => Promise<ProjectBrowseDirectoryResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
     readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
     deleteEntry: (input: ProjectDeleteEntryInput) => Promise<void>;

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -58,6 +58,39 @@ export const ProjectListDirectoryResult = Schema.Struct({
 });
 export type ProjectListDirectoryResult = typeof ProjectListDirectoryResult.Type;
 
+export const FileSystemEntry = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  kind: ProjectEntryKind,
+  /** True if the entry is a symlink (regardless of its target kind). */
+  isSymlink: Schema.Boolean,
+});
+export type FileSystemEntry = typeof FileSystemEntry.Type;
+
+export const ProjectBrowseDirectoryInput = Schema.Struct({
+  /**
+   * Absolute path to browse. When omitted, the service user's home directory
+   * is used. Unlike listDirectory, this endpoint walks any accessible path
+   * without project-scoped indexing.
+   */
+  path: Schema.optional(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_DIRECTORY_PATH_MAX_LENGTH)),
+  ),
+  /** Include entries whose name starts with ".". Default false. */
+  includeHidden: Schema.optional(Schema.Boolean),
+});
+export type ProjectBrowseDirectoryInput = typeof ProjectBrowseDirectoryInput.Type;
+
+export const ProjectBrowseDirectoryResult = Schema.Struct({
+  /** Resolved absolute path that was listed. */
+  path: TrimmedNonEmptyString,
+  /** Absolute path of the parent directory, or absent if at filesystem root. */
+  parentPath: Schema.optional(TrimmedNonEmptyString),
+  entries: Schema.Array(FileSystemEntry),
+  /** True if some entries were skipped because they were unreadable. */
+  partial: Schema.Boolean,
+});
+export type ProjectBrowseDirectoryResult = typeof ProjectBrowseDirectoryResult.Type;
+
 export const ProjectWriteFileInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_WRITE_FILE_PATH_MAX_LENGTH)),

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -72,6 +72,7 @@ import {
   SaveProjectEnvironmentVariablesInput,
 } from "./environment";
 import {
+  ProjectBrowseDirectoryInput,
   ProjectDeleteEntryInput,
   ProjectListDirectoryInput,
   ProjectReadFileInput,
@@ -131,6 +132,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsSearchEntries: "projects.searchEntries",
   projectsListDirectory: "projects.listDirectory",
+  projectsBrowseDirectory: "projects.browseDirectory",
   projectsWriteFile: "projects.writeFile",
   projectsReadFile: "projects.readFile",
   projectsDeleteEntry: "projects.deleteEntry",
@@ -292,6 +294,7 @@ const WebSocketRequestBody = Schema.Union([
   // Project Search
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsListDirectory, ProjectListDirectoryInput),
+  tagRequestBody(WS_METHODS.projectsBrowseDirectory, ProjectBrowseDirectoryInput),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
   tagRequestBody(WS_METHODS.projectsReadFile, ProjectReadFileInput),
   tagRequestBody(WS_METHODS.projectsDeleteEntry, ProjectDeleteEntryInput),


### PR DESCRIPTION
## Summary
- Adds a new WS method, `projects.browseDirectory`, that lists immediate children of any directory the server process can stat. Scoped to the authenticated WS transport.
- Adds `ServerFolderPickerDialog` — an in-app folder picker that consumes the new method over WebSocket, used as a fallback from the Sidebar "pick folder" flow whenever the native OS picker is unavailable (i.e. when the server is running headless — osascript / zenity / kdialog return null).
- Electron desktop users continue to see the native OS dialog; the new fallback fires only for non-Electron clients (web, mobile) when the server-side native picker produces no selection.
- 9 unit tests cover the handler: sort order, hidden-file filtering, non-absolute rejection, non-directory rejection, broken-symlink `partial` flag, directory-kind symlinks, filesystem-root `parentPath` omission, and the default-to-home behavior.

## Security posture (documented on the handler)
The new endpoint is gated by the same auth token as every other WS method. Within that gate, it performs **no path allowlisting** — any caller holding a valid token can enumerate the full filesystem of the user the server process runs as. That is intentional for a filesystem picker, but operators sharing the auth token widely should treat filesystem enumeration as within scope of that token. See the docstring on `browseFileSystemDirectory` for details.

## Test plan
- [x] `bun run fmt:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `cd apps/server && bun run test -- fileSystemBrowser` (9/9 passing)
- [ ] Manual: with server on headless host + auth token, open web client, "Add project" → native picker returns null → in-app dialog opens rooted at `$HOME`; navigate up/down via dirent click and the `../` entry; confirm project is added at chosen path
- [ ] Manual: Electron desktop still sees the native OS folder picker (no fallback dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)