### PR TITLE
fix: default iOS release dispatch to current ref

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       ref:
-        description: "Git ref to build (defaults to refs/tags/v<version>; may also be a branch or SHA)"
+        description: "Git ref to build (defaults to the workflow dispatch commit; may also be a tag, branch, or SHA)"
         required: false
         type: string
 
@@ -52,7 +52,7 @@ jobs:
             if [[ -n "$requested_ref" ]]; then
               resolved_ref="$requested_ref"
             else
-              resolved_ref="refs/tags/$tag"
+              resolved_ref="$GITHUB_SHA"
             fi
           else
             resolved_ref="$requested_ref"

--- a/apps/server/src/fileSystemBrowser.test.ts
+++ b/apps/server/src/fileSystemBrowser.test.ts
@@ -66,7 +66,7 @@ describe("browseFileSystemDirectory", () => {
     fs.mkdirSync(path.join(root, ".hidden-dir"));
 
     const result = await browseFileSystemDirectory({ path: root, includeHidden: true });
-    const names = result.entries.map((e) => e.name).sort();
+    const names = result.entries.map((e) => e.name).toSorted();
 
     assert.deepEqual(names, [".hidden-dir", ".secret", "visible.txt"]);
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3895,17 +3895,6 @@ export default function ChatView({
     });
   };
 
-  const onRecoverFromOutOfMemory = async () => {
-    const api = readNativeApi();
-    if (!api || !activeThread || isRemoteActionBlocked) return;
-    await api.orchestration.dispatchCommand({
-      type: "thread.session.stop",
-      commandId: newCommandId(),
-      threadId: activeThread.id,
-      createdAt: new Date().toISOString(),
-    });
-  };
-
   const onClearQueue = useCallback(() => {
     setOptimisticUserMessages((existing) => {
       for (const msg of existing) {

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,7 @@ The next stable train ships one semver across desktop, CLI, and iOS surfaces:
 - macOS arm64 and x64 desktop DMGs plus updater metadata
 - Windows x64 signed NSIS installer
 - Linux x64 AppImage
-- iOS TestFlight build from the same release tag, dispatched separately
+- iOS TestFlight build from the same release version/ref, dispatched separately
 - `okcodes` npm package from the same tag
 
 `docs/release.md` is the source of truth for release policy, release gates, and the platform matrix. Treat `docs/releases/README.md` and README release references as pointers only.
@@ -127,7 +127,7 @@ Optional manual rebuild lane:
 - Build the mobile web bundle and sync Capacitor before archiving.
 - Run a simulator build in CI before archive/upload.
 - Upload the archive to TestFlight from the dedicated `release-ios.yml` workflow.
-- Dispatch `release-ios.yml` with the release version and matching tag/ref (defaults to `refs/tags/vX.Y.Z`).
+- Dispatch `release-ios.yml` with the release version and matching tag/ref. If `ref` is left blank, it builds the workflow dispatch commit.
 - During RC soak, manually verify on:
   - one current supported iPhone/iOS
   - one older supported iPhone/iOS
@@ -189,7 +189,7 @@ If any blocker fails, cut a new RC and repeat the soak.
 ## Post-release expectations
 
 - The GitHub release includes desktop artifacts plus release notes and asset manifest.
-- iOS is distributed through TestFlight by a separate `release-ios.yml` dispatch against the release tag, not attached to the GitHub release.
+- iOS is distributed through TestFlight by a separate `release-ios.yml` dispatch against the release tag or exact release commit, not attached to the GitHub release.
 - `finalize` updates version strings and pushes the post-release bump to `main`.
 
 ## Troubleshooting

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -265,7 +265,7 @@ ${highlights || "- See changelog for detailed changes."}
 
 - **CLI:** \`npm install -g okcodes@${version}\` once the desktop/CLI release workflow finishes.
 - **Desktop:** Download from [GitHub Releases](${REPO_URL}/releases/tag/v${version}). Filenames are listed in [assets.md](v${version}/assets.md).
-- **iOS:** Available via TestFlight after the separate Release iOS workflow is dispatched for this tag.
+- **iOS:** Available via TestFlight after the separate Release iOS workflow is dispatched for the matching release tag/ref.
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary
- default manual Release iOS dispatches to the workflow dispatch commit when `ref` is blank
- keep explicit tag, branch, or SHA refs supported
- update release docs and generated release notes copy for the new default
- clear two existing lint blockers required by the repo gate

## Verification
- bun fmt
- bun lint
- bun typecheck
- git diff --check