### PR TITLE
Default preview layout to side panel

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2553,15 +2553,12 @@ export default function Sidebar() {
                   >
                     <OkCodeMark className="size-4" />
                   </div>
-                  <div className="flex min-w-0 flex-col leading-none">
+                  <div className="min-w-0 flex-1">
                     <span className="truncate text-sm font-semibold tracking-tight text-foreground">
                       {APP_BASE_NAME}
                     </span>
-                    <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground/80">
-                      {brandFooterStatus.detail}
-                    </span>
                   </div>
-                  <div className="ml-auto flex shrink-0 flex-col items-end gap-1">
+                  <div className="ml-auto flex shrink-0 items-center gap-2">
                     <span
                       className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]"
                       style={brandFooterStatus.pillStyle}


### PR DESCRIPTION
## Summary
- Default preview layout to `side` instead of `top` across the preview state store and UI selectors.
- Update the workspace home row action to return the preview to side-panel mode.
- Simplify the sidebar branding row by removing the secondary detail line.
- Adjust the preview panel tests to reflect the new default layout.

## Testing
- Not run (PR content only).
- Existing test coverage updated in `apps/web/src/components/PreviewPanel.test.ts` for the new default layout.