### PR TITLE
Remove OpenClaw integration and rename theme to mocha mousse

### DIFF
--- a/apps/web/src/hooks/themeConfig.ts
+++ b/apps/web/src/hooks/themeConfig.ts
@@ -1,7 +1,7 @@
 export type Theme = "light" | "dark" | "system";
 export type ColorTheme =
   | "default"
-  | "iridescent-void"
+  | "mocha-mousse"
   | "carbon"
   | "purple-stuff"
   | "hot-tamale"
@@ -161,7 +161,7 @@ export const CODE_FONTS: ReadonlyArray<FontOption<CodeFont>> = [
 
 export const COLOR_THEMES: { id: ColorTheme; label: string }[] = [
   { id: "default", label: "Default" },
-  { id: "iridescent-void", label: "Iridescent Void" },
+  { id: "mocha-mousse", label: "Mocha Mousse" },
   { id: "carbon", label: "Carbon" },
   { id: "purple-stuff", label: "Deep Purple" },
   { id: "hot-tamale", label: "Hot Tamale" },


### PR DESCRIPTION
## Summary
- Removed the OpenClaw provider integration, related gateway/config code, and the associated maintainer skills, plans, and docs.
- Simplified provider/server/web contracts and UI state by deleting OpenClaw-specific paths and capability checks.
- Renamed the `iridescent void` theme to `mocha mousse`.
- Cleaned up references and tests that only existed to support the removed OpenClaw flow.

## Testing
- Not run